### PR TITLE
chore(ci): run all workflows on Namespace runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   quality:
     name: Lint, Typecheck, Test, Build
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     permissions:
       contents: read
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   security:
     name: Dependency Audit
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     permissions:
       contents: read
     steps:
@@ -70,7 +70,7 @@ jobs:
 
   secret-scan:
     name: Secret Scan
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-default
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary
- Switch all GitHub Actions jobs from `ubuntu-latest` to `namespace-profile-default`.
- Keeps CI on the Namespace Cloud runner fleet for now.

## Test plan
- [ ] Confirm Namespace is installed/allowed for this repo
- [ ] Trigger CI (or wait for PR checks) and verify jobs schedule on Namespace
- [ ] Spot-check no jobs stuck on "Waiting for a runner"