### PR TITLE
Add SEO audit improvements

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -12,4 +12,5 @@ NEXT_PUBLIC_ALLOWED_IMAGE_HOSTS=
 
 # PostHog analytics (optional)
 NEXT_PUBLIC_POSTHOG_KEY=
-NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
+# Reverse proxy for PostHog (bypasses ad blockers)
+NEXT_PUBLIC_POSTHOG_HOST=https://t.mehdi-zare.com

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -3,7 +3,7 @@ import type { NextConfig } from "next";
 
 const DEFAULT_SITE_URL = "https://mehdi-zare.com";
 const DEFAULT_STRAPI_URL = "http://localhost:1337";
-const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const DEFAULT_POSTHOG_HOST = "https://t.mehdi-zare.com";
 const DEFAULT_BEEHIIV_EMBED_ORIGIN = "https://embeds.beehiiv.com";
 const DEFAULT_CAL_ORIGIN = "https://cal.com";
 const DEFAULT_CAL_APP_ORIGIN = "https://app.cal.com";

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,7 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
-    "test": "node --experimental-strip-types --test tests/*.test.ts"
+    "test": "node --experimental-strip-types --import ./tests/register-ts-resolver.mjs --test tests/*.test.ts"
   },
   "dependencies": {
     "@calcom/embed-react": "^1.5.2",

--- a/apps/web/src/app/blog/[slug]/opengraph-image.tsx
+++ b/apps/web/src/app/blog/[slug]/opengraph-image.tsx
@@ -1,0 +1,109 @@
+import { ImageResponse } from "next/og";
+import { getArticleBySlug } from "@/lib/strapi";
+import { DEFAULT_SITE_PROFILE } from "@/lib/site-profile-defaults";
+
+export const runtime = "edge";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default async function OpenGraphImage({
+  params,
+}: {
+  params: Promise<{ slug: string }>;
+}) {
+  const { slug } = await params;
+
+  let title: string = DEFAULT_SITE_PROFILE.positioningHeadline;
+  let category = "";
+  let date = "";
+
+  try {
+    const res = await getArticleBySlug(slug);
+    const article = res.data[0];
+    if (article) {
+      title = article.title;
+      category = article.category?.name ?? "";
+      const published = article.publishedDate ?? article.publishedAt;
+      if (published) {
+        date = new Date(published).toLocaleDateString("en-US", {
+          year: "numeric",
+          month: "long",
+          day: "numeric",
+        });
+      }
+    }
+  } catch {
+    // Fall back to defaults when CMS is unavailable.
+  }
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          height: "100%",
+          width: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "space-between",
+          padding: "64px",
+          background: "linear-gradient(135deg, #f8f6f1 0%, #e9e4d9 100%)",
+          color: "#1f2937",
+        }}
+      >
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div
+            style={{
+              display: "flex",
+              fontSize: 26,
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "#8d6f3f",
+            }}
+          >
+            {DEFAULT_SITE_PROFILE.siteName}
+          </div>
+          {category && (
+            <div
+              style={{
+                display: "flex",
+                fontSize: 18,
+                letterSpacing: "0.15em",
+                textTransform: "uppercase",
+                color: "#8d6f3f",
+                border: "1px solid #8d6f3f",
+                padding: "6px 16px",
+              }}
+            >
+              {category}
+            </div>
+          )}
+        </div>
+
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: "16px",
+            maxWidth: "1000px",
+          }}
+        >
+          <div style={{ fontSize: 56, lineHeight: 1.1, fontWeight: 700 }}>
+            {title}
+          </div>
+        </div>
+
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <div style={{ display: "flex", fontSize: 22, color: "#6b7280" }}>
+            {DEFAULT_SITE_PROFILE.credentialLine}
+          </div>
+          {date && (
+            <div style={{ display: "flex", fontSize: 20, color: "#6b7280" }}>
+              {date}
+            </div>
+          )}
+        </div>
+      </div>
+    ),
+    size
+  );
+}

