### PR TITLE
fix(web): stop the about timeline from SSR-hiding its cards

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -27,6 +27,16 @@ html {
   scroll-behavior: smooth;
 }
 
+/* `MotionConfig reducedMotion="user"` only reaches Framer Motion components, so
+   CSS-driven motion needs its own guard. Without this, in-page anchors (the skip
+   link, the blog table of contents, the homepage section links) animate the
+   scroll for users who asked not to see motion. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+}
+
 body {
   background: var(--color-paper);
   color: var(--color-ink);

--- a/apps/web/src/components/about/CareerTimeline.tsx
+++ b/apps/web/src/components/about/CareerTimeline.tsx
@@ -8,6 +8,20 @@ interface CareerTimelineProps {
   experiences: Experience[];
 }
 
+// Reveal by translation only. A zero-opacity initial state gets inlined into
+// the SSR markup, so timeline cards would stay invisible whenever JS is delayed
+// or hydration fails. `MotionProvider` wraps the tree in
+// `MotionConfig reducedMotion="user"`, which turns the transform into an
+// instant jump for reduced-motion clients, so `initial` stays the same on every
+// client and hydration never mismatches.
+const cardVariants = {
+  hidden: { y: 24 },
+  visible: (delay: number) => ({
+    y: 0,
+    transition: { duration: 0.5, ease: "easeOut" as const, delay },
+  }),
+};
+
 export function CareerTimeline({ experiences }: CareerTimelineProps) {
   return (
     <div className="relative">
@@ -21,14 +35,11 @@ export function CareerTimeline({ experiences }: CareerTimelineProps) {
           return (
             <motion.div
               key={experience.id}
-              initial={{ opacity: 0, y: 40 }}
-              whileInView={{ opacity: 1, y: 0 }}
+              variants={cardVariants}
+              custom={index * 0.15}
+              initial="hidden"
+              whileInView="visible"
               viewport={{ once: true, margin: "-50px" }}
-              transition={{
-                duration: 0.5,
-                ease: "easeOut",
-                delay: index * 0.15,
-              }}
               className={cn(
                 "relative flex items-start",
                 "pl-12 md:pl-0",

--- a/apps/web/tests/motion-visibility.test.ts
+++ b/apps/web/tests/motion-visibility.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// Framer Motion inlines the resolved `initial` state as a `style` attribute
+// during SSR. Any initial state that zeroes out opacity, size, or scale is
+// therefore shipped in the HTML, and the content stays hidden until hydration
+// runs. PR #28 removed that pattern from the homepage; these contracts keep it
+// out of the pages #28 did not cover.
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+test("CareerTimeline reveals by transform through named variants", () => {
+  const source = readSource("src/components/about/CareerTimeline.tsx");
+
+  assert.doesNotMatch(source, /opacity:\s*0/);
+  assert.match(source, /hidden:\s*\{/);
+  assert.match(source, /initial="hidden"/);
+  // Always a motion element: swapping to a plain div for some clients is the
+  // hydration mismatch #28 removed from AnimatedSection.
+  assert.match(source, /<motion\.div/);
+  // Likewise, a `useReducedMotion()` branch on `initial` makes the server and
+  // the client disagree. `MotionConfig reducedMotion="user"` handles it instead.
+  assert.doesNotMatch(source, /useReducedMotion/);
+});
+
+test("CSS smooth scroll is disabled for reduced-motion users", () => {
+  const source = readSource("src/app/globals.css");
+
+  assert.match(source, /scroll-behavior:\s*smooth/);
+  assert.match(
+    source,
+    /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{\s*html\s*\{\s*scroll-behavior:\s*auto/,
+    'MotionConfig reducedMotion="user" does not reach CSS scroll-behavior, so ' +
+      "globals.css needs its own prefers-reduced-motion guard."
+  );
+});


### PR DESCRIPTION
Closes #30

## The bug, as production shipped it

`/about` served seven timeline cards as:

```html
<div class="relative flex items-start pl-12 md:pl-0 md:flex-row" style="opacity:0;transform:translateY(40px)">
```

`CareerTimeline` still used the inline `initial={{ opacity: 0, y: 40 }}` pattern that #28 removed from the homepage. Framer Motion resolves `initial` into a `style` attribute during SSR, so the cards were painted invisible and only revealed once `whileInView` fired. With JS delayed or hydration broken, the whole career history stayed blank.

Homepage: 0 `opacity:0`. `/about`: 7. It was the only page left shipping SSR-hidden markup.

## The fix

Named `hidden` / `visible` variants that translate only, matching `AnimatedSection`:

```tsx
const cardVariants = {
  hidden: { y: 24 },
  visible: (delay: number) => ({ y: 0, transition: { duration: 0.5, ease: "easeOut", delay } }),
};
```

Following the three rules #28 established:

- no opacity in `initial`, so content is in the paint from the first byte
- always a `motion.div` — never swapped for a plain `div` on some clients
- no `useReducedMotion()` branch on `initial`. That is precisely the server/client mismatch #28 pulled out of `AnimatedSection`; `MotionConfig reducedMotion="user"` in `MotionProvider` already turns positional transforms into an instant jump.

The per-card stagger is preserved by moving `delay` into the variant via `custom`.

## Also: CSS smooth scroll had no reduced-motion guard

`MotionConfig` only reaches Framer components. `globals.css` set `scroll-behavior: smooth` unconditionally, and the repo had **zero** `prefers-reduced-motion` rules anywhere, so every in-page anchor — the skip link, the blog TOC, the homepage section links — animated the scroll for users who asked not to see motion.

## Verification

Against a real production build, not a source grep:

| | before | after |
|---|---|---|
| `/about` `opacity:0` | 7 | **0** |
| timeline text in HTML | yes | yes |
| remaining inline style | — | `transform:translateY(24px)` |

New `tests/motion-visibility.test.ts` pins the contract: no zero-opacity initial state, named variants, stable motion element, no `useReducedMotion`, and the CSS guard.

## Merge order

#31 (`fix/proof-of-work-ssr-values`) is stacked on this branch and should merge after it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)