### PR TITLE
chore(cms): share a Corepack pnpm Docker stage

### DIFF
--- a/apps/cms/Dockerfile
+++ b/apps/cms/Dockerfile
@@ -1,6 +1,8 @@
-FROM node:24-alpine AS base
+FROM node:24-alpine AS pnpm
 
-RUN apk add --no-cache build-base gcc autoconf automake libtool zlib-dev libpng-dev vips-dev
+# Corepack is unbundled from Node 25+. Install it here so this stage
+# still works when the CMS image leaves Node 24.
+RUN npm install -g corepack
 
 WORKDIR /app
 
@@ -8,6 +10,10 @@ WORKDIR /app
 COPY package.json ./
 COPY scripts/package-manager.mjs scripts/corepack-prepare-pnpm.mjs ./scripts/
 RUN node scripts/corepack-prepare-pnpm.mjs
+
+FROM pnpm AS base
+
+RUN apk add --no-cache build-base gcc autoconf automake libtool zlib-dev libpng-dev vips-dev
 
 # Remaining root workspace manifests (lockfile + pnpm-workspace).
 COPY pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -31,17 +37,11 @@ COPY packages/shared/ ./packages/shared/
 RUN pnpm --filter cms build
 
 # --- Production stage ---
-FROM node:24-alpine AS production
+FROM pnpm AS production
 
 RUN apk add --no-cache vips-dev
 
-WORKDIR /app
-
-# pnpm from package.json#packageManager (Corepack-safe hex integrity).
-COPY package.json ./
-COPY scripts/package-manager.mjs scripts/corepack-prepare-pnpm.mjs ./scripts/
-RUN node scripts/corepack-prepare-pnpm.mjs
-
+# Remaining root workspace manifests (lockfile + pnpm-workspace).
 COPY pnpm-lock.yaml pnpm-workspace.yaml ./
 
 # Copy cms package.json

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -11,11 +11,11 @@ Strapi 5 backend that powers site content and contact submissions.
 
 ## Docker / Corepack pnpm pin
 
-The CMS Dockerfile does **not** hardcode a pnpm version. Both stages copy `package.json`, `scripts/package-manager.mjs`, and `scripts/corepack-prepare-pnpm.mjs`, then run the prepare script so Corepack activates `package.json#packageManager`.
+The CMS Dockerfile does **not** hardcode a pnpm version. A shared `pnpm` stage copies `package.json`, `scripts/package-manager.mjs`, and `scripts/corepack-prepare-pnpm.mjs`, installs Corepack (`npm install -g corepack`), and runs the prepare script so Corepack activates `package.json#packageManager`. `base` and `production` inherit that stage.
 
 `packageManager` integrity **must be hex SHA-512** (`pnpm@<version>+sha512.<128 hex chars>`), not npm's SRI form (`sha512-...`). Corepack treats `+…` as semver build metadata and compares a hex digest, so base64 hashes are rejected.
 
-Root `pnpm test` runs `node --test 'scripts/*.test.mjs'` and fails CI if a Docker stage stops using the helper or the hash is not hex.
+Root `pnpm test` runs `node --test 'scripts/*.test.mjs'` and fails CI if the shared stage stops using the helper, `base`/`production` stop inheriting it, or the hash is not hex.
 
 To bump pnpm: run `corepack use pnpm@<version>` at the repo root (writes hex integrity) and rebuild the image. Do not edit `pnpm@…` inside `apps/cms/Dockerfile`.
 

--- a/scripts/package-manager.test.mjs
+++ b/scripts/package-manager.test.mjs
@@ -97,16 +97,39 @@ test("corepack-prepare-pnpm --check accepts the repo packageManager field withou
   );
 });
 
-test("each CMS Docker stage copies package.json and runs the Corepack helper", () => {
+test("CMS Docker prepares pnpm in a shared stage from package.json#packageManager", () => {
+  const dockerfile = readFileSync(resolve(root, "apps/cms/Dockerfile"), "utf8");
+  const stages = dockerStages(dockerfile);
+  const pnpm = stages.pnpm;
+  assert.ok(pnpm, "missing stage pnpm");
+  assert.match(pnpm, /^FROM node:24-alpine AS pnpm/m);
+  assert.match(
+    pnpm,
+    /npm install -g corepack/,
+    "shared stage must install Corepack explicitly (unbundled after Node 24)",
+  );
+  assert.match(pnpm, /COPY package\.json \.\//);
+  assert.match(pnpm, /package-manager\.mjs/);
+  assert.match(pnpm, /corepack-prepare-pnpm\.mjs/);
+  assert.match(pnpm, /RUN node scripts\/corepack-prepare-pnpm\.mjs/);
+  assert.doesNotMatch(
+    pnpm,
+    /corepack prepare pnpm@\d/,
+    "pnpm stage must not hardcode corepack prepare pnpm@version",
+  );
+});
+
+test("base and production inherit the shared pnpm stage", () => {
   const dockerfile = readFileSync(resolve(root, "apps/cms/Dockerfile"), "utf8");
   const stages = dockerStages(dockerfile);
   for (const name of ["base", "production"]) {
     const stage = stages[name];
     assert.ok(stage, `missing stage ${name}`);
-    assert.match(stage, /COPY package\.json \.\//);
-    assert.match(stage, /package-manager\.mjs/);
-    assert.match(stage, /corepack-prepare-pnpm\.mjs/);
-    assert.match(stage, /RUN node scripts\/corepack-prepare-pnpm\.mjs/);
+    assert.match(
+      stage,
+      new RegExp(`^FROM pnpm AS ${name}`, "m"),
+      `${name} must inherit FROM pnpm`,
+    );
     assert.doesNotMatch(
       stage,
       /corepack prepare pnpm@\d/,


### PR DESCRIPTION
## Summary

Isolated follow-up for #25. CMS Docker already activated pnpm from `package.json#packageManager` in both stages (#22). This removes the copy-paste and future-proofs Corepack.

- Shared `FROM node:24-alpine AS pnpm` copies `package.json` plus the helper scripts and runs `scripts/corepack-prepare-pnpm.mjs`.
- `npm install -g corepack` in that stage so the image still works after Node 24 (Corepack is unbundled from 25+).
- `base` and `production` inherit `FROM pnpm` instead of repeating the four-line block.
- Tests require the shared stage to copy/run the helper and both consumers to inherit it. Neither may hardcode `corepack prepare pnpm@version`.

Verified:
- `node --test scripts/package-manager.test.mjs` — 12/12 pass
- `docker build --target pnpm -f apps/cms/Dockerfile .` activated `pnpm@11.23.0`; `pnpm --version` is `11.23.0`

## Out of scope
- Changing `packageManager` integrity format
- Building the full CMS image in GitHub Actions (Railway still builds it)
- Residual Strapi audit findings (#13, closed as not planned)

Fixes #25