### PR TITLE
fix(web): narrow the PostHog CSP and collect violation reports

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -14,12 +14,13 @@ ENABLE_BINA_PRINT=false
 # Optional: comma-separated hostnames for remote images
 # Example: cdn.example.com,images.ctfassets.net
 NEXT_PUBLIC_ALLOWED_IMAGE_HOSTS=
-# Optional: override Beehiiv embed origin
-NEXT_PUBLIC_BEEHIIV_EMBED_URL=https://embeds.beehiiv.com
 
 # PostHog analytics (optional)
 NEXT_PUBLIC_POSTHOG_KEY=
-# Reverse proxy for PostHog (bypasses ad blockers)
+# First-party reverse proxy for PostHog. Serves the SDK, per-project config,
+# recorder/survey bundles and ingest, so it is the only PostHog origin the
+# browser contacts and the only one the CSP has to allow. Pointing this at
+# us.i.posthog.com instead makes analytics ad-blockable and widens the CSP.
 NEXT_PUBLIC_POSTHOG_HOST=https://t.mehdi-zare.com
 
 # PostHog dashboard sync script (optional, not used by runtime app)

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -31,7 +31,6 @@ Next.js App Router frontend for the public portfolio.
 - `POSTHOG_ENVIRONMENT_ID` (optional, defaults to `@current`)
 - `POSTHOG_APP_HOST` (optional, defaults to `https://us.posthog.com`)
 - `POSTHOG_DRY_RUN` (optional, `true` to preview API actions)
-- `NEXT_PUBLIC_BEEHIIV_EMBED_URL` (defaults to `https://embeds.beehiiv.com`)
 
 ## CMS Cache Invalidation
 

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,30 +1,17 @@
 import path from "node:path";
 import type { NextConfig } from "next";
+import { buildCsp, buildReportingEndpoints } from "./src/lib/csp";
 
 const DEFAULT_SITE_URL = "https://www.mehdi-zare.com";
 const DEFAULT_STRAPI_URL = "http://localhost:1337";
 const DEFAULT_POSTHOG_HOST = "https://t.mehdi-zare.com";
-const DEFAULT_BEEHIIV_EMBED_ORIGIN = "https://embeds.beehiiv.com";
-const DEFAULT_CAL_ORIGIN = "https://cal.com";
-const DEFAULT_CAL_APP_ORIGIN = "https://app.cal.com";
+const CSP_REPORT_PATH = "/api/csp-report";
 
 function parseOrigin(value: string | undefined, fallback: string): URL {
   try {
     return new URL(value?.trim() || fallback);
   } catch {
     return new URL(fallback);
-  }
-}
-
-function parseOptionalOrigin(value: string | undefined): URL | null {
-  if (!value?.trim()) {
-    return null;
-  }
-
-  try {
-    return new URL(value);
-  } catch {
-    return null;
   }
 }
 
