### PR TITLE
chore(cms): derive Docker pnpm pin from packageManager

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -44,8 +44,8 @@ tasks:
     cmd: pnpm --filter=web exec tsc --noEmit
 
   test:
-    desc: Run web test suite
-    cmd: pnpm --filter=web test
+    desc: Run web and repo script tests
+    cmd: pnpm test
 
   posthog:push-dashboard:
     desc: Create/update the managed PostHog funnel dashboard via API
@@ -56,7 +56,7 @@ tasks:
     cmds:
       - pnpm --filter=web lint
       - pnpm --filter=web exec tsc --noEmit
-      - pnpm --filter=web test
+      - pnpm test
       - pnpm --filter=web build
 
   prepush:

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -1,12 +1,16 @@
 FROM node:24-alpine AS base
 
-RUN corepack enable && corepack prepare pnpm@11.23.0 --activate
 RUN apk add --no-cache build-base gcc autoconf automake libtool zlib-dev libpng-dev vips-dev
 
 WORKDIR /app
 
-# Copy root workspace files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# Activate pnpm from package.json#packageManager (hex SHA-512 required; Corepack splits on +).
+COPY package.json ./
+COPY scripts/package-manager.mjs scripts/corepack-prepare-pnpm.mjs ./scripts/
+RUN node scripts/corepack-prepare-pnpm.mjs
+
+# Copy remaining workspace files
+COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Copy cms package.json for dependency resolution
 COPY apps/cms/package.json ./apps/cms/
@@ -29,13 +33,16 @@ RUN pnpm --filter cms build
 # --- Production stage ---
 FROM node:24-alpine AS production
 
-RUN corepack enable && corepack prepare pnpm@11.23.0 --activate
 RUN apk add --no-cache vips-dev
 
 WORKDIR /app
 
-# Copy root workspace files
-COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+# Activate pnpm from package.json#packageManager (hex SHA-512 required; Corepack splits on +).
+COPY package.json ./
+COPY scripts/package-manager.mjs scripts/corepack-prepare-pnpm.mjs ./scripts/
+RUN node scripts/corepack-prepare-pnpm.mjs
+
+COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Copy cms package.json
 COPY apps/cms/package.json ./apps/cms/

--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -4,12 +4,12 @@ RUN apk add --no-cache build-base gcc autoconf automake libtool zlib-dev libpng-
 
 WORKDIR /app
 
-# Activate pnpm from package.json#packageManager (hex SHA-512 required; Corepack splits on +).
+# pnpm from package.json#packageManager (Corepack-safe hex integrity).
 COPY package.json ./
 COPY scripts/package-manager.mjs scripts/corepack-prepare-pnpm.mjs ./scripts/
 RUN node scripts/corepack-prepare-pnpm.mjs
 
-# Copy remaining workspace files
+# Remaining root workspace manifests (lockfile + pnpm-workspace).
 COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Copy cms package.json for dependency resolution
@@ -37,7 +37,7 @@ RUN apk add --no-cache vips-dev
 
 WORKDIR /app
 
-# Activate pnpm from package.json#packageManager (hex SHA-512 required; Corepack splits on +).
+# pnpm from package.json#packageManager (Corepack-safe hex integrity).
 COPY package.json ./
 COPY scripts/package-manager.mjs scripts/corepack-prepare-pnpm.mjs ./scripts/
 RUN node scripts/corepack-prepare-pnpm.mjs

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -11,11 +11,13 @@ Strapi 5 backend that powers site content and contact submissions.
 
 ## Docker / Corepack pnpm pin
 
-The CMS Dockerfile does **not** hardcode a pnpm version. Both stages copy `package.json` and run `scripts/corepack-prepare-pnpm.mjs`, which activates `package.json#packageManager`.
+The CMS Dockerfile does **not** hardcode a pnpm version. Both stages copy `package.json`, `scripts/package-manager.mjs`, and `scripts/corepack-prepare-pnpm.mjs`, then run the prepare script so Corepack activates `package.json#packageManager`.
 
