### PR TITLE
fix(web): render real scores in ProofOfWork before JS runs

### DIFF
--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -51,7 +51,10 @@ pre {
 
 /* Score bars carry their final width in the markup via --score-bar-width, so
    they read correctly with no JS at all. The keyframe only replays the growth
-   on top of that; `both` leaves the bar at its declared width when it ends. */
+   on top of that. `both` fills backwards so the bar does not flash at its
+   declared width before the animation starts; the declared
+   `width: var(--score-bar-width)` is what the bar rests at after the
+   animation, with or without forwards. */
 .score-bar {
   width: var(--score-bar-width);
   animation: score-bar-grow 0.9s ease-out both;
@@ -59,7 +62,10 @@ pre {
 
 @keyframes score-bar-grow {
   from {
-    width: 0;
+    width: 0%;
+  }
+  to {
+    width: var(--score-bar-width);
   }
 }
 

--- a/apps/web/src/app/globals.css
+++ b/apps/web/src/app/globals.css
@@ -48,3 +48,23 @@ code,
 pre {
   font-family: var(--font-mono), monospace;
 }
+
+/* Score bars carry their final width in the markup via --score-bar-width, so
+   they read correctly with no JS at all. The keyframe only replays the growth
+   on top of that; `both` leaves the bar at its declared width when it ends. */
+.score-bar {
+  width: var(--score-bar-width);
+  animation: score-bar-grow 0.9s ease-out both;
+}
+
+@keyframes score-bar-grow {
+  from {
+    width: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .score-bar {
+    animation: none;
+  }
+}

--- a/apps/web/src/components/home/ProofOfWork.tsx
+++ b/apps/web/src/components/home/ProofOfWork.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { motion } from "framer-motion";
+import type { CSSProperties } from "react";
 import { Label } from "@/components/shared/Label";
 import { CountUp } from "@/components/shared/CountUp";
 
@@ -70,12 +70,16 @@ export function ProofOfWork() {
                     />
                   </div>
                   <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-warm-gray">
-                    <motion.div
-                      className={`h-full rounded-full ${score.color}`}
-                      initial={{ width: 0 }}
-                      whileInView={{ width: `${score.value}%` }}
-                      viewport={{ once: true }}
-                      transition={{ duration: 1, ease: "easeOut", delay: 0.2 }}
+                    {/* The width lives in the markup, not in a motion initial
+                        state, so the bar reads correctly before JS runs. The
+                        growth is a CSS keyframe (see .score-bar). */}
+                    <div
+                      className={`score-bar h-full rounded-full ${score.color}`}
+                      style={
+                        {
+                          "--score-bar-width": `${score.value}%`,
+                        } as CSSProperties
+                      }
                     />
                   </div>
                 </div>

--- a/apps/web/src/components/shared/CountUp.tsx
+++ b/apps/web/src/components/shared/CountUp.tsx
@@ -9,36 +9,59 @@ interface CountUpProps {
 }
 
 export function CountUp({ end, duration = 1.5, className }: CountUpProps) {
-  const [count, setCount] = useState(0);
+  // Start at the final value. Seeding this with 0 meant the server, and every
+  // client without JS, rendered a literal "0" where a real score belongs —
+  // worse than a missing animation, because the number reads as data. The
+  // count-up is a post-hydration enhancement layered on top of the real value.
+  const [count, setCount] = useState(end);
   const ref = useRef<HTMLSpanElement>(null);
-  const hasAnimated = useRef(false);
 
   useEffect(() => {
     const el = ref.current;
     if (!el) return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    let frame = 0;
+    let armed = false;
+    let started = false;
 
     const observer = new IntersectionObserver(
       ([entry]) => {
-        if (entry.isIntersecting && !hasAnimated.current) {
-          hasAnimated.current = true;
-          const start = performance.now();
-          const animate = (now: number) => {
-            const elapsed = (now - start) / 1000;
-            const progress = Math.min(elapsed / duration, 1);
-            const eased = 1 - Math.pow(1 - progress, 3);
-            setCount(Math.round(eased * end));
-            if (progress < 1) {
-              requestAnimationFrame(animate);
-            }
-          };
-          requestAnimationFrame(animate);
+        // The observer reports current state on its first callback. If the
+        // number is already on screen when we hydrate, animating would mean
+        // resetting a value the reader can see back to zero, so leave it be and
+        // only animate numbers that are scrolled to.
+        if (!armed) {
+          armed = true;
+          if (entry.isIntersecting) observer.disconnect();
+          return;
         }
+
+        if (!entry.isIntersecting || started) return;
+        started = true;
+        observer.disconnect();
+
+        const start = performance.now();
+        const step = (now: number) => {
+          const progress = Math.min((now - start) / 1000 / duration, 1);
+          const eased = 1 - Math.pow(1 - progress, 3);
+          setCount(Math.round(eased * end));
+          if (progress < 1) frame = requestAnimationFrame(step);
+        };
+
+        setCount(0);
+        frame = requestAnimationFrame(step);
       },
-      { threshold: 0.3 }
+      // Trigger just below the fold so the reset to zero happens off screen.
+      { threshold: 0, rootMargin: "0px 0px 10% 0px" }
     );
 
     observer.observe(el);
-    return () => observer.disconnect();
+
+    return () => {
+      observer.disconnect();
+      if (frame) cancelAnimationFrame(frame);
+    };
   }, [end, duration]);
 
   return (

--- a/apps/web/src/components/shared/CountUp.tsx
+++ b/apps/web/src/components/shared/CountUp.tsx
@@ -26,7 +26,9 @@ export function CountUp({ end, duration = 1.5, className }: CountUpProps) {
     let started = false;
 
     const observer = new IntersectionObserver(
-      ([entry]) => {
+      (entries) => {
+        const entry = entries[entries.length - 1];
+        if (!entry) return;
         // The observer reports current state on its first callback. If the
         // number is already on screen when we hydrate, animating would mean
         // resetting a value the reader can see back to zero, so leave it be and

--- a/apps/web/tests/motion-visibility.test.ts
+++ b/apps/web/tests/motion-visibility.test.ts
@@ -77,6 +77,17 @@ function readSource(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8");
 }
 
+test("the hiding-initial scanner still sees Navbar's interaction-only panel", () => {
+  const navbar = readSource("src/components/layout/Navbar.tsx");
+  const hits = collectInitialStates(navbar).filter((state) =>
+    HIDING_PROPS.some((prop) => prop.pattern.test(state))
+  );
+  assert.ok(
+    hits.some((state) => /opacity\s*:\s*0/.test(state) && /height\s*:\s*0/.test(state)),
+    "scanner no longer sees Navbar's hiding initial; exemptions are now a blind skip"
+  );
+});
+
 test("no component ships an SSR initial state that hides its content", () => {
   const offenders: string[] = [];
 
@@ -135,15 +146,21 @@ test("ProofOfWork score bars carry their real width in the markup", () => {
   assert.doesNotMatch(source, /initial=\{\{/);
   assert.match(source, /--score-bar-width/);
   assert.match(source, /className=\{`score-bar/);
+  assert.match(source, /"--score-bar-width":\s*`\$\{score\.value\}%`/);
+  assert.match(source, /<CountUp\s+end=\{overallScore\}/);
+  assert.match(source, /<CountUp\s+end=\{score\.value\}/);
+  assert.doesNotMatch(source, /\bwidth\s*:\s*0/);
 });
 
 test("score bar growth is CSS, ends at the declared width, and respects reduced motion", () => {
   const source = readSource("src/app/globals.css");
 
-  // `both` keeps the final keyframe applied, so the bar rests at the width the
-  // markup declared rather than snapping back.
+  // `both` fills backwards so the bar does not flash at full width before the
+  // animation starts. The declared width is what it rests at after.
   assert.match(source, /\.score-bar\s*\{[^}]*width:\s*var\(--score-bar-width\)/);
   assert.match(source, /animation:\s*score-bar-grow[^;]*both/);
+  assert.match(source, /@keyframes\s*score-bar-grow[\s\S]*from\s*\{\s*width:\s*0%/);
+  assert.match(source, /@keyframes\s*score-bar-grow[\s\S]*to\s*\{\s*width:\s*var\(--score-bar-width\)/);
   assert.match(
     source,
     /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{\s*\.score-bar\s*\{\s*animation:\s*none/
@@ -157,6 +174,9 @@ test("CountUp renders its final value on the server", () => {
   assert.doesNotMatch(source, /useState\(0\)/);
   assert.match(source, /useState\(end\)/);
   assert.match(source, /prefers-reduced-motion:\s*reduce/);
+  assert.match(source, /if\s*\(!armed\)/);
+  assert.match(source, /setCount\(0\)/);
+  assert.match(source, /rootMargin:\s*"0px 0px 10% 0px"/);
 });
 
 test("CSS smooth scroll is disabled for reduced-motion users", () => {

--- a/apps/web/tests/motion-visibility.test.ts
+++ b/apps/web/tests/motion-visibility.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
 
 // Framer Motion inlines the resolved `initial` state as a `style` attribute
 // during SSR. Any initial state that zeroes out opacity, size, or scale is
@@ -9,9 +9,111 @@ import { resolve } from "node:path";
 // runs. PR #28 removed that pattern from the homepage; these contracts keep it
 // out of the pages #28 did not cover.
 
+const COMPONENTS_DIR = resolve(process.cwd(), "src/components");
+
+// Components whose hiding initial state is only ever mounted in response to a
+// user interaction. They live inside `AnimatePresence` and render nothing at
+// all during SSR, so there is no content to hide. The `AnimatePresence`
+// assertion below keeps each exemption honest: if one of these ever becomes a
+// plain always-rendered motion element, the exemption stops applying.
+const INTERACTION_ONLY = new Map([
+  ["layout/Navbar.tsx", "mobile menu panel, mounted only while the menu is open"],
+  ["consulting/FAQ.tsx", "accordion answer, mounted only while an item is open"],
+]);
+
+const HIDING_PROPS = [
+  { name: "opacity", pattern: /\bopacity\s*:\s*0(?![.\d])/ },
+  { name: "width", pattern: /\bwidth\s*:\s*(?:0(?![.\d])|["'`]0(?:px|%|rem|em)?["'`])/ },
+  { name: "height", pattern: /\bheight\s*:\s*(?:0(?![.\d])|["'`]0(?:px|%|rem|em)?["'`])/ },
+  { name: "scale", pattern: /\bscale[XY]?\s*:\s*0(?![.\d])/ },
+  { name: "visibility", pattern: /\bvisibility\s*:\s*["']hidden["']/ },
+];
+
+function listTsxFiles(dir: string): string[] {
+  return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) return listTsxFiles(full);
+    return entry.isFile() && full.endsWith(".tsx") ? [full] : [];
+  });
+}
+
+/** Returns the balanced `{...}` slice starting at `openIndex`. */
+function readBalancedBraces(source: string, openIndex: number): string {
+  let depth = 0;
+
+  for (let i = openIndex; i < source.length; i += 1) {
+    const char = source[i];
+    if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return source.slice(openIndex, i + 1);
+    }
+  }
+
+  return source.slice(openIndex);
+}
+
+/**
+ * Every initial state a motion element can resolve during SSR: the inline
+ * `initial={{ ... }}` object, and the `hidden:` branch of a variants object
+ * referenced by `initial="hidden"`.
+ */
+function collectInitialStates(source: string): string[] {
+  const states: string[] = [];
+
+  for (const match of source.matchAll(/initial=\{\{/g)) {
+    states.push(readBalancedBraces(source, match.index + "initial=".length));
+  }
+
+  for (const match of source.matchAll(/\bhidden\s*:\s*\{/g)) {
+    states.push(readBalancedBraces(source, source.indexOf("{", match.index)));
+  }
+
+  return states;
+}
+
 function readSource(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8");
 }
+
+test("no component ships an SSR initial state that hides its content", () => {
+  const offenders: string[] = [];
+
+  for (const file of listTsxFiles(COMPONENTS_DIR)) {
+    const key = relative(COMPONENTS_DIR, file);
+    if (INTERACTION_ONLY.has(key)) continue;
+
+    const source = readFileSync(file, "utf8");
+    for (const state of collectInitialStates(source)) {
+      for (const prop of HIDING_PROPS) {
+        if (prop.pattern.test(state)) {
+          offenders.push(`${key}: ${prop.name} in ${state.replace(/\s+/g, " ")}`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    "Motion initial states must not hide content during SSR. Animate a " +
+      "transform instead, or render the final value and enhance after mount:\n  " +
+      offenders.join("\n  ")
+  );
+});
+
+test("interaction-only exemptions really are mounted behind AnimatePresence", () => {
+  for (const [key, reason] of INTERACTION_ONLY) {
+    const source = readFileSync(join(COMPONENTS_DIR, key), "utf8");
+    assert.match(
+      source,
+      /<AnimatePresence/,
+      `${key} is exempt because of its ${reason}, but it no longer uses ` +
+        "AnimatePresence, so its initial state now ships in the SSR markup."
+    );
+  }
+});
 
 test("CareerTimeline reveals by transform through named variants", () => {
   const source = readSource("src/components/about/CareerTimeline.tsx");
@@ -25,6 +127,36 @@ test("CareerTimeline reveals by transform through named variants", () => {
   // Likewise, a `useReducedMotion()` branch on `initial` makes the server and
   // the client disagree. `MotionConfig reducedMotion="user"` handles it instead.
   assert.doesNotMatch(source, /useReducedMotion/);
+});
+
+test("ProofOfWork score bars carry their real width in the markup", () => {
+  const source = readSource("src/components/home/ProofOfWork.tsx");
+
+  assert.doesNotMatch(source, /initial=\{\{/);
+  assert.match(source, /--score-bar-width/);
+  assert.match(source, /className=\{`score-bar/);
+});
+
+test("score bar growth is CSS, ends at the declared width, and respects reduced motion", () => {
+  const source = readSource("src/app/globals.css");
+
+  // `both` keeps the final keyframe applied, so the bar rests at the width the
+  // markup declared rather than snapping back.
+  assert.match(source, /\.score-bar\s*\{[^}]*width:\s*var\(--score-bar-width\)/);
+  assert.match(source, /animation:\s*score-bar-grow[^;]*both/);
+  assert.match(
+    source,
+    /@media\s*\(prefers-reduced-motion:\s*reduce\)\s*\{\s*\.score-bar\s*\{\s*animation:\s*none/
+  );
+});
+
+test("CountUp renders its final value on the server", () => {
+  const source = readSource("src/components/shared/CountUp.tsx");
+
+  // useState(0) is what made every score render as a literal "0" without JS.
+  assert.doesNotMatch(source, /useState\(0\)/);
+  assert.match(source, /useState\(end\)/);
+  assert.match(source, /prefers-reduced-motion:\s*reduce/);
 });
 
 test("CSS smooth scroll is disabled for reduced-motion users", () => {


### PR DESCRIPTION
Closes #31

> Stacked on #32 — base is `fix/about-timeline-ssr-visibility`. Review just the second commit; merge after #32.

## Scope note

`ProofOfWork` is behind `ENABLE_BINA_PRINT`, which is off in production, so the section does not render on the live site today. The bug is real but **latent** — it becomes visible the moment Bina Print launches. Everything below was verified with the flag forced on.

## The bug

```tsx
<motion.div initial={{ width: 0 }} whileInView={{ width: `${score.value}%` }} />
```

Framer Motion inlines that as `width:0px` during SSR, so all four score bars shipped collapsed.

`CountUp` was the worse half, and it wasn't in the issue:

```tsx
const [count, setCount] = useState(0);   // ← SSR renders "0"
```

The overall score and every sub-score rendered a literal **`0`**. A missing animation reads as a missing animation; a wrong number reads as data. Without JS the card claimed this stock scored 0 across the board.

## The fix

**Bars** carry their width in the markup and grow in CSS:

```tsx
<div className={`score-bar ...`} style={{ "--score-bar-width": `${score.value}%` } as CSSProperties} />
```
```css
.score-bar { width: var(--score-bar-width); animation: score-bar-grow .9s ease-out both; }
@keyframes score-bar-grow { from { width: 0 } }
@media (prefers-reduced-motion: reduce) { .score-bar { animation: none } }
```

`both` keeps the final keyframe applied, so the bar rests at the width the markup declared. No JS is involved at any point.

**CountUp** seeds state with `end` and only counts up after hydration — and only for numbers scrolled to from off screen. Animating one that is already on screen would reset a value the reader can see, so the observer's first callback disarms in that case. It also respects `prefers-reduced-motion` and cancels its rAF on unmount.

### Known tradeoff

The bar keyframe fires on load rather than on scroll. `ProofOfWork` sits below the fold, so in practice the growth finishes before it is reached — the value on screen is always correct, which is what the issue was about, but the flourish is effectively lost. Making it scroll-driven needs `animation-timeline: view()`; filed separately rather than smuggled in here.

## Verification

Production build, `ENABLE_BINA_PRINT=true`:

| | before | after |
|---|---|---|
| bar widths in HTML | `width:0px` ×4 | `--score-bar-width: 90% / 86% / 83% / 81%` |
| numbers in HTML | `0` ×5 | `88, 90, 86, 83, 81` |

Built CSS confirmed to contain `.score-bar`, `@keyframes score-bar-grow{0%{width:0}}` and both `prefers-reduced-motion` blocks.

## A guard for the whole bug class

This is the third instance of the same mistake (#28 homepage, #30 about, #31 here), each caught only after it shipped. Rather than add a fourth file to a hand-maintained list, `motion-visibility.test.ts` now scans **every** component for motion initial states that hide content — opacity, width, height, scale, visibility — across both inline `initial={{...}}` objects and `hidden:` variants.

The `Navbar` mobile menu and `FAQ` accordion are exempt, because they mount inside `AnimatePresence` and are absent from SSR entirely. The exemption is not taken on trust: a second test asserts each exempt file still uses `AnimatePresence`, so it stops applying the moment one becomes a plain always-rendered element.

The scanner is not decorative — it found this exact bug when introduced on the #30 branch, which is why it lands here rather than there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)