@@ -42,11 +29,6 @@ function parseHostList(value: string | undefined): string[] {
 const siteUrl = parseOrigin(process.env.NEXT_PUBLIC_SITE_URL, DEFAULT_SITE_URL);
 const strapiUrl = parseOrigin(process.env.STRAPI_URL, DEFAULT_STRAPI_URL);
 const posthogUrl = parseOrigin(process.env.NEXT_PUBLIC_POSTHOG_HOST, DEFAULT_POSTHOG_HOST);
-const beehiivUrl =
-  parseOptionalOrigin(process.env.NEXT_PUBLIC_BEEHIIV_EMBED_URL) ??
-  new URL(DEFAULT_BEEHIIV_EMBED_ORIGIN);
-const calUrl = new URL(DEFAULT_CAL_ORIGIN);
-const calAppUrl = new URL(DEFAULT_CAL_APP_ORIGIN);
 
 const additionalImageHosts = parseHostList(process.env.NEXT_PUBLIC_ALLOWED_IMAGE_HOSTS);
 const imageHosts = Array.from(
@@ -65,56 +47,28 @@ const imageRemotePatterns = imageHosts.flatMap((hostname) => {
   return [{ protocol: "https" as const, hostname }];
 });
 
-// PostHog loads ingest + assets from nested subdomains (us.i / us-assets.i).
-// `*.posthog.com` does not cover those, so both wildcards are required.
-// https://posthog.com/docs/advanced/content-security-policy
-const posthogCspOrigins = [
-  posthogUrl.origin,
-  "https://*.posthog.com",
-  "https://*.i.posthog.com",
-];
-
-const cspConnectOrigins = Array.from(
-  new Set([
-    siteUrl.origin,
-    calUrl.origin,
-    calAppUrl.origin,
-    ...posthogCspOrigins,
-  ])
-);
-const cspFrameOrigins = Array.from(
-  new Set([beehiivUrl.origin, calUrl.origin, calAppUrl.origin])
-);
-const cspImageOrigins = Array.from(
-  new Set([siteUrl.origin, ...posthogCspOrigins])
+// Keep img-src in step with what next/image is configured to fetch, so adding a
+// remote image host cannot silently produce CSP-blocked images.
+const cspImageOrigins = imageRemotePatterns.map(
+  ({ protocol, hostname }) => `${protocol}://${hostname}`
 );
 
-const cspDirectives = [
-  "default-src 'self'",
-  "base-uri 'self'",
-  "frame-ancestors 'none'",
-  "form-action 'self'",
-  "object-src 'none'",
-  "script-src 'self' 'unsafe-inline' " + cspConnectOrigins.join(" "),
-  "style-src 'self' 'unsafe-inline'",
-  "img-src 'self' data: blob: " + cspImageOrigins.join(" "),
-  "font-src 'self' data:",
-  "connect-src 'self' " + cspConnectOrigins.join(" "),
-  "media-src 'self' data: blob: " + cspImageOrigins.join(" "),
-  "frame-src 'self' " + cspFrameOrigins.join(" "),
-  "worker-src 'self' blob: data:",
-];
-
-if (process.env.NODE_ENV === "production") {
-  cspDirectives.push("upgrade-insecure-requests");
-}
-
-const contentSecurityPolicy = cspDirectives.join("; ");
+const contentSecurityPolicy = buildCsp({
+  siteOrigin: siteUrl.origin,
+  posthogOrigin: posthogUrl.origin,
+  imageOrigins: cspImageOrigins,
+  isProduction: process.env.NODE_ENV === "production",
+  reportPath: CSP_REPORT_PATH,
+});
 
 const securityHeaders = [
   {
     key: "Content-Security-Policy",
     value: contentSecurityPolicy,
+  },
+  {
+    key: "Reporting-Endpoints",
+    value: buildReportingEndpoints(CSP_REPORT_PATH),
   },
   {
     key: "Referrer-Policy",

--- a/apps/web/src/app/api/csp-report/route.ts
+++ b/apps/web/src/app/api/csp-report/route.ts
@@ -74,7 +74,7 @@ function asNumber(value: unknown): number | null {
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+  return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
 function toViolation(body: Record<string, unknown>, userAgent: string): Violation {

--- a/apps/web/src/app/api/csp-report/route.ts
+++ b/apps/web/src/app/api/csp-report/route.ts
@@ -1,0 +1,178 @@
+import { NextResponse } from "next/server";
+import { publicEnv } from "@/lib/public-env";
+
+/**
+ * Collects Content-Security-Policy violation reports and forwards them to
+ * PostHog.
+ *
+ * Without this the policy fails silently: a directive that is too tight simply
+ * stops analytics, or an embed, from loading and nothing anywhere records it.
+ */
+
+export const dynamic = "force-dynamic";
+
+interface Violation {
+  documentUri: string;
+  violatedDirective: string;
+  effectiveDirective: string;
+  blockedUri: string;
+  disposition: string;
+  statusCode: number | null;
+  sourceFile: string;
+  lineNumber: number | null;
+  userAgent: string;
+}
+
+/**
+ * Violations we cannot act on. Browser extensions inject scripts and stylesheets
+ * into every page and generate a constant stream of reports that say nothing
+ * about this site's policy.
+ */
+const IGNORED_BLOCKED_URI_PREFIXES = [
+  "chrome-extension:",
+  "moz-extension:",
+  "safari-extension:",
+  "safari-web-extension:",
+  "webkit-masked-url:",
+  "about:",
+];
+
+const WINDOW_MS = 60_000;
+const MAX_REPORTS_PER_WINDOW = 60;
+
+// Per-instance budget. Fluid Compute reuses instances across requests, so this
+// meaningfully caps a report storm without any shared state.
+let windowStartedAt = 0;
+let reportsInWindow = 0;
+let seenInWindow = new Set<string>();
+
+function claimBudget(key: string): boolean {
+  const now = Date.now();
+
+  if (now - windowStartedAt > WINDOW_MS) {
+    windowStartedAt = now;
+    reportsInWindow = 0;
+    seenInWindow = new Set();
+  }
+
+  // One report per distinct violation per window: a blocked resource on a busy
+  // page produces the same report from every visitor.
+  if (seenInWindow.has(key)) return false;
+  if (reportsInWindow >= MAX_REPORTS_PER_WINDOW) return false;
+
+  seenInWindow.add(key);
+  reportsInWindow += 1;
+  return true;
+}
+
+function asString(value: unknown): string {
+  return typeof value === "string" ? value : "";
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function toViolation(body: Record<string, unknown>, userAgent: string): Violation {
+  const violated = asString(body["violated-directive"]) || asString(body.violatedDirective);
+  const effective = asString(body["effective-directive"]) || asString(body.effectiveDirective);
+
+  return {
+    documentUri: asString(body["document-uri"]) || asString(body.documentURL),
+    violatedDirective: violated || effective,
+    effectiveDirective: effective || violated.split(" ")[0] || "",
+    blockedUri: asString(body["blocked-uri"]) || asString(body.blockedURL),
+    disposition: asString(body.disposition) || "enforce",
+    statusCode: asNumber(body["status-code"]) ?? asNumber(body.statusCode),
+    sourceFile: asString(body["source-file"]) || asString(body.sourceFile),
+    lineNumber: asNumber(body["line-number"]) ?? asNumber(body.lineNumber),
+    userAgent,
+  };
+}
+
+/**
+ * Normalises both report shapes: the legacy `application/csp-report` body and
+ * the Reporting API's `application/reports+json` array.
+ */
+function parseReports(payload: unknown, userAgent: string): Violation[] {
+  if (Array.isArray(payload)) {
+    return payload.flatMap((report) => {
+      if (!isRecord(report) || report.type !== "csp-violation") return [];
+      return isRecord(report.body) ? [toViolation(report.body, userAgent)] : [];
+    });
+  }
+
+  if (isRecord(payload) && isRecord(payload["csp-report"])) {
+    return [toViolation(payload["csp-report"], userAgent)];
+  }
+
+  return [];
+}
+
+function isActionable(violation: Violation): boolean {
+  if (!violation.effectiveDirective) return false;
+  const blocked = violation.blockedUri.toLowerCase();
+  return !IGNORED_BLOCKED_URI_PREFIXES.some((prefix) => blocked.startsWith(prefix));
+}
+
+async function capture(violation: Violation): Promise<void> {
+  if (!publicEnv.posthogKey) return;
+
+  await fetch(`${publicEnv.posthogHost}/i/v0/e/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      api_key: publicEnv.posthogKey,
+      event: "csp_violation",
+      // Violations are not attributable to a person, and should not create one.
+      distinct_id: `csp-${violation.effectiveDirective}`,
+      properties: {
+        $process_person_profile: false,
+        directive: violation.effectiveDirective,
+        violated_directive: violation.violatedDirective,
+        blocked_uri: violation.blockedUri,
+        document_uri: violation.documentUri,
+        source_file: violation.sourceFile,
+        line_number: violation.lineNumber,
+        disposition: violation.disposition,
+        status_code: violation.statusCode,
+        $raw_user_agent: violation.userAgent,
+      },
+    }),
+  });
+}
+
+export async function POST(request: Request): Promise<NextResponse> {
+  let payload: unknown;
+
+  try {
+    payload = await request.json();
+  } catch {
+    return new NextResponse(null, { status: 204 });
+  }
+
+  const userAgent = request.headers.get("user-agent") ?? "";
+  const violations = parseReports(payload, userAgent).filter(isActionable);
+
+  for (const violation of violations) {
+    if (!claimBudget(`${violation.effectiveDirective}|${violation.blockedUri}`)) {
+      continue;
+    }
+
+    if (process.env.NODE_ENV !== "production") {
+      console.warn(
+        `CSP violation: ${violation.effectiveDirective} blocked ${violation.blockedUri}`
+      );
+      continue;
+    }
+
+    // A failed report must never surface as a 500 to the browser.
+    await capture(violation).catch(() => {});
+  }
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -1,0 +1,116 @@
+/**
+ * Content-Security-Policy for the web app.
+ *
+ * This lives in its own module, rather than inline in `next.config.ts`, so the
+ * joined header can be asserted directly in tests instead of grepped out of the
+ * config source.
+ */
+
+export interface CspOptions {
+  /** Canonical site origin, from NEXT_PUBLIC_SITE_URL. */
+  siteOrigin: string;
+  /**
+   * Origin that serves PostHog. In production this is the first-party reverse
+   * proxy, which serves the SDK, the per-project config, the recorder/survey
+   * bundles and the ingest endpoints, so it is the only PostHog origin the
+   * browser ever contacts.
+   */
+  posthogOrigin: string;
+  /** Origins `next/image` may load from. Mirrors `images.remotePatterns`. */
+  imageOrigins?: string[];
+  isProduction?: boolean;
+  /** Same-origin path that collects violation reports. */
+  reportPath?: string;
+}
+
+/**
+ * Cal.com's embed injects a script from app.cal.com and then opens an iframe,
+ * so these origins are load-bearing on script-src, connect-src and frame-src.
+ */
+export const CAL_ORIGINS = ["https://cal.com", "https://app.cal.com"] as const;
+
+/** Name tying the `report-to` directive to the `Reporting-Endpoints` header. */
+export const CSP_REPORT_ENDPOINT_NAME = "csp-endpoint";
+
+type Source = string | null | undefined;
+
+function sources(...values: (Source | readonly Source[])[]): string {
+  return Array.from(
+    new Set(values.flat().filter((value): value is string => Boolean(value)))
+  ).join(" ");
+}
+
+/**
+ * The companion origin PostHog serves assets from, or null when the configured
+ * origin serves everything itself.
+ *
+ * posthog-js splits its endpoints by region. Point `api_host` at a
+ * PostHog-hosted origin and it still fetches the remote config and the
+ * recorder, survey, dead-click and web-vitals bundles from a sibling
+ * `<region>-assets.i.posthog.com`, so allowing only `api_host` blocks them. A
+ * first-party reverse proxy serves both, so it needs no companion and the
+ * policy stays a single origin.
+ *
+ * Deriving this from the configured origin, rather than assuming one
+ * deployment, keeps the header correct for whatever NEXT_PUBLIC_POSTHOG_HOST
+ * happens to be set to.
+ */
+export function posthogAssetsOrigin(posthogOrigin: string): string | null {
+  const match = /^https:\/\/(?:app|(us|eu)(?:-assets)?)(?:\.i)?\.posthog\.com$/.exec(
+    posthogOrigin
+  );
+
+  if (!match) return null;
+
+  return `https://${match[1] ?? "us"}-assets.i.posthog.com`;
+}
+
+export function buildCsp({
+  siteOrigin,
+  posthogOrigin,
+  imageOrigins = [],
+  isProduction = false,
+  reportPath,
+}: CspOptions): string {
+  const posthogOrigins = [posthogOrigin, posthogAssetsOrigin(posthogOrigin)];
+
+  const directives = [
+    "default-src 'self'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    "object-src 'none'",
+    // 'unsafe-inline' is required by Next's inline bootstrap script. It is the
+    // weakest part of this policy; removing it needs a nonce threaded through
+    // the proxy layer, which is a separate change.
+    `script-src ${sources("'self'", "'unsafe-inline'", siteOrigin, CAL_ORIGINS, posthogOrigins)}`,
+    "style-src 'self' 'unsafe-inline'",
+    `img-src ${sources("'self'", "data:", "blob:", siteOrigin, imageOrigins, posthogOrigin)}`,
+    "font-src 'self' data:",
+    `connect-src ${sources("'self'", siteOrigin, CAL_ORIGINS, posthogOrigins)}`,
+    // No PostHog here: nothing it loads is audio or video.
+    "media-src 'self' data: blob:",
+    `frame-src ${sources("'self'", CAL_ORIGINS)}`,
+    // PostHog's session recorder compresses payloads in a worker built from a
+    // blob URL.
+    "worker-src 'self' blob:",
+  ];
+
+  if (reportPath) {
+    // report-uri is deprecated but is still the only mechanism Firefox and
+    // Safari implement; report-to is the Reporting API successor Chrome uses.
+    directives.push(`report-uri ${reportPath}`);
+    directives.push(`report-to ${CSP_REPORT_ENDPOINT_NAME}`);
+  }
+
+  if (isProduction) {
+    directives.push("upgrade-insecure-requests");
+  }
+
+  return directives.join("; ");
+}
+
+/** Value for the `Reporting-Endpoints` header that `report-to` refers to. */
+export function buildReportingEndpoints(reportPath: string): string {
+  return `${CSP_REPORT_ENDPOINT_NAME}="${reportPath}"`;
+}

--- a/apps/web/src/lib/csp.ts
+++ b/apps/web/src/lib/csp.ts
@@ -35,9 +35,15 @@ export const CSP_REPORT_ENDPOINT_NAME = "csp-endpoint";
 type Source = string | null | undefined;
 
 function sources(...values: (Source | readonly Source[])[]): string {
-  return Array.from(
+  const tokens = Array.from(
     new Set(values.flat().filter((value): value is string => Boolean(value)))
-  ).join(" ");
+  );
+  for (const token of tokens) {
+    if (token.includes("*") || token.includes(";")) {
+      throw new Error(`Illegal CSP source: ${token}`);
+    }
+  }
+  return tokens.join(" ");
 }
 
 /**

--- a/apps/web/tests/csp-contract.test.ts
+++ b/apps/web/tests/csp-contract.test.ts
@@ -1,0 +1,162 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+const { buildCsp, buildReportingEndpoints, posthogAssetsOrigin, CAL_ORIGINS } =
+  await import("../src/lib/csp.ts");
+
+const SITE = "https://www.mehdi-zare.com";
+const PROXY = "https://t.mehdi-zare.com";
+
+function directives(policy: string): Map<string, string[]> {
+  return new Map(
+    policy.split("; ").map((directive) => {
+      const [name, ...sources] = directive.split(" ");
+      return [name, sources];
+    })
+  );
+}
+
+function policy(overrides = {}) {
+  return buildCsp({ siteOrigin: SITE, posthogOrigin: PROXY, ...overrides });
+}
+
+test("PostHog is allowed only on the directives it actually uses", () => {
+  const parsed = directives(policy());
+
+  // Observed on a production page load: the SDK and the recorder/survey/
+  // web-vitals bundles are scripts, config and ingest are fetches.
+  assert.ok(parsed.get("script-src")?.includes(PROXY));
+  assert.ok(parsed.get("connect-src")?.includes(PROXY));
+
+  // Nothing PostHog loads is audio or video.
+  assert.ok(!parsed.get("media-src")?.includes(PROXY));
+  assert.ok(!parsed.get("frame-src")?.includes(PROXY));
+});
+
+test("no wildcard host ever reaches the policy", () => {
+  // A host wildcard is a plain suffix match, so `https://*.posthog.com` would
+  // silently re-admit every PostHog subdomain that routing the traffic through
+  // the first-party proxy was meant to remove.
+  assert.doesNotMatch(policy(), /\*/);
+});
+
+test("only the configured PostHog origin is allowed", () => {
+  const parsed = directives(policy());
+
+  for (const name of ["script-src", "connect-src", "img-src"]) {
+    const sources = parsed.get(name) ?? [];
+    assert.deepEqual(
+      sources.filter((source) => source.includes("posthog")),
+      [],
+      `${name} should reach PostHog through the proxy, not a posthog.com origin`
+    );
+  }
+});
+
+test("a PostHog-hosted origin also allows the assets origin it loads from", () => {
+  // posthog-js resolves /array/<token>/config.js and the recorder, survey,
+  // dead-click and web-vitals bundles against a sibling assets host, not
+  // against api_host. Allowing only api_host blocks all of them.
+  const parsed = directives(policy({ posthogOrigin: "https://us.i.posthog.com" }));
+
+  for (const name of ["script-src", "connect-src"]) {
+    assert.ok(parsed.get(name)?.includes("https://us.i.posthog.com"), name);
+    assert.ok(parsed.get(name)?.includes("https://us-assets.i.posthog.com"), name);
+  }
+
+  assert.ok(!policy({ posthogOrigin: "https://us.i.posthog.com" }).includes(PROXY));
+});
+
+test("the assets origin is derived per region, and not at all for a proxy", () => {
+  assert.equal(posthogAssetsOrigin("https://us.i.posthog.com"), "https://us-assets.i.posthog.com");
+  assert.equal(posthogAssetsOrigin("https://eu.i.posthog.com"), "https://eu-assets.i.posthog.com");
+  assert.equal(posthogAssetsOrigin("https://app.posthog.com"), "https://us-assets.i.posthog.com");
+  assert.equal(posthogAssetsOrigin("https://us.posthog.com"), "https://us-assets.i.posthog.com");
+  // A first-party proxy serves assets and ingest itself.
+  assert.equal(posthogAssetsOrigin(PROXY), null);
+  // Not a PostHog origin at all, and not one a lookalike domain can claim.
+  assert.equal(posthogAssetsOrigin("https://us.i.posthog.com.evil.test"), null);
+  assert.equal(posthogAssetsOrigin("https://evil-posthog.com"), null);
+});
+
+test("routing through the proxy keeps the policy to a single PostHog origin", () => {
+  const parsed = directives(policy());
+
+  for (const name of ["script-src", "connect-src", "img-src"]) {
+    const posthogSources = (parsed.get(name) ?? []).filter((source) =>
+      source.includes("posthog") || source === PROXY
+    );
+    assert.deepEqual(posthogSources, [PROXY], name);
+  }
+});
+
+test("Cal.com keeps the origins its embed needs", () => {
+  const parsed = directives(policy());
+
+  // Pin the constant itself: iterating an empty CAL_ORIGINS would pass.
+  assert.deepEqual([...CAL_ORIGINS], ["https://cal.com", "https://app.cal.com"]);
+
+  // getCalApi() injects a script from app.cal.com and then opens an iframe.
+  for (const origin of CAL_ORIGINS) {
+    assert.ok(parsed.get("script-src")?.includes(origin), `script-src ${origin}`);
+    assert.ok(parsed.get("connect-src")?.includes(origin), `connect-src ${origin}`);
+    assert.ok(parsed.get("frame-src")?.includes(origin), `frame-src ${origin}`);
+  }
+});
+
+test("img-src covers every origin next/image is configured to fetch", () => {
+  const imageOrigins = ["https://cdn.example.com", "https://cms.example.com"];
+  const parsed = directives(policy({ imageOrigins }));
+
+  for (const origin of imageOrigins) {
+    assert.ok(parsed.get("img-src")?.includes(origin));
+  }
+});
+
+test("the baseline hardening directives stay put", () => {
+  const parsed = directives(policy());
+
+  assert.deepEqual(parsed.get("default-src"), ["'self'"]);
+  assert.deepEqual(parsed.get("frame-ancestors"), ["'none'"]);
+  assert.deepEqual(parsed.get("object-src"), ["'none'"]);
+  assert.deepEqual(parsed.get("base-uri"), ["'self'"]);
+  assert.deepEqual(parsed.get("form-action"), ["'self'"]);
+  // PostHog's session recorder builds its compression worker from a blob URL.
+  assert.deepEqual(parsed.get("worker-src"), ["'self'", "blob:"]);
+});
+
+test("violations are reported through both the legacy and Reporting API paths", () => {
+  const parsed = directives(policy({ reportPath: "/api/csp-report" }));
+
+  // Firefox and Safari only implement report-uri; Chrome only report-to.
+  assert.deepEqual(parsed.get("report-uri"), ["/api/csp-report"]);
+  assert.deepEqual(parsed.get("report-to"), ["csp-endpoint"]);
+  assert.equal(
+    buildReportingEndpoints("/api/csp-report"),
+    'csp-endpoint="/api/csp-report"'
+  );
+});
+
+test("reporting directives are omitted when no collector is configured", () => {
+  const bare = policy();
+
+  assert.ok(!bare.includes("report-uri"));
+  assert.ok(!bare.includes("report-to"));
+});
+
+test("upgrade-insecure-requests is production only", () => {
+  assert.ok(policy({ isProduction: true }).includes("upgrade-insecure-requests"));
+  assert.ok(!policy({ isProduction: false }).includes("upgrade-insecure-requests"));
+});
+
+test("the joined header is a single well-formed policy", () => {
+  const header = policy({ reportPath: "/api/csp-report", isProduction: true });
+
+  assert.ok(!header.includes(";;"));
+  assert.ok(!header.includes("  "));
+  assert.ok(!header.endsWith(";"));
+  for (const [name, sources] of directives(header)) {
+    assert.match(name, /^[a-z-]+$/);
+    assert.equal(new Set(sources).size, sources.length, `${name} repeats a source`);
+  }
+});

--- a/apps/web/tests/csp-contract.test.ts
+++ b/apps/web/tests/csp-contract.test.ts
@@ -1,5 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 
 const { buildCsp, buildReportingEndpoints, posthogAssetsOrigin, CAL_ORIGINS } =
   await import("../src/lib/csp.ts");
@@ -65,6 +67,16 @@ test("a PostHog-hosted origin also allows the assets origin it loads from", () =
   }
 
   assert.ok(!policy({ posthogOrigin: "https://us.i.posthog.com" }).includes(PROXY));
+
+  const hosted = "https://us.i.posthog.com";
+  const hostedAssets = "https://us-assets.i.posthog.com";
+  const hostedPolicy = directives(policy({ posthogOrigin: hosted }));
+  assert.ok(hostedPolicy.get("img-src")?.includes(hosted));
+  assert.ok(!hostedPolicy.get("img-src")?.includes(hostedAssets));
+  assert.ok(!hostedPolicy.get("media-src")?.includes(hosted));
+  assert.ok(!hostedPolicy.get("media-src")?.includes(hostedAssets));
+  assert.ok(!hostedPolicy.get("frame-src")?.includes(hosted));
+  assert.doesNotMatch(policy({ posthogOrigin: hosted }), /\*/);
 });
 
 test("the assets origin is derived per region, and not at all for a proxy", () => {
@@ -123,6 +135,10 @@ test("the baseline hardening directives stay put", () => {
   assert.deepEqual(parsed.get("form-action"), ["'self'"]);
   // PostHog's session recorder builds its compression worker from a blob URL.
   assert.deepEqual(parsed.get("worker-src"), ["'self'", "blob:"]);
+  // Next's inline bootstrap still needs these; removing them blanks production.
+  assert.ok(parsed.get("script-src")?.includes("'unsafe-inline'"));
+  assert.ok(parsed.get("style-src")?.includes("'unsafe-inline'"));
+  assert.deepEqual(parsed.get("media-src"), ["'self'", "data:", "blob:"]);
 });
 
 test("violations are reported through both the legacy and Reporting API paths", () => {
@@ -147,6 +163,23 @@ test("reporting directives are omitted when no collector is configured", () => {
 test("upgrade-insecure-requests is production only", () => {
   assert.ok(policy({ isProduction: true }).includes("upgrade-insecure-requests"));
   assert.ok(!policy({ isProduction: false }).includes("upgrade-insecure-requests"));
+});
+
+test("next.config.ts ships buildCsp with image origins and reporting", () => {
+  const source = readFileSync(resolve(process.cwd(), "next.config.ts"), "utf8");
+  assert.match(source, /from "\.\/src\/lib\/csp"/);
+  assert.match(source, /buildCsp\(/);
+  assert.match(source, /imageOrigins:\s*cspImageOrigins/);
+  assert.match(source, /reportPath:\s*CSP_REPORT_PATH/);
+  assert.match(source, /buildReportingEndpoints\(CSP_REPORT_PATH\)/);
+  assert.match(source, /cspImageOrigins = imageRemotePatterns\.map/);
+});
+
+test("buildCsp refuses wildcard hosts", () => {
+  assert.throws(
+    () => policy({ posthogOrigin: "https://*.posthog.com" }),
+    /Illegal CSP source/
+  );
 });
 
 test("the joined header is a single well-formed policy", () => {

--- a/apps/web/tests/csp-report-route.test.ts
+++ b/apps/web/tests/csp-report-route.test.ts
@@ -1,0 +1,184 @@
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// The route only forwards to PostHog in production; Next types NODE_ENV as
+// read-only, so it has to be set through the record type.
+(process.env as Record<string, string>).NODE_ENV = "production";
+process.env.NEXT_PUBLIC_POSTHOG_KEY = "phc_test_key";
+process.env.NEXT_PUBLIC_POSTHOG_HOST = "https://t.example.com";
+
+const { POST } = await import("../src/app/api/csp-report/route.ts");
+
+interface Captured {
+  url: string;
+  body: Record<string, unknown>;
+}
+
+let captured: Captured[] = [];
+
+globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+  captured.push({
+    url: String(input),
+    body: JSON.parse(String(init?.body ?? "{}")),
+  });
+  return new Response(null, { status: 200 });
+}) as typeof fetch;
+
+// The route holds its rate-limit window in module scope, and node:test runs a
+// file's tests in one process. Without this, whichever test ran first would
+// spend the budget and every later test would be answered by the rate limiter
+// instead of the behaviour it names. Advancing past the window between tests
+// gives each one a clean budget, and exercises the rollover while it is at it.
+let clock = Date.UTC(2026, 0, 1);
+Date.now = () => clock;
+
+beforeEach(() => {
+  clock += 61_000;
+});
+
+function report(body: Record<string, unknown>): Request {
+  return new Request("https://www.mehdi-zare.com/api/csp-report", {
+    method: "POST",
+    headers: { "content-type": "application/reports+json" },
+    body: JSON.stringify([{ type: "csp-violation", body }]),
+  });
+}
+
+async function post(request: Request) {
+  captured = [];
+  const response = await POST(request);
+  return { status: response.status, sent: captured };
+}
+
+test("forwards a Reporting API violation to PostHog", async () => {
+  const { status, sent } = await post(
+    report({
+      documentURL: "https://www.mehdi-zare.com/",
+      effectiveDirective: "connect-src",
+      blockedURL: "https://us.i.posthog.com/e/",
+      disposition: "enforce",
+    })
+  );
+
+  assert.equal(status, 204);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0]?.url, "https://t.example.com/i/v0/e/");
+  assert.equal(sent[0]?.body.event, "csp_violation");
+
+  const properties = sent[0]?.body.properties as Record<string, unknown>;
+  assert.equal(properties.directive, "connect-src");
+  assert.equal(properties.blocked_uri, "https://us.i.posthog.com/e/");
+  // Violations are not a person, and must not create a profile.
+  assert.equal(properties.$process_person_profile, false);
+});
+
+test("accepts the legacy application/csp-report body shape", async () => {
+  const { status, sent } = await post(
+    new Request("https://www.mehdi-zare.com/api/csp-report", {
+      method: "POST",
+      headers: { "content-type": "application/csp-report" },
+      body: JSON.stringify({
+        "csp-report": {
+          "document-uri": "https://www.mehdi-zare.com/about",
+          "violated-directive": "img-src 'self'",
+          "blocked-uri": "https://cdn.example.com/a.png",
+        },
+      }),
+    })
+  );
+
+  assert.equal(status, 204);
+  assert.equal(sent.length, 1);
+  const properties = sent[0]?.body.properties as Record<string, unknown>;
+  assert.equal(properties.directive, "img-src");
+  assert.equal(properties.violated_directive, "img-src 'self'");
+});
+
+test("drops violations caused by browser extensions", async () => {
+  for (const blockedURL of [
+    "chrome-extension://abcdef/inject.js",
+    "moz-extension://abcdef/inject.js",
+    "safari-web-extension://abcdef/inject.js",
+    "about:blank",
+  ]) {
+    const { status, sent } = await post(
+      report({ effectiveDirective: "script-src", blockedURL })
+    );
+    assert.equal(status, 204);
+    assert.deepEqual(sent, [], `${blockedURL} should not be forwarded`);
+  }
+});
+
+test("reports the same violation only once per window", async () => {
+  const first = await post(
+    report({ effectiveDirective: "font-src", blockedURL: "https://fonts.example/x.woff2" })
+  );
+  const second = await post(
+    report({ effectiveDirective: "font-src", blockedURL: "https://fonts.example/x.woff2" })
+  );
+
+  assert.equal(first.sent.length, 1);
+  assert.deepEqual(second.sent, [], "a repeat of the same violation is deduped");
+});
+
+test("the same violation is reported again in the next window", async () => {
+  const violation = { effectiveDirective: "font-src", blockedURL: "https://fonts.example/y.woff2" };
+
+  assert.equal((await post(report(violation))).sent.length, 1);
+  assert.deepEqual((await post(report(violation))).sent, []);
+
+  clock += 61_000;
+
+  assert.equal(
+    (await post(report(violation))).sent.length,
+    1,
+    "an ongoing violation should keep being visible, not be silenced forever"
+  );
+});
+
+test("caps how many distinct violations one window forwards", async () => {
+  let forwarded = 0;
+
+  for (let i = 0; i < 200; i += 1) {
+    const { sent } = await post(
+      report({ effectiveDirective: "media-src", blockedURL: `https://flood.example/${i}` })
+    );
+    forwarded += sent.length;
+  }
+
+  assert.ok(forwarded > 0, "some reports get through");
+  assert.ok(forwarded <= 60, `a report storm is capped, forwarded ${forwarded}`);
+});
+
+test("never fails the request on a malformed body", async () => {
+  const { status, sent } = await post(
+    new Request("https://www.mehdi-zare.com/api/csp-report", {
+      method: "POST",
+      body: "not json at all",
+    })
+  );
+
+  assert.equal(status, 204);
+  assert.deepEqual(sent, []);
+});
+
+test("never fails the request when PostHog is unreachable", async () => {
+  const restore = globalThis.fetch;
+  let attempts = 0;
+  globalThis.fetch = (async () => {
+    attempts += 1;
+    throw new Error("network down");
+  }) as typeof fetch;
+
+  try {
+    const response = await POST(
+      report({ effectiveDirective: "style-src", blockedURL: "https://down.example/a.css" })
+    );
+    assert.equal(response.status, 204);
+    // Load-bearing: without this the test passes even when the report is
+    // dropped before it ever reaches the failing call it claims to guard.
+    assert.equal(attempts, 1, "the forward should have been attempted and swallowed");
+  } finally {
+    globalThis.fetch = restore;
+  }
+});

--- a/apps/web/tests/csp-report-route.test.ts
+++ b/apps/web/tests/csp-report-route.test.ts
@@ -64,6 +64,7 @@ test("forwards a Reporting API violation to PostHog", async () => {
   assert.equal(sent.length, 1);
   assert.equal(sent[0]?.url, "https://t.example.com/i/v0/e/");
   assert.equal(sent[0]?.body.event, "csp_violation");
+  assert.equal(sent[0]?.body.api_key, "phc_test_key");
 
   const properties = sent[0]?.body.properties as Record<string, unknown>;
   assert.equal(properties.directive, "connect-src");
@@ -147,7 +148,7 @@ test("caps how many distinct violations one window forwards", async () => {
   }
 
   assert.ok(forwarded > 0, "some reports get through");
-  assert.ok(forwarded <= 60, `a report storm is capped, forwarded ${forwarded}`);
+  assert.equal(forwarded, 60, `a report storm is capped, forwarded ${forwarded}`);
 });
 
 test("never fails the request on a malformed body", async () => {

--- a/apps/web/tests/homepage-visibility.test.ts
+++ b/apps/web/tests/homepage-visibility.test.ts
@@ -153,23 +153,5 @@ test("WritingSection pads CMS rows through the shared helper and keys the CTA of
   assert.match(source, /cards\.some\(\(card\) => !card\.external\)/);
 });
 
-test("CSP allows nested PostHog ingest and asset hosts on script, connect, and images", () => {
-  const source = readSource("next.config.ts");
-
-  assert.match(source, /https:\/\/\*\.posthog\.com/);
-  assert.match(source, /https:\/\/\*\.i\.posthog\.com/);
-  assert.match(source, /worker-src 'self' blob: data:/);
-  assert.equal([...source.matchAll(/\.\.\.posthogCspOrigins/g)].length, 2);
-  assert.match(
-    source,
-    /script-src 'self' 'unsafe-inline' " \+ cspConnectOrigins\.join\(" "\)/
-  );
-  assert.match(
-    source,
-    /connect-src 'self' " \+ cspConnectOrigins\.join\(" "\)/
-  );
-  assert.match(
-    source,
-    /img-src 'self' data: blob: " \+ cspImageOrigins\.join\(" "\)/
-  );
-});
+// The CSP is asserted against the built header in csp-contract.test.ts rather
+// than by grepping next.config.ts for the expressions that produce it.


### PR DESCRIPTION
Refs #29 — the code half. The Vercel env flip is tracked separately; see *Deploy note*.

## The premise in #28 was wrong

`next.config.ts` carried this:

```ts
// PostHog loads ingest + assets from nested subdomains (us.i / us-assets.i).
// `*.posthog.com` does not cover those, so both wildcards are required.
```

CSP host wildcards are a plain **suffix** match (CSP3 §6.6.2.6), so `https://*.posthog.com` already covered `us.i.posthog.com` *and* `us-assets.i.posthog.com`. Both extra entries were pure redundancy, while the wildcard admitted every PostHog subdomain that will ever exist — on `script-src`, `connect-src`, `img-src` and `media-src` alike.

## What production actually requests

Recorded from a real browser load, which is step 1 of #29 — so no further network capture is needed:

| request | directive |
|---|---|
| `us.i.posthog.com/static/array.js` | script |
| `us-assets.i.posthog.com/array/<key>/config.js` | script |
| `us-assets.i.posthog.com/static/1.418.5/{posthog-recorder,surveys,dead-clicks-autocapture,web-vitals}.js` | script |
| `POST us.i.posthog.com/e/`, `POST us.i.posthog.com/i/v0/e/` | connect |

Zero console errors. No PostHog images, media or frames at all — so `img-src`, `media-src` and `frame-src` never needed it.

## The fix, and the trap inside it

`buildCsp()` allows only the origins actually contacted. The subtlety is that **there is no single right answer** — posthog-js splits its endpoints by region, so a PostHog-hosted `api_host` still fetches remote config and the recorder/survey/dead-click/web-vitals bundles from a sibling `<region>-assets.i.posthog.com`:

```js
// posthog-js 1.418.11
case "assets": return "https://" + region + "-assets." + "i.posthog.com" + path
```

So `buildCsp()` derives that companion from whatever `NEXT_PUBLIC_POSTHOG_HOST` is set to, instead of assuming one deployment:

```
NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com   (production today)
  script-src  … https://us.i.posthog.com https://us-assets.i.posthog.com

NEXT_PUBLIC_POSTHOG_HOST=https://t.mehdi-zare.com   (repo default, the proxy)
  script-src  … https://t.mehdi-zare.com
```

**This matters.** Production overrides the host to `us.i.posthog.com` while the repo default is the proxy. An earlier revision of this branch emitted a single origin and would have blocked `us-assets.i.posthog.com` on merge, silently killing session replay and surveys. Deriving the companion removes the ordering hazard entirely — the header is correct under either value, so the env flip is an independent follow-up rather than a precondition.

Split by directive, `media-src` and `frame-src` drop PostHog, and `worker-src` drops `data:` while keeping the `blob:` the session recorder needs.

## Silent failure was the real problem

A too-tight policy does not raise anything — analytics or an embed just stops loading. There was no `report-uri` or `report-to` at all. New collector at `/api/csp-report`, wired to both (Firefox and Safari only implement `report-uri`; Chrome only `report-to`). It normalises both report body shapes, drops browser-extension noise, dedupes per violation per window, caps a storm at 60/min per instance, and can never fail the request.

## Also in scope

- **Extracted `buildCsp()`** into `src/lib/csp.ts` so tests assert the joined header, instead of grepping `next.config.ts` for the expressions that build it — the approach #29 asked for.
- **`img-src` now derives from `images.remotePatterns`.** They had drifted: a host added via `NEXT_PUBLIC_ALLOWED_IMAGE_HOSTS` was loadable by `next/image` but blocked by CSP. Latent only because CMS media is proxied same-origin.
- **Dropped `frame-src https://embeds.beehiiv.com`** and its env plumbing. Nothing in `apps/web/src` has ever referenced beehiiv.

## Verification

Every request observed on a production page load was replayed against the built policy under **both** PostHog hosts: all allowed, zero wildcards, and the proxy config collapses to one origin across all 11 of its endpoints.

The tests were mutation-checked rather than assumed — each of these makes the suite fail:

- removing the assets-origin derivation
- emptying `CAL_ORIGINS` (Cal.com's `getCalApi()` injects a script from `app.cal.com`, so those origins are load-bearing on `script-src`)
- dropping the collector's error guard

That last one mattered: the collector tests initially passed **vacuously**, because the route's module-scope rate-limit budget was exhausted by an earlier test in the same file, so the failure path was never reached. Fixed by stubbing the clock so each test gets a clean window, plus an assertion that the forward was actually attempted.

## Deploy note

Production still sets `NEXT_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com`, bypassing the working `t.mehdi-zare.com` proxy. This PR is safe to merge as-is. Pointing production at the proxy — which also makes analytics ad-blocker resistant and collapses the policy to a single origin — is a separate step to be done after merge and verified on the served header.

🤖 Generated with [Claude Code](https://claude.com/claude-code)