-`packageManager` integrity **must be hex SHA-512** (`pnpm@<version>+sha512.<hex>`), not npm's base64 form (`sha512-...`). Corepack splits that field on `+`, so a base64 hash that contains `+` is rejected. `node --test scripts/*.test.mjs` (via root `pnpm test`) fails the build if the Dockerfile pin drifts or the hash is not hex.
+`packageManager` integrity **must be hex SHA-512** (`pnpm@<version>+sha512.<128 hex chars>`), not npm's SRI form (`sha512-...`). Corepack treats `+…` as semver build metadata and compares a hex digest, so base64 hashes are rejected.
 
-To bump pnpm: change `packageManager` in the root `package.json` (hex integrity) and rebuild. Do not edit `pnpm@…` inside `apps/cms/Dockerfile`.
+Root `pnpm test` runs `node --test 'scripts/*.test.mjs'` and fails CI if a Docker stage stops using the helper or the hash is not hex.
+
+To bump pnpm: run `corepack use pnpm@<version>` at the repo root (writes hex integrity) and rebuild the image. Do not edit `pnpm@…` inside `apps/cms/Dockerfile`.
 
 ## Required Environment Variables (Production)
 

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -7,6 +7,15 @@ Strapi 5 backend that powers site content and contact submissions.
 - `pnpm --filter=cms dev`
 - `pnpm --filter=cms build`
 - `pnpm --filter=cms start`
+- `task docker:build:cms` (image build from the repo root)
+
+## Docker / Corepack pnpm pin
+
+The CMS Dockerfile does **not** hardcode a pnpm version. Both stages copy `package.json` and run `scripts/corepack-prepare-pnpm.mjs`, which activates `package.json#packageManager`.
+
+`packageManager` integrity **must be hex SHA-512** (`pnpm@<version>+sha512.<hex>`), not npm's base64 form (`sha512-...`). Corepack splits that field on `+`, so a base64 hash that contains `+` is rejected. `node --test scripts/*.test.mjs` (via root `pnpm test`) fails the build if the Dockerfile pin drifts or the hash is not hex.
+
+To bump pnpm: change `packageManager` in the root `package.json` (hex integrity) and rebuild. Do not edit `pnpm@…` inside `apps/cms/Dockerfile`.
 
 ## Required Environment Variables (Production)
 

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:web": "turbo dev --filter=web",
     "dev:cms": "turbo dev --filter=cms",
     "typecheck": "pnpm --filter=web exec tsc --noEmit",
-    "test": "pnpm --filter=web test",
+    "test": "pnpm --filter=web test && node --test scripts/*.test.mjs",
     "prepare": "[ -d .git ] && husky || true"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dev:web": "turbo dev --filter=web",
     "dev:cms": "turbo dev --filter=cms",
     "typecheck": "pnpm --filter=web exec tsc --noEmit",
