### PR TITLE
ci: run required checks on Ubicloud runners

### DIFF
--- a/.github/CI.md
+++ b/.github/CI.md
@@ -1,24 +1,21 @@
 # CI
 
-Required jobs in `.github/workflows/ci.yml` run on GitHub-hosted `ubuntu-latest`.
+Required jobs in `.github/workflows/ci.yml` run on Ubicloud (`ubicloud-standard-2`).
 The required check names are the job `name:` fields (`Lint, Typecheck, Test, Build`, `Dependency Audit`, `Secret Scan`); a runner-only switch does not need a branch-protection change.
 
-## Why not Namespace.so
+## Why Ubicloud (not Namespace.so, not GitHub-hosted)
 
 PR #11 switched those jobs to `runs-on: namespace-profile-default`. The Namespace GitHub App / billing / profile stopped picking up jobs. Required checks sat `queued` for over an hour and blocked merges to `main` (#18).
 
-The GitHub-hosted workaround landed on `main` via #16 (PR #19 was closed as superseded). That is the runner policy until Namespace is proven again. Do not fold a runner switch into product or dependency PRs.
+GitHub-hosted `ubuntu-latest` was a temporary unblock (#16 / #19, documented in #23). **Runner policy is Ubicloud only.** Do not restore Namespace. Do not fold a runner switch into product or dependency PRs.
 
-During #18, `GET /repos/MehdiZare/MehdiZare/actions/runners` was empty while jobs requested `namespace-profile-default`. An empty list while jobs use `ubuntu-latest` is expected: Namespace registers ephemeral runners only when a job requests `namespace-profile-*`.
+Ubicloud registers **ephemeral** runners when a job requests `ubicloud` / `ubicloud-standard-*`. An idle `GET /repos/MehdiZare/MehdiZare/actions/runners` of `total_count: 0` while jobs still use `ubuntu-latest` is expected and is **not** a health check.
 
-## Restore Namespace later
+Label: `ubicloud-standard-2` is the documented 2 vCPU / 8GB Ubuntu 24.04 equivalent of GitHub-hosted `ubuntu-latest`. Do not use `ubuntu-latest` or `namespace-profile-*`.
 
-Isolated PR only, after all of the following are true (#24):
+## Pickup gate (isolated PR)
 
-1. Namespace.so GitHub App is installed for this repo, billed, and the `namespace-profile-default` profile exists.
-2. An isolated branch (do not merge yet) sets `runs-on: namespace-profile-default` in `.github/workflows/ci.yml`.
-3. A `workflow_dispatch` of **that branch** leaves `queued` and completes on Namespace. Idle `GET .../actions/runners == 0` is not a health gate; at most inspect runners while those jobs are queued or running.
-4. Merge that PR and update this file in the same change.
+Do not merge a `runs-on` change until a `workflow_dispatch` of **that Ubicloud-using branch** leaves `queued` and completes on Ubicloud (#24). Idle `GET .../actions/runners == 0` is not a health gate; at most inspect runners while those jobs are queued or running.
 
 ## Out of scope
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
 name: CI
 
-# Runner policy: GitHub-hosted ubuntu-latest (see .github/CI.md).
+# Runner policy: Ubicloud ubicloud-standard-2 (see .github/CI.md).
 # Namespace.so queued jobs indefinitely on namespace-profile-default (#18).
-# Do not switch runs-on in a product or dependency PR.
+# GitHub-hosted ubuntu-latest was a temporary unblock. Do not switch runs-on
+# in a product or dependency PR.
 
 on:
   push:
@@ -15,7 +16,7 @@ on:
 jobs:
   quality:
     name: Lint, Typecheck, Test, Build
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: read
     steps:
@@ -50,7 +51,7 @@ jobs:
 
   security:
     name: Dependency Audit
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: read
     steps:
@@ -74,7 +75,7 @@ jobs:
 
   secret-scan:
     name: Secret Scan
-    runs-on: ubuntu-latest
+    runs-on: ubicloud-standard-2
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
## Summary

We use **Ubicloud exclusively**. This is the isolated runner switch for #24.

- Required jobs (`Lint, Typecheck, Test, Build`, `Dependency Audit`, `Secret Scan`) use `runs-on: ubicloud-standard-2` (2 vCPU / 8GB / Ubuntu 24.04).
- `.github/CI.md` records Ubicloud-only policy. Namespace.so restore is cancelled (#18). GitHub-hosted `ubuntu-latest` was a temporary unblock (#23).
- Check names are unchanged, so branch protection does not need a change.

## Pickup gate (do not merge yet)

Same lesson as #18: do **not** merge until a `workflow_dispatch` of **this branch** leaves `queued` and completes on Ubicloud. Idle `GET .../actions/runners == 0` is expected while `main` still uses `ubuntu-latest`.

## Out of scope

- Residual Strapi-tree audit findings (#13)
- Weakening `pnpm audit --audit-level high`
- CMS Docker Corepack stage DRY (#25)

Fixes #24