### PR TITLE
fix(web): keep sitemap 200 and add in-content /ai-engineer links

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import { CareerTimeline } from "@/components/about/CareerTimeline";
 import { CredentialBadges } from "@/components/about/CredentialBadges";
 import { BlocksRenderer } from "@/components/blog/BlocksRenderer";
+import { AiEngineerProfileLink } from "@/components/seo/AiEngineerProfileLink";
 import { CmsStructuredData } from "@/components/seo/CmsStructuredData";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { AnimatedSection } from "@/components/shared/AnimatedSection";
@@ -128,6 +129,7 @@ export default async function AboutPage() {
             <p className="mt-5 max-w-3xl text-xl leading-relaxed text-mid-gray">
               {data.positioningStatement}
             </p>
+            <AiEngineerProfileLink section="about_hero" className="mt-4" />
           </AnimatedSection>
         </div>
       </section>

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { TrackedLink } from "@/components/analytics/TrackedLink";
+import { AiEngineerProfileLink } from "@/components/seo/AiEngineerProfileLink";
 import { CmsStructuredData } from "@/components/seo/CmsStructuredData";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { getArticles, getArticleBySlug } from "@/lib/strapi";
@@ -25,6 +26,11 @@ interface BlogPostPageProps {
 }
 
 type ArticleList = Awaited<ReturnType<typeof getArticles>>["data"];
+
+const AI_ENGINEER_IN_CONTENT_BLOG_SLUGS = new Set([
+  "how-ai-works-from-data-to-decisions",
+  "why-most-ai-projects-die-before-production-and-it-s-not-a-tech-problem",
+]);
 
 async function getAllArticles(): Promise<ArticleList> {
   const pageSize = 100;
@@ -286,6 +292,9 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
               <div className="mt-10">
                 <BlocksRenderer content={article.content} />
               </div>
+              {AI_ENGINEER_IN_CONTENT_BLOG_SLUGS.has(article.slug) ? (
+                <AiEngineerProfileLink section="blog_body" className="mt-10" />
+              ) : null}
 
               {/* Tags */}
               {article.tags && article.tags.length > 0 && (

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -32,6 +32,18 @@ function safeDate(input: string | undefined, fallback: Date): Date {
   return Number.isNaN(parsed.getTime()) ? fallback : parsed;
 }
 
+/** Newest parseable timestamp in `values`, or `fallback` when none are valid. */
+export function maxValidDate(values: Array<string | undefined>, fallback: Date): Date {
+  let latest: Date | null = null;
+  for (const value of values) {
+    if (!value) continue;
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) continue;
+    if (!latest || parsed > latest) latest = parsed;
+  }
+  return latest ?? fallback;
+}
+
 async function getAllArticlesForSitemap(): Promise<Article[]> {
   const pageSize = 100;
   let page = 1;
@@ -380,12 +392,10 @@ async function buildCmsSitemap(now: Date, showBinaPrint: boolean): Promise<Metad
   let articlePages: MetadataRoute.Sitemap = [];
   if (articlesResult.status === "fulfilled") {
     const articles = articlesResult.value;
-    for (const article of articles) {
-      const updated = safeDate(article.updatedAt, pageTimestamps.blog);
-      if (updated > pageTimestamps.blog) {
-        pageTimestamps.blog = updated;
-      }
-    }
+    pageTimestamps.blog = maxValidDate(
+      articles.map((article) => article.updatedAt),
+      pageTimestamps.blog
+    );
     articlePages = mapArticlePages(articles, now);
   } else {
     degradedSources.push("articles");

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import type { Article, Author, Category, Tag } from "@/types/strapi";
+import type { Article, Author } from "@/types/strapi";
 import {
   getAboutPage,
   getArticles,
@@ -11,13 +11,17 @@ import {
   getTags,
 } from "@/lib/strapi";
 import { isBinaPrintEnabled } from "@/lib/feature-flags";
-import { getSiteProfile } from "@/lib/site-profile";
+import { DEFAULT_SITE_PROFILE } from "@/lib/site-profile-defaults";
 import { getSiteUrl, toAbsoluteMediaUrl } from "@/lib/seo";
 import taxonomy from "../../../../data/taxonomy.json";
 
 const SITE_URL = getSiteUrl();
 
 export const revalidate = 3600;
+/** One parallel CMS round uses the 15s Strapi timeout; finish before the isolate is killed. */
+export const maxDuration = 20;
+
+const SITEMAP_MAX_PAGES = 20;
 
 function safeDate(input: string | undefined, fallback: Date): Date {
   if (!input) {
@@ -42,7 +46,7 @@ async function getAllArticlesForSitemap(): Promise<Article[]> {
     articles.push(...response.data);
 
     const pageCount = response.meta.pagination?.pageCount ?? 1;
-    if (page >= pageCount) {
+    if (page >= pageCount || page >= SITEMAP_MAX_PAGES) {
       break;
     }
 
@@ -66,7 +70,7 @@ async function getAllAuthorsForSitemap(): Promise<Author[]> {
     authors.push(...response.data);
 
     const pageCount = response.meta.pagination?.pageCount ?? 1;
-    if (page >= pageCount) {
+    if (page >= pageCount || page >= SITEMAP_MAX_PAGES) {
       break;
     }
 
@@ -90,7 +94,7 @@ async function getAllCategoriesForSitemap(): Promise<Category[]> {
     categories.push(...response.data);
 
     const pageCount = response.meta.pagination?.pageCount ?? 1;
-    if (page >= pageCount) {
+    if (page >= pageCount || page >= SITEMAP_MAX_PAGES) {
       break;
     }
 
@@ -114,7 +118,7 @@ async function getAllTagsForSitemap(): Promise<Tag[]> {
     tags.push(...response.data);
 
     const pageCount = response.meta.pagination?.pageCount ?? 1;
-    if (page >= pageCount) {
+    if (page >= pageCount || page >= SITEMAP_MAX_PAGES) {
       break;
     }
 
@@ -181,67 +185,77 @@ function getFallbackTagSlugs(): string[] {
 const FALLBACK_CATEGORY_SLUGS = getFallbackCategorySlugs();
 const FALLBACK_TAG_SLUGS = getFallbackTagSlugs();
 
-export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-  const now = new Date();
-  const showBinaPrint = isBinaPrintEnabled();
-  const degradedSources: string[] = [];
-  const pageTimestamps = {
-    home: now,
-    about: now,
-    binaPrint: now,
-    consulting: now,
-    aiEngineer: now,
-    blog: now,
-  };
+function fallbackAuthorPages(now: Date): MetadataRoute.Sitemap {
+  const slug = normalizeSlug(DEFAULT_SITE_PROFILE.authorSlug);
+  if (!slug) return [];
+  return [
+    {
+      url: `${SITE_URL}/author/${slug}`,
+      lastModified: now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+  ];
+}
 
-  try {
-    const [homeRes, aboutRes, consultingRes] =
-      await Promise.all([
-        getHomePage(),
-        getAboutPage(),
-        getConsultingPage(),
-      ]);
+function fallbackCategoryPages(now: Date): MetadataRoute.Sitemap {
+  return FALLBACK_CATEGORY_SLUGS.map((slug) => ({
+    url: `${SITE_URL}/blog/category/${slug}`,
+    lastModified: now,
+    changeFrequency: "weekly" as const,
+    priority: 0.7,
+  }));
+}
 
-    pageTimestamps.home = safeDate(homeRes.data?.updatedAt, now);
-    pageTimestamps.about = safeDate(aboutRes.data?.updatedAt, now);
-    pageTimestamps.consulting = safeDate(consultingRes.data?.updatedAt, now);
+function fallbackTagPages(now: Date): MetadataRoute.Sitemap {
+  return FALLBACK_TAG_SLUGS.map((slug) => ({
+    url: `${SITE_URL}/blog/tag/${slug}`,
+    lastModified: now,
+    changeFrequency: "weekly" as const,
+    priority: 0.6,
+  }));
+}
 
-    if (showBinaPrint) {
-      const binaPrintRes = await getBinaPrintPage();
-      pageTimestamps.binaPrint = safeDate(binaPrintRes.data?.updatedAt, now);
-    }
-  } catch {
-    // Keep build-time fallback dates when CMS is unavailable.
-  }
-
+function buildStaticSitemapPages(
+  now: Date,
+  timestamps: {
+    home: Date;
+    about: Date;
+    binaPrint: Date;
+    consulting: Date;
+    aiEngineer: Date;
+    blog: Date;
+  },
+  showBinaPrint: boolean
+): MetadataRoute.Sitemap {
   const staticPages: MetadataRoute.Sitemap = [
     {
       url: SITE_URL,
-      lastModified: pageTimestamps.home,
+      lastModified: timestamps.home,
       changeFrequency: "weekly",
       priority: 1,
     },
     {
       url: `${SITE_URL}/about`,
-      lastModified: pageTimestamps.about,
+      lastModified: timestamps.about,
       changeFrequency: "monthly",
       priority: 0.9,
     },
     {
       url: `${SITE_URL}/consulting`,
-      lastModified: pageTimestamps.consulting,
+      lastModified: timestamps.consulting,
       changeFrequency: "monthly",
       priority: 0.9,
     },
     {
       url: `${SITE_URL}/ai-engineer`,
-      lastModified: pageTimestamps.aiEngineer,
+      lastModified: timestamps.aiEngineer,
       changeFrequency: "monthly",
       priority: 0.9,
     },
     {
       url: `${SITE_URL}/blog`,
-      lastModified: pageTimestamps.blog,
+      lastModified: timestamps.blog,
       changeFrequency: "weekly",
       priority: 0.8,
     },
@@ -256,148 +270,199 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   if (showBinaPrint) {
     staticPages.splice(2, 0, {
       url: `${SITE_URL}/bina-print`,
-      lastModified: pageTimestamps.binaPrint,
+      lastModified: timestamps.binaPrint,
       changeFrequency: "weekly",
       priority: 0.9,
     });
   }
 
-  let articlePages: MetadataRoute.Sitemap = [];
-  let authorPages: MetadataRoute.Sitemap = [];
+  return staticPages;
+}
 
-  try {
-    const articles = await getAllArticlesForSitemap();
+function buildDegradedSitemap(now: Date, showBinaPrint: boolean): MetadataRoute.Sitemap {
+  const timestamps = {
+    home: now,
+    about: now,
+    binaPrint: now,
+    consulting: now,
+    aiEngineer: now,
+    blog: now,
+  };
+  return [
+    ...buildStaticSitemapPages(now, timestamps, showBinaPrint),
+    ...fallbackAuthorPages(now),
+    ...fallbackCategoryPages(now),
+    ...fallbackTagPages(now),
+  ];
+}
+
+function mapArticlePages(articles: Article[], now: Date): MetadataRoute.Sitemap {
+  const pages: MetadataRoute.Sitemap = [];
+  for (const article of articles) {
+    const slug = normalizeSlug(article.slug);
+    if (!slug) continue;
+    try {
+      const imageUrl = toAbsoluteMediaUrl(article.featuredImage?.url);
+      pages.push({
+        url: `${SITE_URL}/blog/${slug}`,
+        lastModified: safeDate(article.updatedAt, now),
+        changeFrequency: "weekly",
+        priority: 0.7,
+        images: imageUrl ? [imageUrl] : undefined,
+      });
+    } catch {
+      // Skip a malformed row; do not fail the whole sitemap.
+    }
+  }
+  return pages;
+}
+
+function mapAuthorPages(authors: Author[], now: Date): MetadataRoute.Sitemap {
+  const pages: MetadataRoute.Sitemap = [];
+  for (const author of authors) {
+    const slug = normalizeSlug(author.slug);
+    if (!slug) continue;
+    try {
+      const imageUrl = toAbsoluteMediaUrl(author.profileImage?.url);
+      pages.push({
+        url: `${SITE_URL}/author/${slug}`,
+        lastModified: safeDate(author.updatedAt, now),
+        changeFrequency: "monthly",
+        priority: 0.6,
+        images: imageUrl ? [imageUrl] : undefined,
+      });
+    } catch {
+      // Skip a malformed row; do not fail the whole sitemap.
+    }
+  }
+  return pages;
+}
+
+async function buildCmsSitemap(now: Date, showBinaPrint: boolean): Promise<MetadataRoute.Sitemap> {
+  const degradedSources: string[] = [];
+  const pageTimestamps = {
+    home: now,
+    about: now,
+    binaPrint: now,
+    consulting: now,
+    aiEngineer: now,
+    blog: now,
+  };
+
+  const timestampWork = (async () => {
+    const [homeRes, aboutRes, consultingRes] = await Promise.all([
+      getHomePage(),
+      getAboutPage(),
+      getConsultingPage(),
+    ]);
+    pageTimestamps.home = safeDate(homeRes.data?.updatedAt, now);
+    pageTimestamps.about = safeDate(aboutRes.data?.updatedAt, now);
+    pageTimestamps.consulting = safeDate(consultingRes.data?.updatedAt, now);
+    if (showBinaPrint) {
+      const binaPrintRes = await getBinaPrintPage();
+      pageTimestamps.binaPrint = safeDate(binaPrintRes.data?.updatedAt, now);
+    }
+  })();
+
+  const [timestampResult, articlesResult, authorsResult, categoriesResult, tagsResult] =
+    await Promise.allSettled([
+      timestampWork,
+      getAllArticlesForSitemap(),
+      getAllAuthorsForSitemap(),
+      getAllCategoriesForSitemap(),
+      getAllTagsForSitemap(),
+    ]);
+
+  if (timestampResult.status === "rejected") {
+    degradedSources.push("pages");
+  }
+
+  let articlePages: MetadataRoute.Sitemap = [];
+  if (articlesResult.status === "fulfilled") {
+    const articles = articlesResult.value;
     if (articles.length > 0) {
       pageTimestamps.blog = safeDate(articles[0]?.updatedAt, pageTimestamps.blog);
     }
-
-    articlePages = articles.map((article) => {
-      const imageUrl = toAbsoluteMediaUrl(article.featuredImage?.url);
-
-      return {
-        url: `${SITE_URL}/blog/${article.slug}`,
-        lastModified: safeDate(article.updatedAt, now),
-        changeFrequency: "weekly" as const,
-        priority: 0.7,
-        images: imageUrl ? [imageUrl] : undefined,
-      };
-    });
-  } catch {
+    articlePages = mapArticlePages(articles, now);
+  } else {
     degradedSources.push("articles");
   }
 
-  try {
-    const authors = await getAllAuthorsForSitemap();
-
-    authorPages = authors.map((author) => ({
-      url: `${SITE_URL}/author/${author.slug}`,
-      lastModified: safeDate(author.updatedAt, now),
-      changeFrequency: "monthly" as const,
-      priority: 0.6,
-      images: author.profileImage?.url
-        ? [toAbsoluteMediaUrl(author.profileImage.url)].filter(
-            (imageUrl): imageUrl is string => Boolean(imageUrl)
-          )
-        : undefined,
-    }));
-  } catch {
+  let authorPages: MetadataRoute.Sitemap = [];
+  if (authorsResult.status === "fulfilled") {
+    authorPages = mapAuthorPages(authorsResult.value, now);
+  } else {
     degradedSources.push("authors");
   }
-
   if (authorPages.length === 0) {
-    try {
-      const siteProfile = await getSiteProfile();
-      const profilePath = siteProfile.author.profilePath;
-      if (profilePath.startsWith("/author/")) {
-        authorPages = [
-          {
-            url: `${SITE_URL}${profilePath}`,
-            lastModified: now,
-            changeFrequency: "monthly" as const,
-            priority: 0.6,
-            images: siteProfile.author.profileImage?.url
-              ? [toAbsoluteMediaUrl(siteProfile.author.profileImage.url)].filter(
-                  (imageUrl): imageUrl is string => Boolean(imageUrl)
-                )
-              : undefined,
-          },
-        ];
-      }
-    } catch {
-      degradedSources.push("authors");
-    }
+    authorPages = fallbackAuthorPages(now);
   }
 
-  const categoryPages = await (async () => {
-    try {
-      const allCategories = await getAllCategoriesForSitemap();
-
-      if (allCategories.length === 0) {
-        degradedSources.push("categories");
-        return FALLBACK_CATEGORY_SLUGS.map((slug) => ({
+  let categoryPages: MetadataRoute.Sitemap = [];
+  if (categoriesResult.status === "fulfilled") {
+    categoryPages = categoriesResult.value.flatMap((category) => {
+      const slug = normalizeSlug(category.slug);
+      if (!slug) return [];
+      return [
+        {
           url: `${SITE_URL}/blog/category/${slug}`,
-          lastModified: now,
+          lastModified: safeDate(category.updatedAt, now),
           changeFrequency: "weekly" as const,
           priority: 0.7,
-        }));
-      }
+        },
+      ];
+    });
+  }
+  if (categoryPages.length === 0) {
+    degradedSources.push("categories");
+    categoryPages = fallbackCategoryPages(now);
+  }
 
-      return allCategories.map((category) => ({
-        url: `${SITE_URL}/blog/category/${category.slug}`,
-        lastModified: safeDate(category.updatedAt, now),
-        changeFrequency: "weekly" as const,
-        priority: 0.7,
-      }));
-    } catch {
-      degradedSources.push("categories");
-      return FALLBACK_CATEGORY_SLUGS.map((slug) => ({
-        url: `${SITE_URL}/blog/category/${slug}`,
-        lastModified: now,
-        changeFrequency: "weekly" as const,
-        priority: 0.7,
-      }));
-    }
-  })();
-
-  const tagPages = await (async () => {
-    try {
-      const allTags = await getAllTagsForSitemap();
-
-      if (allTags.length === 0) {
-        degradedSources.push("tags");
-        return FALLBACK_TAG_SLUGS.map((slug) => ({
+  let tagPages: MetadataRoute.Sitemap = [];
+  if (tagsResult.status === "fulfilled") {
+    tagPages = tagsResult.value.flatMap((tag) => {
+      const slug = normalizeSlug(tag.slug);
+      if (!slug) return [];
+      return [
+        {
           url: `${SITE_URL}/blog/tag/${slug}`,
-          lastModified: now,
+          lastModified: safeDate(tag.updatedAt, now),
           changeFrequency: "weekly" as const,
           priority: 0.6,
-        }));
-      }
-
-      return allTags.map((tag) => ({
-        url: `${SITE_URL}/blog/tag/${tag.slug}`,
-        lastModified: safeDate(tag.updatedAt, now),
-        changeFrequency: "weekly" as const,
-        priority: 0.6,
-      }));
-    } catch {
-      degradedSources.push("tags");
-      return FALLBACK_TAG_SLUGS.map((slug) => ({
-        url: `${SITE_URL}/blog/tag/${slug}`,
-        lastModified: now,
-        changeFrequency: "weekly" as const,
-        priority: 0.6,
-      }));
-    }
-  })();
+        },
+      ];
+    });
+  }
+  if (tagPages.length === 0) {
+    degradedSources.push("tags");
+    tagPages = fallbackTagPages(now);
+  }
 
   if (degradedSources.length > 0) {
-    const uniqueSources = dedupeStrings(degradedSources);
     console.warn(
-      `[sitemap] CMS-backed sections unavailable (${uniqueSources.join(
+      `[sitemap] CMS-backed sections unavailable (${dedupeStrings(degradedSources).join(
         ", "
       )}); serving fallback sitemap entries where possible.`
     );
   }
 
-  return [...staticPages, ...articlePages, ...authorPages, ...categoryPages, ...tagPages];
+  return [
+    ...buildStaticSitemapPages(now, pageTimestamps, showBinaPrint),
+    ...articlePages,
+    ...authorPages,
+    ...categoryPages,
+    ...tagPages,
+  ];
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+  const showBinaPrint = isBinaPrintEnabled();
+
+  try {
+    return await buildCmsSitemap(now, showBinaPrint);
+  } catch (error) {
+    console.warn("[sitemap] CMS enrichment failed; serving static + taxonomy fallback", error);
+    return buildDegradedSitemap(now, showBinaPrint);
+  }
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -380,8 +380,11 @@ async function buildCmsSitemap(now: Date, showBinaPrint: boolean): Promise<Metad
   let articlePages: MetadataRoute.Sitemap = [];
   if (articlesResult.status === "fulfilled") {
     const articles = articlesResult.value;
-    if (articles.length > 0) {
-      pageTimestamps.blog = safeDate(articles[0]?.updatedAt, pageTimestamps.blog);
+    for (const article of articles) {
+      const updated = safeDate(article.updatedAt, pageTimestamps.blog);
+      if (updated > pageTimestamps.blog) {
+        pageTimestamps.blog = updated;
+      }
     }
     articlePages = mapArticlePages(articles, now);
   } else {

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,5 +1,5 @@
 import type { MetadataRoute } from "next";
-import type { Article, Author } from "@/types/strapi";
+import type { Article, Author, Category, Tag } from "@/types/strapi";
 import {
   getAboutPage,
   getArticles,

--- a/apps/web/src/components/seo/AiEngineerProfileLink.tsx
+++ b/apps/web/src/components/seo/AiEngineerProfileLink.tsx
@@ -1,0 +1,32 @@
+import { TrackedLink } from "@/components/analytics/TrackedLink";
+import { cn } from "@/lib/utils";
+
+interface AiEngineerProfileLinkProps {
+  section: string;
+  className?: string;
+}
+
+export function AiEngineerProfileLink({
+  section,
+  className,
+}: AiEngineerProfileLinkProps) {
+  return (
+    <p className={cn("max-w-3xl text-sm text-mid-gray", className)}>
+      Looking for the{" "}
+      <TrackedLink
+        href="/ai-engineer"
+        eventName="funnel_cta_click"
+        eventProperties={{
+          section,
+          cta_label: "AI engineer landing",
+          destination: "/ai-engineer",
+          interaction_type: "link_click",
+        }}
+        className="text-ink underline underline-offset-4 transition-colors hover:text-mid-gray"
+      >
+        AI engineer
+      </TrackedLink>{" "}
+      profile instead?
+    </p>
+  );
+}

--- a/apps/web/tests/ai-engineer-landing.test.ts
+++ b/apps/web/tests/ai-engineer-landing.test.ts
@@ -29,6 +29,24 @@ test("AI engineer landing is a dedicated non-blog route titled to the query", ()
   assert.doesNotMatch(page, /\/blog\//);
   assert.match(readSource("src/components/layout/Footer.tsx"), /href: "\/ai-engineer"/);
   assert.match(readSource("src/components/home/ServicesGrid.tsx"), /href: "\/ai-engineer"/);
+  assert.match(readSource("src/app/about/page.tsx"), /AiEngineerProfileLink/);
+  assert.match(
+    readSource("src/app/blog/[slug]/page.tsx"),
+    /how-ai-works-from-data-to-decisions/
+  );
+  assert.match(
+    readSource("src/app/blog/[slug]/page.tsx"),
+    /why-most-ai-projects-die-before-production-and-it-s-not-a-tech-problem/
+  );
+  assert.match(readSource("src/app/blog/[slug]/page.tsx"), /AiEngineerProfileLink/);
+  assert.match(
+    readSource("src/components/seo/AiEngineerProfileLink.tsx"),
+    /href="\/ai-engineer"/
+  );
+  assert.doesNotMatch(
+    readSource("src/app/consulting/page.tsx"),
+    /AiEngineerProfileLink/
+  );
 });
 
 test("AI engineer landing copy stays AI/finance and omits government/CISA", () => {

--- a/apps/web/tests/ai-engineer-landing.test.ts
+++ b/apps/web/tests/ai-engineer-landing.test.ts
@@ -30,23 +30,24 @@ test("AI engineer landing is a dedicated non-blog route titled to the query", ()
   assert.match(readSource("src/components/layout/Footer.tsx"), /href: "\/ai-engineer"/);
   assert.match(readSource("src/components/home/ServicesGrid.tsx"), /href: "\/ai-engineer"/);
   assert.match(readSource("src/app/about/page.tsx"), /AiEngineerProfileLink/);
+  assert.match(readSource("src/app/about/page.tsx"), /section="about_hero"/);
+  const blogPage = readSource("src/app/blog/[slug]/page.tsx");
+  assert.match(blogPage, /how-ai-works-from-data-to-decisions/);
   assert.match(
-    readSource("src/app/blog/[slug]/page.tsx"),
-    /how-ai-works-from-data-to-decisions/
-  );
-  assert.match(
-    readSource("src/app/blog/[slug]/page.tsx"),
+    blogPage,
     /why-most-ai-projects-die-before-production-and-it-s-not-a-tech-problem/
   );
-  assert.match(readSource("src/app/blog/[slug]/page.tsx"), /AiEngineerProfileLink/);
-  assert.match(
-    readSource("src/components/seo/AiEngineerProfileLink.tsx"),
-    /href="\/ai-engineer"/
-  );
-  assert.doesNotMatch(
-    readSource("src/app/consulting/page.tsx"),
-    /AiEngineerProfileLink/
-  );
+  assert.match(blogPage, /AiEngineerProfileLink/);
+  assert.match(blogPage, /AI_ENGINEER_IN_CONTENT_BLOG_SLUGS\.has\(article\.slug\)/);
+  assert.match(blogPage, /section="blog_body"/);
+  const profileLink = readSource("src/components/seo/AiEngineerProfileLink.tsx");
+  assert.match(profileLink, /href="\/ai-engineer"/);
+  assert.match(profileLink, /TrackedLink/);
+  assert.match(profileLink, /eventName="funnel_cta_click"/);
+  assert.match(profileLink, /cta_label: "AI engineer landing"/);
+  assert.match(profileLink, /destination: "\/ai-engineer"/);
+  assert.doesNotMatch(readSource("src/app/consulting/page.tsx"), /AiEngineerProfileLink/);
+  assert.doesNotMatch(readSource("src/app/page.tsx"), /AiEngineerProfileLink/);
 });
 
 test("AI engineer landing copy stays AI/finance and omits government/CISA", () => {

--- a/apps/web/tests/sitemap-route.test.ts
+++ b/apps/web/tests/sitemap-route.test.ts
@@ -5,7 +5,7 @@ process.env.DISABLE_STRAPI_CMS = "true";
 delete process.env.ENABLE_BINA_PRINT;
 delete process.env.NEXT_PUBLIC_ENABLE_BINA_PRINT;
 
-const { default: sitemap, maxDuration } = await import("../src/app/sitemap.ts");
+const { default: sitemap, maxDuration, maxValidDate } = await import("../src/app/sitemap.ts");
 
 test("sitemap includes fallback category/tag entries when CMS is disabled", async () => {
   const entries = await sitemap();
@@ -24,4 +24,18 @@ test("sitemap includes fallback category/tag entries when CMS is disabled", asyn
   assert.ok(urls.includes("https://www.mehdi-zare.com/blog/tag/llms"));
   assert.ok(urls.includes("https://www.mehdi-zare.com/author/mehdi-zare"));
   assert.equal(maxDuration, 20);
+});
+
+test("blog lastModified uses the newest valid article updatedAt, not wall-clock now", () => {
+  const olderPublished = "2024-01-01T00:00:00.000Z";
+  const newerEdit = "2025-06-15T12:00:00.000Z";
+  const now = new Date("2026-08-26T00:00:00.000Z");
+
+  assert.equal(
+    maxValidDate([olderPublished, newerEdit], now).toISOString(),
+    newerEdit,
+    "past updatedAt values must still beat a later fallback seed"
+  );
+  assert.equal(maxValidDate([undefined, "not-a-date"], now).toISOString(), now.toISOString());
+  assert.equal(maxValidDate([], now).toISOString(), now.toISOString());
 });

--- a/apps/web/tests/sitemap-route.test.ts
+++ b/apps/web/tests/sitemap-route.test.ts
@@ -3,17 +3,23 @@ import assert from "node:assert/strict";
 
 process.env.DISABLE_STRAPI_CMS = "true";
 
-const { default: sitemap } = await import("../src/app/sitemap.ts");
+const { default: sitemap, maxDuration } = await import("../src/app/sitemap.ts");
 
 test("sitemap includes fallback category/tag entries when CMS is disabled", async () => {
   const entries = await sitemap();
   const urls = entries.map((entry) => entry.url);
 
   assert.ok(entries.length > 5);
-  assert.ok(urls.includes("https://www.mehdi-zare.com"));
-  assert.ok(urls.includes("https://www.mehdi-zare.com/blog"));
-  assert.ok(urls.includes("https://www.mehdi-zare.com/ai-engineer"));
+  assert.deepEqual(urls.slice(0, 6), [
+    "https://www.mehdi-zare.com",
+    "https://www.mehdi-zare.com/about",
+    "https://www.mehdi-zare.com/consulting",
+    "https://www.mehdi-zare.com/ai-engineer",
+    "https://www.mehdi-zare.com/blog",
+    "https://www.mehdi-zare.com/contact",
+  ]);
   assert.ok(urls.includes("https://www.mehdi-zare.com/blog/category/ai-engineering"));
   assert.ok(urls.includes("https://www.mehdi-zare.com/blog/tag/llms"));
-  assert.ok(urls.some((url) => url.startsWith("https://www.mehdi-zare.com/author/")));
+  assert.ok(urls.includes("https://www.mehdi-zare.com/author/mehdi-zare"));
+  assert.equal(maxDuration, 20);
 });

--- a/apps/web/tests/sitemap-route.test.ts
+++ b/apps/web/tests/sitemap-route.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 process.env.DISABLE_STRAPI_CMS = "true";
+delete process.env.ENABLE_BINA_PRINT;
+delete process.env.NEXT_PUBLIC_ENABLE_BINA_PRINT;
 
 const { default: sitemap, maxDuration } = await import("../src/app/sitemap.ts");
 


### PR DESCRIPTION
Picks up **#51** (P1 sitemap) and **#54** (P2 internal links). The open board was only #51–#54; motion-scanner leftovers stay on **#53** / **#52**.

## Forks

- **#51 is stale against production.** Live `/sitemap.xml` is already 200 and includes `/ai-engineer`. `robots.txt` still points at that URL. The remaining 500 class is a cache-miss / sequential CMS hang (15s Strapi timeout stacked, no outer catch). This PR hardens that path instead of closing #51 as already done.
- **#54 is git-owned template callouts**, not CMS body edits. About story can come from CMS `storyBlocks`; blogs are `BlocksRenderer`. A template link survives CMS overwrites. Copy matches `/consulting` (`Looking for the AI engineer profile instead?`). Homepage and `/consulting` unchanged.
- **#52 / #53** stay out. They share `motion-visibility.test.ts` but each lists the other as out of scope.

## #51

- Parallelize page timestamps + article/author/category/tag reads (`Promise.allSettled`).
- Cap sitemap pagination at 20 pages.
- Skip rows with empty slugs / mapping throws.
- Author fallback uses `DEFAULT_SITE_PROFILE.authorSlug` (no extra CMS round).
- Outer catch serves static pages + taxonomy fallback so `/ai-engineer` is always present.
- `maxDuration = 20` so one 15s Strapi round can finish.

## #54

- Shared `AiEngineerProfileLink` (same TrackedLink as consulting).
- `/about` after the positioning statement.
- The two named blog slugs after the article body.

## Test plan

- [x] `pnpm --filter=web test` — 127 pass
- [ ] After deploy: `curl -sI https://www.mehdi-zare.com/sitemap.xml` is 200 and lists `/ai-engineer`
- [ ] `/about` and both blogs show an in-body “AI engineer” link, not only nav/footer

Closes #51
Closes #54