-    "test": "pnpm --filter=web test && node --test scripts/*.test.mjs",
+    "test": "pnpm --filter=web test && node --test 'scripts/*.test.mjs'",
     "prepare": "[ -d .git ] && husky || true"
   },
   "devDependencies": {

--- a/scripts/corepack-prepare-pnpm.mjs
+++ b/scripts/corepack-prepare-pnpm.mjs
@@ -2,13 +2,15 @@
 /**
  * Enable Corepack and activate the pnpm version from package.json#packageManager.
  *
- * Integrity must be hex SHA-512 (`sha512.<hex>`). npm base64 hashes contain `+`,
- * and Corepack splits the packageManager field on `+`.
+ * Integrity must be hex SHA-512 (`sha512.` plus 128 hex chars). npm SRI
+ * (`sha512-…`) can contain `+`/`/`, and Corepack treats `+` as semver
+ * build metadata.
  *
  * Usage:
  *   node scripts/corepack-prepare-pnpm.mjs          # corepack enable + prepare
- *   node scripts/corepack-prepare-pnpm.mjs --check  # validate only
+ *   node scripts/corepack-prepare-pnpm.mjs --check  # validate packageManager shape only
  */
+
 import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
@@ -24,16 +26,28 @@ if (process.argv.includes("--check")) {
   process.exit(0);
 }
 
+// Disable Corepack's TTY download prompt so Docker/CI cannot hang.
 const env = { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" };
 
-const enable = spawnSync("corepack", ["enable"], { stdio: "inherit", env });
-if (enable.status !== 0) {
-  process.exit(enable.status ?? 1);
+function runCorepack(args) {
+  const result = spawnSync("corepack", args, {
+    stdio: "inherit",
+    env,
+    cwd: root,
+  });
+  const command = `corepack ${args.join(" ")}`;
+  if (result.error) {
+    console.error(`${command} failed: ${result.error.message}`);
+    process.exit(1);
+  }
+  if (result.signal) {
+    console.error(`${command} killed by ${result.signal}`);
+    process.exit(1);
+  }
+  if (result.status !== 0) {
+    process.exit(result.status ?? 1);
+  }
 }
 
-const prepare = spawnSync(
-  "corepack",
-  ["prepare", parsed.spec, "--activate"],
-  { stdio: "inherit", env },
-);
-process.exit(prepare.status ?? 1);
+runCorepack(["enable"]);
+runCorepack(["prepare", parsed.spec, "--activate"]);

--- a/scripts/corepack-prepare-pnpm.mjs
+++ b/scripts/corepack-prepare-pnpm.mjs
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+/**
+ * Enable Corepack and activate the pnpm version from package.json#packageManager.
+ *
+ * Integrity must be hex SHA-512 (`sha512.<hex>`). npm base64 hashes contain `+`,
+ * and Corepack splits the packageManager field on `+`.
+ *
+ * Usage:
+ *   node scripts/corepack-prepare-pnpm.mjs          # corepack enable + prepare
+ *   node scripts/corepack-prepare-pnpm.mjs --check  # validate only
+ */
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parsePackageManagerField } from "./package-manager.mjs";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+const parsed = parsePackageManagerField(pkg.packageManager);
+
+if (process.argv.includes("--check")) {
+  console.log(`packageManager ok: ${parsed.spec}`);
+  process.exit(0);
+}
+
+const env = { ...process.env, COREPACK_ENABLE_DOWNLOAD_PROMPT: "0" };
+
+const enable = spawnSync("corepack", ["enable"], { stdio: "inherit", env });
+if (enable.status !== 0) {
+  process.exit(enable.status ?? 1);
+}
+
+const prepare = spawnSync(
+  "corepack",
+  ["prepare", parsed.spec, "--activate"],
+  { stdio: "inherit", env },
+);
+process.exit(prepare.status ?? 1);

--- a/scripts/package-manager.mjs
+++ b/scripts/package-manager.mjs
@@ -1,27 +1,30 @@
 /**
  * Parse and validate package.json#packageManager for Corepack.
  *
- * Corepack splits `name@version+integrity` on `+`. npm's base64 SHA-512
- * integrity (`sha512-...`) can contain `+`, so Corepack rejects it. Use hex
- * (`sha512.<hex>`) until Corepack stops splitting on `+`.
+ * Corepack treats `+…` as semver build metadata (`name@version+integrity`)
+ * and compares a hex digest. npm's SRI form (`sha512-<base64>`) can contain
+ * `+` or `/`, so it is rejected. Use `sha512.` plus 128 hex characters.
  */
 
+const HEX_SHA512 = /^sha512\.[0-9a-f]{128}$/i;
+
 export function parsePackageManagerField(packageManager) {
-  if (typeof packageManager !== "string" || packageManager.trim() === "") {
+  const value = typeof packageManager === "string" ? packageManager.trim() : "";
+  if (value === "") {
     throw new Error("package.json packageManager is missing");
   }
 
-  const match = packageManager.trim().match(/^(pnpm)@([^+]+)(?:\+(.+))?$/);
+  const match = value.match(/^(pnpm)@([^+]+)(?:\+(.+))?$/);
   if (!match) {
     throw new Error(
-      `packageManager must be pnpm@version+sha512.<hex>, got: ${packageManager}`,
+      `packageManager must be pnpm@version+sha512.<128 hex chars>, got: ${packageManager}`,
     );
   }
 
   const [, name, version, integrity] = match;
-  if (!integrity || !/^sha512\.[0-9a-f]+$/i.test(integrity)) {
+  if (!integrity || !HEX_SHA512.test(integrity)) {
     throw new Error(
-      "packageManager integrity must be hex SHA-512 (sha512.<hex>), not npm base64. Corepack splits the field on +, so base64 hashes that contain + are rejected.",
+      "packageManager integrity must be hex SHA-512 (sha512.<128 hex chars>), not npm base64. Corepack treats + as semver build metadata, so base64 SRI is rejected.",
     );
   }
 
@@ -30,6 +33,5 @@ export function parsePackageManagerField(packageManager) {
     version,
     integrity,
     spec: `${name}@${version}+${integrity}`,
-    corepackSpec: `${name}@${version}+${integrity}`,
   };
 }

--- a/scripts/package-manager.mjs
+++ b/scripts/package-manager.mjs
@@ -1,0 +1,35 @@
+/**
+ * Parse and validate package.json#packageManager for Corepack.
+ *
+ * Corepack splits `name@version+integrity` on `+`. npm's base64 SHA-512
+ * integrity (`sha512-...`) can contain `+`, so Corepack rejects it. Use hex
+ * (`sha512.<hex>`) until Corepack stops splitting on `+`.
+ */
+
+export function parsePackageManagerField(packageManager) {
+  if (typeof packageManager !== "string" || packageManager.trim() === "") {
+    throw new Error("package.json packageManager is missing");
+  }
+
+  const match = packageManager.trim().match(/^(pnpm)@([^+]+)(?:\+(.+))?$/);
+  if (!match) {
+    throw new Error(
+      `packageManager must be pnpm@version+sha512.<hex>, got: ${packageManager}`,
+    );
+  }
+
+  const [, name, version, integrity] = match;
+  if (!integrity || !/^sha512\.[0-9a-f]+$/i.test(integrity)) {
+    throw new Error(
+      "packageManager integrity must be hex SHA-512 (sha512.<hex>), not npm base64. Corepack splits the field on +, so base64 hashes that contain + are rejected.",
+    );
+  }
+
+  return {
+    name,
+    version,
+    integrity,
+    spec: `${name}@${version}+${integrity}`,
+    corepackSpec: `${name}@${version}+${integrity}`,
+  };
+}

--- a/scripts/package-manager.test.mjs
+++ b/scripts/package-manager.test.mjs
@@ -1,0 +1,77 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const { parsePackageManagerField } = await import("./package-manager.mjs");
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+test("parsePackageManagerField accepts pnpm version with hex SHA-512 integrity", () => {
+  const parsed = parsePackageManagerField(
+    "pnpm@11.23.0+sha512.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  );
+  assert.equal(parsed.name, "pnpm");
+  assert.equal(parsed.version, "11.23.0");
+  assert.equal(parsed.corepackSpec, parsed.spec);
+  assert.match(parsed.integrity, /^sha512\.[0-9a-f]+$/i);
+});
+
+test("parsePackageManagerField rejects npm base64 integrity that contains +", () => {
+  assert.throws(
+    () =>
+      parsePackageManagerField(
+        "pnpm@11.23.0+sha512-Ab+Cd/ef+base64plus",
+      ),
+    /hex SHA-512/,
+  );
+});
+
+test("parsePackageManagerField rejects missing integrity", () => {
+  assert.throws(
+    () => parsePackageManagerField("pnpm@11.23.0"),
+    /integrity/,
+  );
+});
+
+test("parsePackageManagerField rejects non-pnpm package managers", () => {
+  assert.throws(
+    () =>
+      parsePackageManagerField(
+        "npm@10.0.0+sha512.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+      ),
+    /pnpm/,
+  );
+});
+
+test("root package.json packageManager is Corepack-safe hex SHA-512", () => {
+  const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+  const parsed = parsePackageManagerField(pkg.packageManager);
+  assert.equal(parsed.version, pkg.packageManager.split("+")[0].replace("pnpm@", ""));
+});
+
+test("corepack-prepare-pnpm --check accepts the repo packageManager field", () => {
+  const result = spawnSync(
+    process.execPath,
+    [resolve(root, "scripts/corepack-prepare-pnpm.mjs"), "--check"],
+    { encoding: "utf8" },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.match(result.stdout, /packageManager ok: pnpm@/);
+});
+
+test("CMS Dockerfile derives pnpm from package.json instead of a hardcoded version", () => {
+  const dockerfile = readFileSync(resolve(root, "apps/cms/Dockerfile"), "utf8");
+  assert.match(dockerfile, /corepack-prepare-pnpm\.mjs/);
+  assert.doesNotMatch(
+    dockerfile,
+    /corepack prepare pnpm@\d/,
+    "Dockerfile must not hardcode corepack prepare pnpm@version",
+  );
+  const prepareCopies = dockerfile.match(
+    /COPY scripts\/package-manager\.mjs scripts\/corepack-prepare-pnpm\.mjs \.\/scripts\//g,
+  );
+  assert.equal(prepareCopies?.length, 2, "both Docker stages must copy the prepare scripts");
+});

--- a/scripts/package-manager.test.mjs
+++ b/scripts/package-manager.test.mjs
@@ -4,27 +4,46 @@ import { spawnSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
-
-const { parsePackageManagerField } = await import("./package-manager.mjs");
+import { parsePackageManagerField } from "./package-manager.mjs";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const HEX_128 = "a".repeat(128);
+const HEX_SPEC = `pnpm@11.23.0+sha512.${HEX_128}`;
+
+function dockerStages(text) {
+  const stages = {};
+  for (const part of text.split(/^FROM /m).slice(1)) {
+    const name = part.match(/AS (\S+)/)?.[1];
+    stages[name] = `FROM ${part}`;
+  }
+  return stages;
+}
 
 test("parsePackageManagerField accepts pnpm version with hex SHA-512 integrity", () => {
-  const parsed = parsePackageManagerField(
-    "pnpm@11.23.0+sha512.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  );
+  const parsed = parsePackageManagerField(HEX_SPEC);
   assert.equal(parsed.name, "pnpm");
   assert.equal(parsed.version, "11.23.0");
-  assert.equal(parsed.corepackSpec, parsed.spec);
-  assert.match(parsed.integrity, /^sha512\.[0-9a-f]+$/i);
+  assert.equal(parsed.spec, HEX_SPEC);
+  assert.match(parsed.integrity, /^sha512\.[0-9a-f]{128}$/i);
 });
 
 test("parsePackageManagerField rejects npm base64 integrity that contains +", () => {
   assert.throws(
-    () =>
-      parsePackageManagerField(
-        "pnpm@11.23.0+sha512-Ab+Cd/ef+base64plus",
-      ),
+    () => parsePackageManagerField("pnpm@11.23.0+sha512-Ab+Cd/ef+base64plus"),
+    /hex SHA-512/,
+  );
+});
+
+test("parsePackageManagerField rejects npm SRI base64 without an extra +", () => {
+  assert.throws(
+    () => parsePackageManagerField("pnpm@11.23.0+sha512-AbCdEfGhij="),
+    /hex SHA-512/,
+  );
+});
+
+test("parsePackageManagerField rejects short hex integrity", () => {
+  assert.throws(
+    () => parsePackageManagerField("pnpm@11.23.0+sha512.aa"),
     /hex SHA-512/,
   );
 });
@@ -36,42 +55,62 @@ test("parsePackageManagerField rejects missing integrity", () => {
   );
 });
 
+test("parsePackageManagerField rejects missing or blank packageManager", () => {
+  assert.throws(() => parsePackageManagerField(undefined), /missing/);
+  assert.throws(() => parsePackageManagerField(""), /missing/);
+  assert.throws(() => parsePackageManagerField("   "), /missing/);
+});
+
 test("parsePackageManagerField rejects non-pnpm package managers", () => {
   assert.throws(
-    () =>
-      parsePackageManagerField(
-        "npm@10.0.0+sha512.aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-      ),
+    () => parsePackageManagerField(`npm@10.0.0+sha512.${HEX_128}`),
     /pnpm/,
   );
 });
 
 test("root package.json packageManager is Corepack-safe hex SHA-512", () => {
   const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+  assert.match(
+    pkg.packageManager,
+    /^pnpm@[^+]+\+sha512\.[0-9a-f]{128}$/i,
+  );
   const parsed = parsePackageManagerField(pkg.packageManager);
-  assert.equal(parsed.version, pkg.packageManager.split("+")[0].replace("pnpm@", ""));
+  assert.equal(parsed.spec, pkg.packageManager);
 });
 
-test("corepack-prepare-pnpm --check accepts the repo packageManager field", () => {
+test("root pnpm test still runs repo script tests", () => {
+  const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
+  assert.match(pkg.scripts.test, /node --test ['"]scripts\/\*\.test\.mjs['"]/);
+});
+
+test("corepack-prepare-pnpm --check accepts the repo packageManager field without corepack", () => {
+  const pkg = JSON.parse(readFileSync(resolve(root, "package.json"), "utf8"));
   const result = spawnSync(
     process.execPath,
     [resolve(root, "scripts/corepack-prepare-pnpm.mjs"), "--check"],
-    { encoding: "utf8" },
+    { encoding: "utf8", env: { ...process.env, PATH: "" } },
   );
   assert.equal(result.status, 0, result.stderr);
-  assert.match(result.stdout, /packageManager ok: pnpm@/);
+  assert.equal(
+    result.stdout.trim(),
+    `packageManager ok: ${pkg.packageManager}`,
+  );
 });
 
-test("CMS Dockerfile derives pnpm from package.json instead of a hardcoded version", () => {
+test("each CMS Docker stage copies package.json and runs the Corepack helper", () => {
   const dockerfile = readFileSync(resolve(root, "apps/cms/Dockerfile"), "utf8");
-  assert.match(dockerfile, /corepack-prepare-pnpm\.mjs/);
-  assert.doesNotMatch(
-    dockerfile,
-    /corepack prepare pnpm@\d/,
-    "Dockerfile must not hardcode corepack prepare pnpm@version",
-  );
-  const prepareCopies = dockerfile.match(
-    /COPY scripts\/package-manager\.mjs scripts\/corepack-prepare-pnpm\.mjs \.\/scripts\//g,
-  );
-  assert.equal(prepareCopies?.length, 2, "both Docker stages must copy the prepare scripts");
+  const stages = dockerStages(dockerfile);
+  for (const name of ["base", "production"]) {
+    const stage = stages[name];
+    assert.ok(stage, `missing stage ${name}`);
+    assert.match(stage, /COPY package\.json \.\//);
+    assert.match(stage, /package-manager\.mjs/);
+    assert.match(stage, /corepack-prepare-pnpm\.mjs/);
+    assert.match(stage, /RUN node scripts\/corepack-prepare-pnpm\.mjs/);
+    assert.doesNotMatch(
+      stage,
+      /corepack prepare pnpm@\d/,
+      `${name} must not hardcode corepack prepare pnpm@version`,
+    );
+  }
 });


### PR DESCRIPTION
## Summary

Keeps the CMS Docker pnpm pin from drifting away from `package.json#packageManager`.

- Both Dockerfile stages copy `package.json` plus the helper scripts and run `scripts/corepack-prepare-pnpm.mjs` instead of `corepack prepare pnpm@11.23.0`.
- `packageManager` integrity must be hex SHA-512 (`sha512.` plus 128 hex chars). Corepack treats `+…` as semver build metadata, so npm base64 SRI is rejected.
- Root `pnpm test` runs `node --test 'scripts/*.test.mjs'` so a Docker stage that skips the helper or a non-hex hash fails CI.
- Review follow-up (`244246e`): fail loudly on Corepack ENOENT/signal, tighten the hex length, and assert both stages `RUN` the helper.

Verified:
- `node --test 'scripts/*.test.mjs'` — 11/11 pass
- `pnpm --filter=web test` — 62/62 pass (parent commit)
- `docker run … node:24-alpine node scripts/corepack-prepare-pnpm.mjs` activated `pnpm@11.23.0+sha512.…` (parent commit)

## Test plan

- [x] Script unit tests reject base64 / short hex / missing field and require both Docker stages to RUN the helper
- [x] `--check` accepts the current root `packageManager` field without invoking Corepack
- [x] Alpine Corepack prepare succeeds against the real `package.json`
- [ ] CI quality job on this PR includes the new script tests

Follow-up: #25 (**P3**) share a Corepack pnpm Docker stage.

Fixes #20