### PR TITLE
ci: run required checks on GitHub-hosted ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   quality:
     name: Lint, Typecheck, Test, Build
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -46,7 +46,7 @@ jobs:
 
   security:
     name: Dependency Audit
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -70,7 +70,7 @@ jobs:
 
   secret-scan:
     name: Secret Scan
-    runs-on: namespace-profile-default
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
Fixes #18.

## Why
Required checks (`Lint, Typecheck, Test, Build`, `Dependency Audit`, `Secret Scan`) never completed because every job in `.github/workflows/ci.yml` used `runs-on: namespace-profile-default`. Jobs sat queued with no registered classic self-hosted runners, and Namespace.so was not picking up work.

This PR switches those jobs to GitHub-hosted `ubuntu-latest` so required checks can **run**. Restoring Namespace (or documenting why we stay on GitHub-hosted) is the P1 follow-up: #21. That track is split out so closing #18 does not lose it.

## Isolated audit floor (this PR only)
Once jobs actually ran, required **Dependency Audit** failed on a pre-existing pin: `tar@7.5.20` is the last version in [GHSA-r292-9mhp-454m](https://github.com/advisories/GHSA-r292-9mhp-454m). This PR floors `tar` to `7.5.21` (the GHSA patch) and refreshes the lockfile so that required check can **pass**.

Left on #13 / #16 / #17 (not this PR):
- Strapi 5.52, hono, yaml, react-router, override-policy docs
- Residual low/moderate findings (CI policy stays `--audit-level high`)

## Isolated from #15 / #16 / #17
This is infrastructure plus a one-package security floor, not a feature/deps rewrite. Those branches already have the `runs-on` change. #16/#17 already pin tar ≥ 7.5.21; rebase if the lockfile conflicts. #15 still needs this tar floor (or a rebase onto `main` after this merges) for Dependency Audit to pass.

`pull_request` workflows use the workflow file from the **head branch**, so merging this unblocks future work on `main` without rewriting those PRs' own CI files.