### PR TITLE
Ship /ai-engineer landing for the GSC query

### DIFF
--- a/apps/web/src/app/ai-engineer/page.tsx
+++ b/apps/web/src/app/ai-engineer/page.tsx
@@ -1,0 +1,251 @@
+import type { Metadata } from "next";
+import { TrackedLink } from "@/components/analytics/TrackedLink";
+import { FAQ } from "@/components/consulting/FAQ";
+import { JsonLd } from "@/components/seo/JsonLd";
+import { AnimatedSection } from "@/components/shared/AnimatedSection";
+import { SectionHeading } from "@/components/shared/SectionHeading";
+import {
+  aiEngineerKeywords,
+  aiEngineerMetadataTitle,
+  buildAiEngineerFallback,
+} from "@/content/fallbacks/ai-engineer";
+import {
+  buildBreadcrumbJsonLd,
+  buildFAQJsonLd,
+  buildPageMetadata,
+  buildWebPageJsonLd,
+  getSiteUrl,
+} from "@/lib/seo";
+import { getSiteProfile } from "@/lib/site-profile";
+
+const pathname = "/ai-engineer";
+
+export async function generateMetadata(): Promise<Metadata> {
+  const siteProfile = await getSiteProfile();
+  const data = buildAiEngineerFallback(siteProfile);
+
+  return buildPageMetadata({
+    pathname,
+    title: aiEngineerMetadataTitle,
+    description: data.description,
+    type: "website",
+    keywords: aiEngineerKeywords,
+  });
+}
+
+export default async function AiEngineerPage() {
+  const siteProfile = await getSiteProfile();
+  const siteUrl = getSiteUrl();
+  const data = buildAiEngineerFallback(siteProfile);
+  const schedulerHref = siteProfile.bookCallHref;
+
+  const faqJsonLd = buildFAQJsonLd(
+    data.faq
+      .filter((faq) => faq.question && faq.answer)
+      .map((faq) => ({
+        question: faq.question,
+        answer: faq.answer,
+      }))
+  );
+
+  const webpageJsonLd = {
+    ...buildWebPageJsonLd({
+      pathname,
+      title: data.headline,
+      description: data.description,
+      type: "WebPage",
+    }),
+    about: {
+      "@id": `${siteUrl}/#person`,
+    },
+    keywords: aiEngineerKeywords.join(", "),
+  };
+
+  return (
+    <div className="bg-paper pb-24">
+      <JsonLd id="ai-engineer-webpage-jsonld" data={webpageJsonLd} />
+      <JsonLd
+        id="ai-engineer-breadcrumb-jsonld"
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", path: "/" },
+          { name: "AI Engineer", path: pathname },
+        ])}
+      />
+      {faqJsonLd ? <JsonLd id="ai-engineer-faq-jsonld" data={faqJsonLd} /> : null}
+
+      <section className="pb-16 pt-10">
+        <div className="mx-auto max-w-7xl px-6">
+          <AnimatedSection>
+            <p className="font-mono text-xs uppercase tracking-[0.25em] text-mid-gray">
+              {siteProfile.credentialLine}
+            </p>
+            <h1 className="mt-4 font-serif text-4xl leading-tight text-ink sm:text-5xl">
+              {data.headline}
+            </h1>
+            <p className="mt-6 max-w-3xl text-xl leading-relaxed text-mid-gray">
+              {data.subtitle}
+            </p>
+            <div className="mt-10 flex flex-col items-start gap-4 sm:flex-row sm:items-center">
+              <TrackedLink
+                href={schedulerHref}
+                eventName="funnel_cta_click"
+                eventProperties={{
+                  section: "ai_engineer_hero",
+                  cta_label: siteProfile.primaryCtaLabel,
+                  destination: schedulerHref,
+                  interaction_type: "link_click",
+                }}
+                className="inline-flex bg-ink px-8 py-3 text-sm font-medium text-paper transition hover:bg-ink/85"
+              >
+                {siteProfile.primaryCtaLabel}
+              </TrackedLink>
+              <TrackedLink
+                href="/consulting"
+                eventName="funnel_cta_click"
+                eventProperties={{
+                  section: "ai_engineer_hero",
+                  cta_label: "See consulting",
+                  destination: "/consulting",
+                  interaction_type: "link_click",
+                }}
+                className="rounded-sm border border-ink/20 px-5 py-2.5 text-sm font-medium text-ink transition-colors hover:border-ink hover:bg-ink hover:text-paper"
+              >
+                See consulting
+              </TrackedLink>
+            </div>
+          </AnimatedSection>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto max-w-7xl px-6">
+          <AnimatedSection>
+            <SectionHeading
+              title="What this AI engineer does"
+              subtitle="Systems that have to run in finance, not just look good in a demo"
+            />
+          </AnimatedSection>
+          <div className="mt-10 grid gap-6 md:grid-cols-3">
+            {data.capabilities.map((capability, index) => (
+              <AnimatedSection key={capability.id} delay={index * 0.08}>
+                <article className="border border-warm-gray bg-paper p-6">
+                  <h3 className="font-serif text-lg text-ink">{capability.title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-mid-gray">
+                    {capability.description}
+                  </p>
+                </article>
+              </AnimatedSection>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto max-w-7xl px-6">
+          <AnimatedSection>
+            <SectionHeading
+              title="Finance is the domain"
+              subtitle="The CFA is not decoration — it is how the work stays honest"
+            />
+          </AnimatedSection>
+          <AnimatedSection delay={0.15} className="mt-10">
+            <div className="mx-auto max-w-3xl space-y-5 text-lg leading-relaxed text-mid-gray">
+              <p>
+                Plenty of teams can stand up a chatbot. Fewer can put a model next
+                to a funding forecast, a research workflow, or a risk process and
+                have it survive contact with operations.
+              </p>
+              <p>
+                I trained as a physicist, then earned an MBA in finance and the CFA
+                charter. That combination is the job: learn the domain first, then
+                engineer the system that ships.
+              </p>
+            </div>
+          </AnimatedSection>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto max-w-7xl px-6">
+          <AnimatedSection>
+            <SectionHeading
+              title="Selected finance work"
+              subtitle="Proof that the AI engineer title is earned in markets, not slides"
+            />
+          </AnimatedSection>
+          <div className="mt-10 grid gap-6 md:grid-cols-2">
+            {data.proofPoints.map((point, index) => (
+              <AnimatedSection key={point.id} delay={index * 0.08}>
+                <article className="border border-warm-gray bg-paper p-6">
+                  <p className="font-mono text-xs uppercase tracking-[0.2em] text-accent-warm">
+                    {point.role}
+                  </p>
+                  <h3 className="mt-3 font-serif text-lg text-ink">{point.title}</h3>
+                  <p className="mt-3 text-sm leading-relaxed text-mid-gray">
+                    {point.description}
+                  </p>
+                </article>
+              </AnimatedSection>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16">
+        <div className="mx-auto max-w-4xl px-6">
+          <AnimatedSection>
+            <SectionHeading
+              title="Need an AI engineer on a live problem?"
+              subtitle={siteProfile.contactPrompt}
+            />
+          </AnimatedSection>
+          <AnimatedSection delay={0.15} className="mt-10 text-center">
+            <TrackedLink
+              href={schedulerHref}
+              eventName="funnel_cta_click"
+              eventProperties={{
+                section: "ai_engineer_mid_cta",
+                cta_label: siteProfile.primaryCtaLabel,
+                destination: schedulerHref,
+                interaction_type: "link_click",
+              }}
+              className="inline-flex bg-ink px-8 py-3 text-sm font-medium text-paper transition hover:bg-ink/85"
+            >
+              {siteProfile.primaryCtaLabel}
+            </TrackedLink>
+            <p className="mt-3 text-sm text-mid-gray">
+              Prefer email?{" "}
+              <TrackedLink
+                href="/contact"
+                eventName="funnel_contact_intent"
+                eventProperties={{
+                  section: "ai_engineer_mid_cta",
+                  cta_label: "Start a conversation",
+                  destination: "/contact",
+                  interaction_type: "link_click",
+                }}
+                className="text-ink underline underline-offset-4 transition-colors hover:text-mid-gray"
+              >
+                Start a conversation
+              </TrackedLink>
+              .
+            </p>
+          </AnimatedSection>
+        </div>
+      </section>
+
+      <section className="pt-4">
+        <div className="mx-auto max-w-3xl px-6">
+          <AnimatedSection>
+            <SectionHeading title="Frequently Asked Questions" />
+          </AnimatedSection>
+          <AnimatedSection delay={0.15} className="mt-8">
+            <div className="border border-warm-gray bg-paper px-6">
+              <FAQ faqs={data.faq} />
+            </div>
+          </AnimatedSection>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/app/consulting/page.tsx
+++ b/apps/web/src/app/consulting/page.tsx
@@ -179,6 +179,23 @@ export default async function ConsultingPage() {
             <p className="font-mono text-xs uppercase tracking-[0.25em] text-mid-gray">Consulting</p>
             <h1 className="mt-4 font-serif text-4xl leading-tight text-ink sm:text-5xl">{data.title}</h1>
             <p className="mt-6 max-w-3xl text-xl leading-relaxed text-mid-gray">{data.subtitle}</p>
+            <p className="mt-4 max-w-3xl text-sm text-mid-gray">
+              Looking for the{" "}
+              <TrackedLink
+                href="/ai-engineer"
+                eventName="funnel_cta_click"
+                eventProperties={{
+                  section: "consulting_hero",
+                  cta_label: "AI engineer landing",
+                  destination: "/ai-engineer",
+                  interaction_type: "link_click",
+                }}
+                className="text-ink underline underline-offset-4 transition-colors hover:text-mid-gray"
+              >
+                AI engineer
+              </TrackedLink>{" "}
+              profile instead?
+            </p>
           </AnimatedSection>
         </div>
       </section>

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -190,6 +190,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     about: now,
     binaPrint: now,
     consulting: now,
+    aiEngineer: now,
     blog: now,
   };
 
@@ -229,6 +230,12 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     {
       url: `${SITE_URL}/consulting`,
       lastModified: pageTimestamps.consulting,
+      changeFrequency: "monthly",
+      priority: 0.9,
+    },
+    {
+      url: `${SITE_URL}/ai-engineer`,
+      lastModified: pageTimestamps.aiEngineer,
       changeFrequency: "monthly",
       priority: 0.9,
     },

--- a/apps/web/src/components/home/ServicesGrid.tsx
+++ b/apps/web/src/components/home/ServicesGrid.tsx
@@ -21,7 +21,7 @@ const services: ServiceCard[] = [
     title: "Production AI Engineering",
     description:
       "Your AI system needs to work on Monday morning, not just in a Thursday demo. I build LLM-powered products—agents, search, and document intelligence—that run in production with monitoring and governance.",
-    href: "/consulting",
+    href: "/ai-engineer",
   },
   {
     number: "02",

--- a/apps/web/src/components/layout/Footer.tsx
+++ b/apps/web/src/components/layout/Footer.tsx
@@ -1,4 +1,13 @@
+import Link from "next/link";
 import type { SocialLink } from "@/types/strapi";
+
+const footerLinks = [
+  { href: "/ai-engineer", label: "AI Engineer" },
+  { href: "/consulting", label: "Consulting" },
+  { href: "/about", label: "About" },
+  { href: "/blog", label: "Writing" },
+  { href: "/contact", label: "Contact" },
+] as const;
 
 interface FooterProps {
   siteName: string;
@@ -71,7 +80,21 @@ export function Footer({
       </div>
 
       <div className="border-t border-warm-gray">
-        <div className="mx-auto max-w-7xl px-6 py-6 lg:px-8">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-6 py-6 sm:flex-row sm:items-center sm:justify-between lg:px-8">
+          <nav aria-label="Footer">
+            <ul className="flex flex-wrap items-center gap-x-5 gap-y-2">
+              {footerLinks.map((link) => (
+                <li key={link.href}>
+                  <Link
+                    href={link.href}
+                    className="text-sm text-mid-gray transition-colors hover:text-ink"
+                  >
+                    {link.label}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
           <p className="text-xs text-mid-gray">
             {footerText} {new Date().getFullYear()}
           </p>

--- a/apps/web/src/content/fallbacks/ai-engineer.ts
+++ b/apps/web/src/content/fallbacks/ai-engineer.ts
@@ -1,0 +1,117 @@
+import type { FAQ as FAQType } from "@/types/strapi";
+import type { SiteProfile } from "@/lib/site-profile";
+
+export const aiEngineerMetadataTitle = "AI Engineer";
+
+export const aiEngineerKeywords = [
+  "AI engineer",
+  "AI engineering",
+  "production AI systems",
+  "LLM engineering",
+  "financial AI",
+  "quantitative AI",
+];
+
+export const aiEngineerCapabilities = [
+  {
+    id: 1,
+    title: "Production LLM systems",
+    description:
+      "Agents, search, and document intelligence that stay up, stay observable, and stay inside the constraints of a real financial workflow.",
+  },
+  {
+    id: 2,
+    title: "Domain-first architecture",
+    description:
+      "I learn the market, risk, or operations problem before I pick a model. The system has to survive review by people who own P&L and audit.",
+  },
+  {
+    id: 3,
+    title: "Delivery past the demo",
+    description:
+      "Most AI work dies between a working prototype and a Monday-morning product. I take ownership of that gap — evaluation, monitoring, and handoff.",
+  },
+];
+
+export const aiEngineerProofPoints = [
+  {
+    id: 1,
+    title: "Capital One",
+    role: "Quantitative Analysis Manager",
+    description:
+      "Led machine-learning liquidity forecasting across finance, data engineering, and compliance — the kind of model work that has to reconcile with how a bank actually funds itself.",
+  },
+  {
+    id: 2,
+    title: "CFA Charter",
+    role: "CFA Institute",
+    description:
+      "The charter is how I talk risk, valuation, and capital markets with the people who will live with the system — not just the team that built the notebook.",
+  },
+  {
+    id: 3,
+    title: "Adviser",
+    role: "Co-Founder",
+    description:
+      "Co-built a virtual investment adviser that turned conversation into personalized financial visualizations people could use, not just admire.",
+  },
+  {
+    id: 4,
+    title: "FI Consulting",
+    role: "Senior Consultant",
+    description:
+      "Earned the CFA while contributing financial data work with the Office of Financial Research — translating market and policy context into usable analytical output.",
+  },
+];
+
+export const aiEngineerFaqs: FAQType[] = [
+  {
+    id: 1,
+    question: "What does an AI engineer do?",
+    answer:
+      "An AI engineer designs, builds, and operates systems that use models in production. That includes retrieval, agents, evaluation, monitoring, and the product surface — not just training a model in a notebook.",
+  },
+  {
+    id: 2,
+    question: "How is an AI engineer different from a data scientist?",
+    answer:
+      "Data science finds signal. AI engineering ships the system around that signal: APIs, latency, failure modes, governance, and the domain workflow the model has to live in. I do both, but the job is delivery.",
+  },
+  {
+    id: 3,
+    question: "Do you work with financial services teams?",
+    answer:
+      "Yes. Finance is the primary domain — research, risk, liquidity, and decision-support systems that have to stand up to audit and Monday-morning operations.",
+  },
+  {
+    id: 4,
+    question: "How do I start working with an AI engineer?",
+    answer:
+      "Book a 20-minute discovery call. We align on the outcome, the constraints, and whether a production path exists. If it does, you get a scoped proposal — not a slide deck of possibilities.",
+  },
+];
+
+export interface AiEngineerFallbackData {
+  title: string;
+  headline: string;
+  subtitle: string;
+  description: string;
+  capabilities: typeof aiEngineerCapabilities;
+  proofPoints: typeof aiEngineerProofPoints;
+  faq: FAQType[];
+}
+
+export function buildAiEngineerFallback(
+  siteProfile: SiteProfile
+): AiEngineerFallbackData {
+  return {
+    title: aiEngineerMetadataTitle,
+    headline: aiEngineerMetadataTitle,
+    subtitle: `${siteProfile.authorName} is an AI engineer who ships production systems in finance — from prototype to something operations can run.`,
+    description:
+      "AI engineer Mehdi Zare ships production AI systems for financial services: LLM products, architecture, and delivery from prototype to production.",
+    capabilities: aiEngineerCapabilities,
+    proofPoints: aiEngineerProofPoints,
+    faq: aiEngineerFaqs,
+  };
+}

--- a/apps/web/src/content/fallbacks/ai-engineer.ts
+++ b/apps/web/src/content/fallbacks/ai-engineer.ts
@@ -108,8 +108,7 @@ export function buildAiEngineerFallback(
     title: aiEngineerMetadataTitle,
     headline: aiEngineerMetadataTitle,
     subtitle: `${siteProfile.authorName} is an AI engineer who ships production systems in finance — from prototype to something operations can run.`,
-    description:
-      "AI engineer Mehdi Zare ships production AI systems for financial services: LLM products, architecture, and delivery from prototype to production.",
+    description: `AI engineer ${siteProfile.siteName} ships production AI systems for financial services: LLM products, architecture, and delivery from prototype to production.`,
     capabilities: aiEngineerCapabilities,
     proofPoints: aiEngineerProofPoints,
     faq: aiEngineerFaqs,

--- a/apps/web/src/content/fallbacks/index.ts
+++ b/apps/web/src/content/fallbacks/index.ts
@@ -1,4 +1,9 @@
 export { buildAboutFallback } from "./about";
+export {
+  aiEngineerKeywords,
+  aiEngineerMetadataTitle,
+  buildAiEngineerFallback,
+} from "./ai-engineer";
 export { fallbackBinaPrintData } from "./bina-print";
 export { buildConsultingFallback } from "./consulting";
 export { buildHomeFallback, splitIndustries } from "./home";

--- a/apps/web/src/lib/analytics.ts
+++ b/apps/web/src/lib/analytics.ts
@@ -12,6 +12,7 @@ export type AnalyticsProperties = Record<string, AnalyticsPropertyValue>;
 export type AnalyticsPageType =
   | "home"
   | "consulting"
+  | "ai_engineer"
   | "contact"
   | "blog"
   | "blog_post"
@@ -87,6 +88,9 @@ export function resolvePageType(pathname: string): AnalyticsPageType {
   if (normalized === "/") return "home";
   if (normalized === "/consulting" || normalized.startsWith("/consulting/")) {
     return "consulting";
+  }
+  if (normalized === "/ai-engineer" || normalized.startsWith("/ai-engineer/")) {
+    return "ai_engineer";
   }
   if (normalized === "/contact" || normalized.startsWith("/contact/")) {
     return "contact";

--- a/apps/web/src/lib/llms.ts
+++ b/apps/web/src/lib/llms.ts
@@ -18,6 +18,7 @@ export function buildLlmsTxtContent(): string {
     `- ${siteUrl}`,
     `- ${buildAbsolutePath("/about", siteUrl)}`,
     `- ${buildAbsolutePath("/consulting", siteUrl)}`,
+    `- ${buildAbsolutePath("/ai-engineer", siteUrl)}`,
     `- ${buildAbsolutePath("/blog", siteUrl)}`,
     `- ${buildAbsolutePath("/author/mehdi-zare", siteUrl)}`,
     `- ${buildAbsolutePath("/contact", siteUrl)}`,

--- a/apps/web/tests/ai-engineer-landing.test.ts
+++ b/apps/web/tests/ai-engineer-landing.test.ts
@@ -1,0 +1,47 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const forbiddenTerms = [
+  /\bCISA\b/i,
+  /\bgovernment\b/i,
+  /\bdefense\b/i,
+  /\bclearance\b/i,
+  /\bfederal\b/i,
+  /\bnational security\b/i,
+];
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+test("AI engineer landing is a dedicated non-blog route titled to the query", () => {
+  const page = readSource("src/app/ai-engineer/page.tsx");
+  const fallback = readSource("src/content/fallbacks/ai-engineer.ts");
+
+  assert.match(page, /pathname = "\/ai-engineer"/);
+  assert.match(page, /title: aiEngineerMetadataTitle/);
+  assert.match(page, /getSiteProfile/);
+  assert.match(fallback, /export const aiEngineerMetadataTitle = "AI Engineer"/);
+  assert.doesNotMatch(page, /\/blog\//);
+  assert.match(readSource("src/components/layout/Footer.tsx"), /href: "\/ai-engineer"/);
+  assert.match(readSource("src/components/home/ServicesGrid.tsx"), /href: "\/ai-engineer"/);
+});
+
+test("AI engineer landing copy stays AI/finance and omits government/CISA", () => {
+  const sources = [
+    readSource("src/app/ai-engineer/page.tsx"),
+    readSource("src/content/fallbacks/ai-engineer.ts"),
+  ];
+
+  for (const source of sources) {
+    for (const term of forbiddenTerms) {
+      assert.doesNotMatch(source, term);
+    }
+  }
+
+  const fallback = sources[1];
+  assert.match(fallback, /finance/i);
+  assert.match(fallback, /CFA/);
+});

--- a/apps/web/tests/ai-engineer-landing.test.ts
+++ b/apps/web/tests/ai-engineer-landing.test.ts
@@ -24,6 +24,8 @@ test("AI engineer landing is a dedicated non-blog route titled to the query", ()
   assert.match(page, /title: aiEngineerMetadataTitle/);
   assert.match(page, /getSiteProfile/);
   assert.match(fallback, /export const aiEngineerMetadataTitle = "AI Engineer"/);
+  assert.match(fallback, /`AI engineer \$\{siteProfile\.siteName\}/);
+  assert.doesNotMatch(fallback, /AI engineer Mehdi Zare/);
   assert.doesNotMatch(page, /\/blog\//);
   assert.match(readSource("src/components/layout/Footer.tsx"), /href: "\/ai-engineer"/);
   assert.match(readSource("src/components/home/ServicesGrid.tsx"), /href: "\/ai-engineer"/);

--- a/apps/web/tests/analytics-tracking.test.ts
+++ b/apps/web/tests/analytics-tracking.test.ts
@@ -98,6 +98,7 @@ function installBrowserMocks(url: string, referrer = ""): {
 test("resolvePageType classifies core routes correctly", () => {
   assert.equal(resolvePageType("/"), "home");
   assert.equal(resolvePageType("/consulting"), "consulting");
+  assert.equal(resolvePageType("/ai-engineer"), "ai_engineer");
   assert.equal(resolvePageType("/contact"), "contact");
   assert.equal(resolvePageType("/author/mehdi-zare"), "author");
   assert.equal(resolvePageType("/blog"), "blog");

--- a/apps/web/tests/llms-contract.test.ts
+++ b/apps/web/tests/llms-contract.test.ts
@@ -12,6 +12,7 @@ test("llms.txt route returns text content with canonical host and sitemap", asyn
   const body = await response.text();
   assert.match(body, /canonical_host:\s+https:\/\/www\.mehdi-zare\.com/);
   assert.match(body, /sitemap:\s+https:\/\/www\.mehdi-zare\.com\/sitemap\.xml/);
+  assert.match(body, /https:\/\/www\.mehdi-zare\.com\/ai-engineer/);
 });
 
 test(".well-known llms.txt route mirrors main llms.txt content", async () => {

--- a/apps/web/tests/site-profile-usage.test.ts
+++ b/apps/web/tests/site-profile-usage.test.ts
@@ -8,6 +8,7 @@ const pageFiles = [
   "src/app/page.tsx",
   "src/app/about/page.tsx",
   "src/app/consulting/page.tsx",
+  "src/app/ai-engineer/page.tsx",
   "src/app/contact/page.tsx",
   "src/app/blog/page.tsx",
   "src/app/blog/[slug]/page.tsx",

--- a/apps/web/tests/sitemap-route.test.ts
+++ b/apps/web/tests/sitemap-route.test.ts
@@ -12,6 +12,7 @@ test("sitemap includes fallback category/tag entries when CMS is disabled", asyn
   assert.ok(entries.length > 5);
   assert.ok(urls.includes("https://www.mehdi-zare.com"));
   assert.ok(urls.includes("https://www.mehdi-zare.com/blog"));
+  assert.ok(urls.includes("https://www.mehdi-zare.com/ai-engineer"));
   assert.ok(urls.includes("https://www.mehdi-zare.com/blog/category/ai-engineering"));
   assert.ok(urls.includes("https://www.mehdi-zare.com/blog/tag/llms"));
   assert.ok(urls.some((url) => url.startsWith("https://www.mehdi-zare.com/author/")));


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #14.

Google Search Console has “AI engineer” at position 2 with no dedicated URL. This adds `/ai-engineer` as a standalone landing (not a blog post) titled to that query.

## What shipped
- `/ai-engineer` page with H1/title **AI Engineer**, finance-only proof (CFA, Capital One, Adviser, OFR/finance work)
- Copy excludes government/CISA/defense/clearance content
- Sitemap, `llms.txt`, footer, homepage “Production AI Engineering” card, and consulting hero now point at the landing
- JSON-LD (WebPage + breadcrumbs + FAQ) and analytics `ai_engineer` page type
- Contract tests for route, title, sitemap, and forbidden terms

## Verification
- `pnpm --filter=web` lint, typecheck, tests (62), and production build all pass
- Live check against `next start`: `/ai-engineer` is 200, title is `AI Engineer | Mehdi Zare`, canonical is `https://www.mehdi-zare.com/ai-engineer`
- Browser walkthrough: FAQ opens, Let’s Talk goes to `/consulting#book`, homepage service card and consulting/footer links reach the landing, `/about` and `/blog` still load, mobile nav/footer work

## Also on this branch
- Bumped the `tar` override to `7.5.21` so CI `pnpm audit --audit-level high` stays green (GHSA-r292-9mhp-454m). Residual moderate/low Strapi findings remain on #13.

## Out of scope
- Issue #13 (Strapi moderate/low audit debt) is a separate security track
- Related content refresh for “why most AI projects die” and `/consulting` is called out in #14 as not this ticket

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cc34901f-38e2-43db-8a44-0e582e3ff300?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cc34901f-38e2-43db-8a44-0e582e3ff300&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

