### PR TITLE
docs(ci): stay on GitHub-hosted ubuntu-latest runners

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,0 +1,25 @@
+# CI
+
+Required jobs in `.github/workflows/ci.yml` run on GitHub-hosted `ubuntu-latest`.
+
+## Why not Namespace.so
+
+PR #11 switched those jobs to `runs-on: namespace-profile-default`. The Namespace GitHub App / billing / profile stopped picking up jobs (`GET /repos/MehdiZare/MehdiZare/actions/runners` was empty). Required checks sat `queued` for over an hour and blocked merges to `main` (#18).
+
+The GitHub-hosted workaround landed on `main` via #16 (PR #19 was closed as superseded). That is the runner policy until Namespace is proven again. Do not fold a runner switch into product or dependency PRs.
+
+Checked 2026-08-24: `gh api repos/MehdiZare/MehdiZare/actions/runners` still returns `total_count: 0`.
+
+## Restore Namespace later
+
+Isolated PR only, after all of the following are true:
+
+1. Namespace.so GitHub App is installed, billed, and the `namespace-profile-default` profile exists.
+2. Runners are registered (`gh api repos/MehdiZare/MehdiZare/actions/runners` is non-empty).
+3. A `workflow_dispatch` of `.github/workflows/ci.yml` is picked up on Namespace (status is not stuck in `queued`).
+4. `runs-on` in `ci.yml` switches back to `namespace-profile-default`, and this file is updated.
+
+## Out of scope
+
+- Residual Strapi-tree audit findings and pnpm overrides (#13)
+- Weakening `pnpm audit --audit-level high`

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,23 +1,24 @@
 # CI
 
 Required jobs in `.github/workflows/ci.yml` run on GitHub-hosted `ubuntu-latest`.
+The required check names are the job `name:` fields (`Lint, Typecheck, Test, Build`, `Dependency Audit`, `Secret Scan`); a runner-only switch does not need a branch-protection change.
 
 ## Why not Namespace.so
 
-PR #11 switched those jobs to `runs-on: namespace-profile-default`. The Namespace GitHub App / billing / profile stopped picking up jobs (`GET /repos/MehdiZare/MehdiZare/actions/runners` was empty). Required checks sat `queued` for over an hour and blocked merges to `main` (#18).
+PR #11 switched those jobs to `runs-on: namespace-profile-default`. The Namespace GitHub App / billing / profile stopped picking up jobs. Required checks sat `queued` for over an hour and blocked merges to `main` (#18).
 
 The GitHub-hosted workaround landed on `main` via #16 (PR #19 was closed as superseded). That is the runner policy until Namespace is proven again. Do not fold a runner switch into product or dependency PRs.
 
-Checked 2026-08-24: `gh api repos/MehdiZare/MehdiZare/actions/runners` still returns `total_count: 0`.
+During #18, `GET /repos/MehdiZare/MehdiZare/actions/runners` was empty while jobs requested `namespace-profile-default`. An empty list while jobs use `ubuntu-latest` is expected: Namespace registers ephemeral runners only when a job requests `namespace-profile-*`.
 
 ## Restore Namespace later
 
-Isolated PR only, after all of the following are true:
+Isolated PR only, after all of the following are true (#24):
 
-1. Namespace.so GitHub App is installed, billed, and the `namespace-profile-default` profile exists.
-2. Runners are registered (`gh api repos/MehdiZare/MehdiZare/actions/runners` is non-empty).
-3. A `workflow_dispatch` of `.github/workflows/ci.yml` is picked up on Namespace (status is not stuck in `queued`).
-4. `runs-on` in `ci.yml` switches back to `namespace-profile-default`, and this file is updated.
+1. Namespace.so GitHub App is installed for this repo, billed, and the `namespace-profile-default` profile exists.
+2. An isolated branch (do not merge yet) sets `runs-on: namespace-profile-default` in `.github/workflows/ci.yml`.
+3. A `workflow_dispatch` of **that branch** leaves `queued` and completes on Namespace. Idle `GET .../actions/runners == 0` is not a health gate; at most inspect runners while those jobs are queued or running.
+4. Merge that PR and update this file in the same change.
 
 ## Out of scope
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: CI
 
+# Runner policy: GitHub-hosted ubuntu-latest (see .github/CI.md).
+# Namespace.so (namespace-profile-default) queued jobs indefinitely (#18 / #21).
+# Do not switch runs-on in a product or dependency PR.
+
 on:
   push:
     branches:
@@ -11,7 +15,7 @@ on:
 jobs:
   quality:
     name: Lint, Typecheck, Test, Build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # GitHub-hosted; see .github/CI.md (#21)
     permissions:
       contents: read
     steps:
@@ -46,7 +50,7 @@ jobs:
 
   security:
     name: Dependency Audit
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # GitHub-hosted; see .github/CI.md (#21)
     permissions:
       contents: read
     steps:
@@ -70,7 +74,7 @@ jobs:
 
   secret-scan:
     name: Secret Scan
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest # GitHub-hosted; see .github/CI.md (#21)
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 
 # Runner policy: GitHub-hosted ubuntu-latest (see .github/CI.md).
-# Namespace.so (namespace-profile-default) queued jobs indefinitely (#18 / #21).
+# Namespace.so queued jobs indefinitely on namespace-profile-default (#18).
 # Do not switch runs-on in a product or dependency PR.
 
 on:
@@ -15,7 +15,7 @@ on:
 jobs:
   quality:
     name: Lint, Typecheck, Test, Build
-    runs-on: ubuntu-latest # GitHub-hosted; see .github/CI.md (#21)
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -50,7 +50,7 @@ jobs:
 
   security:
     name: Dependency Audit
-    runs-on: ubuntu-latest # GitHub-hosted; see .github/CI.md (#21)
+    runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
@@ -74,7 +74,7 @@ jobs:
 
   secret-scan:
     name: Secret Scan
-    runs-on: ubuntu-latest # GitHub-hosted; see .github/CI.md (#21)
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary

Records the runner policy from #18 / #19 instead of switching back to Namespace.so.

- Required jobs stay on GitHub-hosted `ubuntu-latest` (see `.github/CI.md`).
- Restore Namespace only from an isolated PR after a `workflow_dispatch` of a **Namespace-using branch** leaves `queued` and completes (#24).
- Idle `GET .../actions/runners == 0` while jobs use `ubuntu-latest` is expected (Namespace JIT runners), not a health gate.

This is the "document staying on GitHub-hosted" half of #21. Restore continues in #24 (**P2**).

## Test plan

- [x] No `runs-on` change
- [x] `.github/CI.md` matches the current `ubuntu-latest` jobs and the JIT restore procedure
- [ ] CI on this PR stays green on GitHub-hosted runners

Fixes #21