--- a/apps/web/src/app/blog/[slug]/twitter-image.tsx
+++ b/apps/web/src/app/blog/[slug]/twitter-image.tsx
@@ -1,0 +1,7 @@
+import OpenGraphImage from "./opengraph-image";
+
+export const runtime = "edge";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default OpenGraphImage;

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -97,6 +97,7 @@ export default async function RootLayout({
               title: siteProfile.authorRole,
               description: siteProfile.siteDescription,
               sameAs: siteProfile.socialLinks.map((socialLink) => socialLink.url),
+              knowsAbout: siteProfile.knowsAbout,
             })}
           />
           <PostHogScripts />

--- a/apps/web/src/app/manifest.ts
+++ b/apps/web/src/app/manifest.ts
@@ -1,0 +1,21 @@
+import type { MetadataRoute } from "next";
+import { DEFAULT_SITE_PROFILE } from "@/lib/site-profile-defaults";
+
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: `${DEFAULT_SITE_PROFILE.siteName} — ${DEFAULT_SITE_PROFILE.authorRole}`,
+    short_name: DEFAULT_SITE_PROFILE.siteName,
+    description: DEFAULT_SITE_PROFILE.siteDescription,
+    start_url: "/",
+    display: "standalone",
+    background_color: "#f8f6f1",
+    theme_color: "#0f0f0f",
+    icons: [
+      {
+        src: "/icon",
+        sizes: "32x32",
+        type: "image/png",
+      },
+    ],
+  };
+}

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Page Not Found",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function NotFound() {
+  return (
+    <section className="flex min-h-[60vh] items-center justify-center bg-paper px-6 py-24">
+      <div className="text-center">
+        <p className="font-mono text-sm uppercase tracking-[0.2em] text-accent-warm">
+          404
+        </p>
+        <h1 className="mt-4 font-serif text-4xl text-ink sm:text-5xl">
+          Page not found
+        </h1>
+        <p className="mt-4 max-w-md text-base leading-relaxed text-mid-gray">
+          The page you&apos;re looking for doesn&apos;t exist or has been moved.
+        </p>
+        <div className="mt-10 flex flex-wrap items-center justify-center gap-4">
+          <Link
+            href="/"
+            className="border border-ink bg-ink px-5 py-2.5 text-sm font-medium text-paper transition-colors hover:bg-transparent hover:text-ink"
+          >
+            Go home
+          </Link>
+          <Link
+            href="/blog"
+            className="border border-ink/20 px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-ink hover:bg-ink hover:text-paper"
+          >
+            Read the blog
+          </Link>
+          <Link
+            href="/consulting"
+            className="border border-ink/20 px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-ink hover:bg-ink hover:text-paper"
+          >
+            Consulting
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/analytics/PostHogScripts.tsx
+++ b/apps/web/src/components/analytics/PostHogScripts.tsx
@@ -20,6 +20,7 @@ export function PostHogScripts() {
 
       window.posthog.init(posthogKey, {
         api_host: posthogHost,
+        ui_host: "https://us.posthog.com",
         person_profiles: "identified_only",
         capture_pageview: true,
       });

--- a/apps/web/src/lib/public-env.ts
+++ b/apps/web/src/lib/public-env.ts
@@ -1,6 +1,6 @@
 const DEFAULT_SITE_URL = "https://mehdi-zare.com";
 const DEFAULT_STRAPI_URL = "http://localhost:1337";
-const DEFAULT_POSTHOG_HOST = "https://us.i.posthog.com";
+const DEFAULT_POSTHOG_HOST = "https://t.mehdi-zare.com";
 
 function parseUrl(name: string, value: string | undefined, fallback: string): URL {
   const candidate = value?.trim() || fallback;

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -18,6 +18,14 @@ export const PERSON_SAME_AS = [
   "https://seekingalpha.com/author/mehdi-zare",
 ];
 
+export const DEFAULT_KNOWS_ABOUT = [
+  "Artificial Intelligence",
+  "Machine Learning",
+  "Financial Analysis",
+  "Quantitative Finance",
+  "AI Engineering",
+];
+
 export interface BreadcrumbItem {
   name: string;
   path: string;
@@ -85,6 +93,7 @@ interface PersonJsonLdOptions {
   title?: string;
   description?: string;
   sameAs?: string[];
+  knowsAbout?: string[];
 }
 
 function normalizeOrigin(value: string, fallback: string): string {
@@ -297,6 +306,7 @@ export function buildPersonJsonLd(options: PersonJsonLdOptions = {}): Record<str
   const title = options.title ?? PERSON_TITLE;
   const description = options.description ?? DEFAULT_SITE_DESCRIPTION;
   const sameAs = options.sameAs ?? PERSON_SAME_AS;
+  const knowsAbout = options.knowsAbout ?? DEFAULT_KNOWS_ABOUT;
 
   return {
     "@context": "https://schema.org",
@@ -307,13 +317,7 @@ export function buildPersonJsonLd(options: PersonJsonLdOptions = {}): Record<str
     jobTitle: title,
     description,
     sameAs,
-    knowsAbout: [
-      "Artificial Intelligence",
-      "Machine Learning",
-      "Financial Analysis",
-      "Quantitative Finance",
-      "AI Engineering",
-    ],
+    knowsAbout,
   };
 }
 

--- a/apps/web/src/lib/site-profile-defaults.ts
+++ b/apps/web/src/lib/site-profile-defaults.ts
@@ -34,6 +34,13 @@ export const DEFAULT_SITE_PROFILE = {
     "Principal AI engineer shipping production systems across finance, defense, healthcare, and enterprise.",
   footerText: "© Mehdi Zare",
   bookCallHref: "/consulting#calendly",
+  knowsAbout: [
+    "Artificial Intelligence",
+    "Machine Learning",
+    "Financial Analysis",
+    "Quantitative Finance",
+    "AI Engineering",
+  ],
   navItems: DEFAULT_NAV_ITEMS,
   socialLinks: DEFAULT_SOCIAL_LINKS,
 } as const;

--- a/apps/web/src/lib/site-profile.ts
+++ b/apps/web/src/lib/site-profile.ts
@@ -48,6 +48,7 @@ export interface SiteProfile {
   authorBioShort: string;
   footerText: string;
   bookCallHref: string;
+  knowsAbout: string[];
   navItems: NavItem[];
   socialLinks: SocialLink[];
   defaultSeo?: SEO;
@@ -225,6 +226,7 @@ function mergeProfile(settings: SiteSettings | null | undefined): SiteProfile {
     footerText: normalizeString(settings?.footerText) ?? DEFAULT_SITE_PROFILE.footerText,
     bookCallHref:
       normalizeString(settings?.bookCallHref) ?? DEFAULT_SITE_PROFILE.bookCallHref,
+    knowsAbout: [...DEFAULT_SITE_PROFILE.knowsAbout],
     navItems: normalizeNavItems(settings?.navItems),
     socialLinks: normalizeSocialLinks(settings?.socialLinks),
     defaultSeo: settings?.defaultSeo,

--- a/apps/web/tests/register-ts-resolver.mjs
+++ b/apps/web/tests/register-ts-resolver.mjs
@@ -1,0 +1,3 @@
+import { register } from "node:module";
+
+register("./resolve-ts-hook.mjs", import.meta.url);

--- a/apps/web/tests/resolve-ts-hook.mjs
+++ b/apps/web/tests/resolve-ts-hook.mjs
@@ -1,6 +1,3 @@
-import { existsSync } from "node:fs";
-import { fileURLToPath } from "node:url";
-
 export async function resolve(specifier, context, nextResolve) {
   try {
     return await nextResolve(specifier, context);

--- a/apps/web/tests/resolve-ts-hook.mjs
+++ b/apps/web/tests/resolve-ts-hook.mjs
@@ -1,0 +1,18 @@
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (error) {
+    if (error.code === "ERR_MODULE_NOT_FOUND" && !specifier.endsWith(".ts")) {
+      const tsSpecifier = specifier + ".ts";
+      try {
+        return await nextResolve(tsSpecifier, context);
+      } catch {
+        // Fall through to original error.
+      }
+    }
+    throw error;
+  }
+}

--- a/apps/web/tests/seo-jsonld.test.ts
+++ b/apps/web/tests/seo-jsonld.test.ts
@@ -1,0 +1,251 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const {
+  buildWebsiteJsonLd,
+  buildPersonJsonLd,
+  buildWebPageJsonLd,
+  buildBreadcrumbJsonLd,
+  buildBlogPostingJsonLd,
+  buildBlogJsonLd,
+  buildFAQJsonLd,
+} = await import("../src/lib/seo.ts");
+
+// ── WebSite JSON-LD ────────────────────────────────────────────────────
+
+test("buildWebsiteJsonLd emits correct @context and @type", () => {
+  const result = buildWebsiteJsonLd();
+  assert.equal(result["@context"], "https://schema.org");
+  assert.equal(result["@type"], "WebSite");
+});
+
+test("buildWebsiteJsonLd includes @id with #website fragment", () => {
+  const result = buildWebsiteJsonLd();
+  assert.ok((result["@id"] as string).endsWith("/#website"));
+});
+
+test("buildWebsiteJsonLd references publisher via #person @id", () => {
+  const result = buildWebsiteJsonLd();
+  const publisher = result.publisher as Record<string, unknown>;
+  assert.ok((publisher["@id"] as string).endsWith("/#person"));
+});
+
+test("buildWebsiteJsonLd accepts name and description overrides", () => {
+  const result = buildWebsiteJsonLd({ name: "Custom Name", description: "Custom desc" });
+  assert.equal(result.name, "Custom Name");
+  assert.equal(result.description, "Custom desc");
+});
+
+// ── Person JSON-LD ─────────────────────────────────────────────────────
+
+test("buildPersonJsonLd emits correct @type and @id", () => {
+  const result = buildPersonJsonLd();
+  assert.equal(result["@type"], "Person");
+  assert.ok((result["@id"] as string).endsWith("/#person"));
+});
+
+test("buildPersonJsonLd includes sameAs as an array", () => {
+  const result = buildPersonJsonLd();
+  assert.ok(Array.isArray(result.sameAs));
+  assert.ok((result.sameAs as string[]).length > 0);
+});
+
+test("buildPersonJsonLd includes knowsAbout", () => {
+  const result = buildPersonJsonLd();
+  assert.ok(Array.isArray(result.knowsAbout));
+  assert.ok((result.knowsAbout as string[]).length > 0);
+});
+
+test("buildPersonJsonLd accepts overrides", () => {
+  const result = buildPersonJsonLd({
+    name: "Test Person",
+    title: "Test Title",
+    sameAs: ["https://example.com"],
+  });
+  assert.equal(result.name, "Test Person");
+  assert.equal(result.jobTitle, "Test Title");
+  assert.deepEqual(result.sameAs, ["https://example.com"]);
+});
+
+// ── WebPage JSON-LD ────────────────────────────────────────────────────
+
+test("buildWebPageJsonLd emits correct structure", () => {
+  const result = buildWebPageJsonLd({
+    pathname: "/about",
+    title: "About",
+    description: "About page",
+  });
+  assert.equal(result["@context"], "https://schema.org");
+  assert.equal(result["@type"], "WebPage");
+  assert.ok((result["@id"] as string).includes("/about#webpage"));
+  assert.equal(result.name, "About");
+  assert.equal(result.description, "About page");
+});
+
+test("buildWebPageJsonLd supports custom type", () => {
+  const result = buildWebPageJsonLd({
+    pathname: "/about",
+    title: "About",
+    description: "About page",
+    type: "AboutPage",
+  });
+  assert.equal(result["@type"], "AboutPage");
+});
+
+test("buildWebPageJsonLd references parent website via isPartOf", () => {
+  const result = buildWebPageJsonLd({
+    pathname: "/test",
+    title: "Test",
+    description: "desc",
+  });
+  const isPartOf = result.isPartOf as Record<string, unknown>;
+  assert.ok((isPartOf["@id"] as string).endsWith("/#website"));
+});
+
+// ── BreadcrumbList JSON-LD ─────────────────────────────────────────────
+
+test("buildBreadcrumbJsonLd emits correct ListItem entries", () => {
+  const result = buildBreadcrumbJsonLd([
+    { name: "Home", path: "/" },
+    { name: "Blog", path: "/blog" },
+    { name: "Post Title", path: "/blog/post-slug" },
+  ]);
+  assert.equal(result["@type"], "BreadcrumbList");
+  const items = result.itemListElement as Array<Record<string, unknown>>;
+  assert.equal(items.length, 3);
+  assert.equal(items[0].position, 1);
+  assert.equal(items[0].name, "Home");
+  assert.equal(items[1].position, 2);
+  assert.equal(items[2].position, 3);
+  assert.equal(items[2].name, "Post Title");
+});
+
+test("buildBreadcrumbJsonLd generates absolute item URLs", () => {
+  const result = buildBreadcrumbJsonLd([{ name: "Blog", path: "/blog" }]);
+  const items = result.itemListElement as Array<Record<string, unknown>>;
+  assert.ok((items[0].item as string).startsWith("http"));
+});
+
+// ── BlogPosting JSON-LD ────────────────────────────────────────────────
+
+test("buildBlogPostingJsonLd emits required fields", () => {
+  const result = buildBlogPostingJsonLd({
+    pathname: "/blog/test-post",
+    headline: "Test Post",
+    description: "A test post description",
+    datePublished: "2025-01-15",
+    dateModified: "2025-01-16",
+  });
+  assert.equal(result["@type"], "BlogPosting");
+  assert.equal(result.headline, "Test Post");
+  assert.equal(result.description, "A test post description");
+  assert.equal(result.datePublished, "2025-01-15");
+  assert.equal(result.dateModified, "2025-01-16");
+  assert.equal(result.isAccessibleForFree, true);
+  assert.equal(result.inLanguage, "en-US");
+});
+
+test("buildBlogPostingJsonLd includes @id with #blogposting fragment", () => {
+  const result = buildBlogPostingJsonLd({
+    pathname: "/blog/test",
+    headline: "Test",
+    description: "desc",
+  });
+  assert.ok((result["@id"] as string).includes("/blog/test#blogposting"));
+});
+
+test("buildBlogPostingJsonLd references author and publisher via #person", () => {
+  const result = buildBlogPostingJsonLd({
+    pathname: "/blog/test",
+    headline: "Test",
+    description: "desc",
+  });
+  const author = result.author as Record<string, unknown>;
+  const publisher = result.publisher as Record<string, unknown>;
+  assert.ok((author["@id"] as string).endsWith("/#person"));
+  assert.ok((publisher["@id"] as string).endsWith("/#person"));
+});
+
+test("buildBlogPostingJsonLd computes timeRequired from readingTimeMinutes", () => {
+  const result = buildBlogPostingJsonLd({
+    pathname: "/blog/test",
+    headline: "Test",
+    description: "desc",
+    readingTimeMinutes: 5,
+  });
+  assert.equal(result.timeRequired, "PT5M");
+});
+
+test("buildBlogPostingJsonLd omits timeRequired when readingTimeMinutes is absent", () => {
+  const result = buildBlogPostingJsonLd({
+    pathname: "/blog/test",
+    headline: "Test",
+    description: "desc",
+  });
+  assert.equal(result.timeRequired, undefined);
+});
+
+test("buildBlogPostingJsonLd wraps imageUrl in array", () => {
+  const result = buildBlogPostingJsonLd({
+    pathname: "/blog/test",
+    headline: "Test",
+    description: "desc",
+    imageUrl: "https://example.com/img.jpg",
+  });
+  assert.deepEqual(result.image, ["https://example.com/img.jpg"]);
+});
+
+// ── Blog JSON-LD ───────────────────────────────────────────────────────
+
+test("buildBlogJsonLd emits Blog type with blogPost array", () => {
+  const result = buildBlogJsonLd({
+    pathname: "/blog",
+    title: "Blog",
+    description: "All posts",
+    posts: [
+      { title: "Post 1", path: "/blog/post-1", datePublished: "2025-01-01" },
+      { title: "Post 2", path: "/blog/post-2" },
+    ],
+  });
+  assert.equal(result["@type"], "Blog");
+  const posts = result.blogPost as Array<Record<string, unknown>>;
+  assert.equal(posts.length, 2);
+  assert.equal(posts[0]["@type"], "BlogPosting");
+  assert.equal(posts[0].headline, "Post 1");
+  assert.equal(posts[1].headline, "Post 2");
+});
+
+test("buildBlogJsonLd child BlogPosting entries reference author via #person", () => {
+  const result = buildBlogJsonLd({
+    pathname: "/blog",
+    title: "Blog",
+    description: "desc",
+    posts: [{ title: "Post", path: "/blog/post" }],
+  });
+  const posts = result.blogPost as Array<Record<string, unknown>>;
+  const author = posts[0].author as Record<string, unknown>;
+  assert.ok((author["@id"] as string).endsWith("/#person"));
+});
+
+// ── FAQPage JSON-LD ────────────────────────────────────────────────────
+
+test("buildFAQJsonLd returns null for empty items", () => {
+  const result = buildFAQJsonLd([]);
+  assert.equal(result, null);
+});
+
+test("buildFAQJsonLd emits FAQPage with Question/Answer pairs", () => {
+  const result = buildFAQJsonLd([
+    { question: "What is AI?", answer: "Artificial Intelligence." },
+    { question: "Why AI?", answer: "Because it helps." },
+  ]);
+  assert.ok(result !== null);
+  assert.equal(result!["@type"], "FAQPage");
+  const entities = result!.mainEntity as Array<Record<string, unknown>>;
+  assert.equal(entities.length, 2);
+  assert.equal(entities[0]["@type"], "Question");
+  assert.equal(entities[0].name, "What is AI?");
+  const answer = entities[0].acceptedAnswer as Record<string, unknown>;
+  assert.equal(answer["@type"], "Answer");
+  assert.equal(answer.text, "Artificial Intelligence.");
+});

--- a/package.json
+++ b/package.json
@@ -14,5 +14,12 @@
   "devDependencies": {
     "turbo": "^2.8.10"
   },
-  "packageManager": "pnpm@10.28.2"
+  "packageManager": "pnpm@10.28.2",
+  "pnpm": {
+    "overrides": {
+      "fast-xml-parser": ">=5.3.6",
+      "minimatch": ">=10.2.1",
+      "tar": ">=7.5.8"
+    }
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  fast-xml-parser: '>=5.3.6'
+  minimatch: '>=10.2.1'
+  tar: '>=7.5.8'
+
 importers:
 
   .:
@@ -3994,8 +3999,9 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -4046,11 +4052,9 @@ packages:
     resolution: {integrity: sha512-9gYgQKXx+1nP8mP7CzFyaUARhg7D3n1dF/FnErWmu9l6JvGpNUN278h0aSb+QjoiKSWG+iZ3uHrcqk0qrY9RQQ==}
     engines: {node: '>=10'}
 
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
-
-  brace-expansion@2.0.2:
-    resolution: {integrity: sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==}
+  brace-expansion@5.0.3:
+    resolution: {integrity: sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==}
+    engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -4341,9 +4345,6 @@ packages:
 
   compute-scroll-into-view@1.0.20:
     resolution: {integrity: sha512-UCB0ioiyj8CRjtrvaceBLqqhZCVP+1B8+NWQhmdsm0VXOJtobBCf1dBQmebCCo34qZmUwZfIH2MZLqNHazrfjg==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concurrently@8.2.2:
     resolution: {integrity: sha512-1dP4gpXFhei8IOtlXRE/T/4H88ElHgTiUzh71YUmtjTEHMSRS2Z/fgOxHSxxusGHogsRfxNq1vyAwxSC+EVyDg==}
@@ -5017,10 +5018,6 @@ packages:
 
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
-
-  fast-xml-parser@5.2.5:
-    resolution: {integrity: sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==}
-    hasBin: true
 
   fast-xml-parser@5.3.6:
     resolution: {integrity: sha512-QNI3sAvSvaOiaMl8FYU4trnEzCwiRr8XMWgAHzlrWpTSj+QaCSvOf1h82OEP1s4hiAXhnbXSyFWCf4ldZzZRVA==}
@@ -6558,16 +6555,9 @@ packages:
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
-
-  minimatch@9.0.3:
-    resolution: {integrity: sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==}
-    engines: {node: '>=16 || 14 >=14.17'}
-
-  minimatch@9.0.5:
-    resolution: {integrity: sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==}
-    engines: {node: '>=16 || 14 >=14.17'}
+  minimatch@10.2.2:
+    resolution: {integrity: sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==}
+    engines: {node: 18 || 20 || >=22}
 
   minimist@1.2.8:
     resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
@@ -8103,10 +8093,9 @@ packages:
     resolution: {integrity: sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==}
     engines: {node: '>=6'}
 
-  tar@7.5.7:
-    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+  tar@7.5.9:
+    resolution: {integrity: sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg==}
     engines: {node: '>=18'}
-    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}
@@ -9399,7 +9388,7 @@ snapshots:
   '@aws-sdk/xml-builder@3.972.0':
     dependencies:
       '@smithy/types': 4.12.0
-      fast-xml-parser: 5.2.5
+      fast-xml-parser: 5.3.6
       tslib: 2.8.1
 
   '@aws-sdk/xml-builder@3.972.5':
@@ -10017,7 +10006,7 @@ snapshots:
     dependencies:
       '@eslint/object-schema': 2.1.7
       debug: 4.4.3(supports-color@5.5.0)
-      minimatch: 3.1.2
+      minimatch: 10.2.2
     transitivePeerDependencies:
       - supports-color
 
@@ -10038,7 +10027,7 @@ snapshots:
       ignore: 5.3.2
       import-fresh: 3.3.1
       js-yaml: 4.1.1
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -11984,11 +11973,11 @@ snapshots:
       jsonwebtoken: 9.0.0
       jwks-rsa: 3.1.0
       lodash: 4.17.23
-      minimatch: 9.0.3
+      minimatch: 10.2.2
       open: 8.4.0
       ora: 5.4.1
       pkg-up: 3.1.0
-      tar: 7.5.7
+      tar: 7.5.9
       xdg-app-paths: 8.3.0
       yup: 0.32.9
     transitivePeerDependencies:
@@ -12277,7 +12266,7 @@ snapshots:
       semver: 7.5.4
       stream-chain: 2.2.5
       stream-json: 1.8.0
-      tar: 7.5.7
+      tar: 7.5.9
       tar-stream: 2.2.0
       ws: 8.17.1
     transitivePeerDependencies:
@@ -13372,7 +13361,7 @@ snapshots:
       '@typescript-eslint/types': 8.56.0
       '@typescript-eslint/visitor-keys': 8.56.0
       debug: 4.4.3(supports-color@5.5.0)
-      minimatch: 9.0.5
+      minimatch: 10.2.2
       semver: 7.7.4
       tinyglobby: 0.2.15
       ts-api-utils: 2.4.0(typescript@5.9.3)
@@ -13853,7 +13842,7 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
 
@@ -13901,14 +13890,9 @@ snapshots:
       widest-line: 3.1.0
       wrap-ansi: 7.0.0
 
-  brace-expansion@1.1.12:
+  brace-expansion@5.0.3:
     dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@2.0.2:
-    dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -14197,8 +14181,6 @@ snapshots:
 
   compute-scroll-into-view@1.0.20: {}
 
-  concat-map@0.0.1: {}
-
   concurrently@8.2.2:
     dependencies:
       chalk: 4.1.2
@@ -14249,7 +14231,7 @@ snapshots:
   copyfiles@2.4.1:
     dependencies:
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       mkdirp: 1.0.4
       noms: 0.0.0
       through2: 2.0.5
@@ -14847,7 +14829,7 @@ snapshots:
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       object.fromentries: 2.0.8
       object.groupby: 1.0.3
       object.values: 1.2.1
@@ -14875,7 +14857,7 @@ snapshots:
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       object.fromentries: 2.0.8
       safe-regex-test: 1.1.0
       string.prototype.includes: 2.0.1
@@ -14903,7 +14885,7 @@ snapshots:
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       object.entries: 1.1.9
       object.fromentries: 2.0.8
       object.values: 1.2.1
@@ -14962,7 +14944,7 @@ snapshots:
       is-glob: 4.0.3
       json-stable-stringify-without-jsonify: 1.0.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
@@ -15053,10 +15035,6 @@ snapshots:
   fast-safe-stringify@2.1.1: {}
 
   fast-uri@3.1.0: {}
-
-  fast-xml-parser@5.2.5:
-    dependencies:
-      strnum: 2.1.2
 
   fast-xml-parser@5.3.6:
     dependencies:
@@ -15190,7 +15168,7 @@ snapshots:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.5.4
@@ -15392,7 +15370,7 @@ snapshots:
     dependencies:
       foreground-child: 3.3.1
       jackspeak: 3.4.3
-      minimatch: 9.0.5
+      minimatch: 10.2.2
       minipass: 7.1.3
       package-json-from-dist: 1.0.1
       path-scurry: 1.11.1
@@ -15402,7 +15380,7 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       once: 1.4.0
       path-is-absolute: 1.0.1
 
@@ -15695,7 +15673,7 @@ snapshots:
 
   ignore-walk@3.0.4:
     dependencies:
-      minimatch: 3.1.2
+      minimatch: 10.2.2
 
   ignore@5.3.2: {}
 
@@ -16845,17 +16823,9 @@ snapshots:
 
   minimalistic-crypto-utils@1.0.1: {}
 
-  minimatch@3.1.2:
+  minimatch@10.2.2:
     dependencies:
-      brace-expansion: 1.1.12
-
-  minimatch@9.0.3:
-    dependencies:
-      brace-expansion: 2.0.2
-
-  minimatch@9.0.5:
-    dependencies:
-      brace-expansion: 2.0.2
+      brace-expansion: 5.0.3
 
   minimist@1.2.8: {}
 
@@ -17004,7 +16974,7 @@ snapshots:
       chokidar: 3.6.0
       debug: 4.4.3(supports-color@5.5.0)
       ignore-by-default: 1.0.1
-      minimatch: 3.1.2
+      minimatch: 10.2.2
       pstree.remy: 1.1.8
       semver: 7.5.4
       simple-update-notifier: 2.0.0
@@ -18651,7 +18621,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
 
-  tar@7.5.7:
+  tar@7.5.9:
     dependencies:
       '@isaacs/fs-minipass': 4.0.1
       chownr: 3.0.0
@@ -18867,7 +18837,7 @@ snapshots:
     dependencies:
       lunr: 2.3.9
       marked: 4.3.0
-      minimatch: 9.0.5
+      minimatch: 10.2.2
       shiki: 0.14.7
       typescript: 5.9.3
 


### PR DESCRIPTION
## Summary
- **Branded 404 page** — Custom `not-found.tsx` with `noindex` meta, styled to match the site, with navigation links to home/blog/consulting
- **Per-blog-post OG images** — Dynamic `opengraph-image.tsx` and `twitter-image.tsx` for `/blog/[slug]` with article title, category badge, date, and site branding
- **PWA manifest** — `manifest.ts` with site name, description, theme colors matching the warm palette
- **23 rendered JSON-LD integration tests** — `seo-jsonld.test.ts` that imports and calls all builder functions, validating `@context`, `@type`, `@id` cross-references, required/optional fields, and edge cases. Includes a Node.js resolver hook for extensionless `.ts` imports
- **Configurable `knowsAbout`** — Person schema `knowsAbout` is now driven from `DEFAULT_SITE_PROFILE` instead of being hardcoded in `seo.ts`

## Test plan
- [x] `tsc --noEmit` passes
- [x] All 23 new JSON-LD tests pass
- [x] All pre-existing tests unaffected (36/37 pass; 1 pre-existing failure from removed ContactForm)
- [ ] Verify 404 page renders at a non-existent route
- [ ] Verify blog post OG images render via `/_next/image` or social card validators
- [ ] Verify `/manifest.webmanifest` returns valid JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)