### PR TITLE
test(web): cover the CMS-on sitemap path

### DIFF
--- a/apps/web/tests/sitemap-cms-on.test.ts
+++ b/apps/web/tests/sitemap-cms-on.test.ts
@@ -1,0 +1,180 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// The CMS-off contract lives in sitemap-route.test.ts. This file covers the
+// opposite branch: a reachable Strapi, so mapArticlePages / mapAuthorPages, the
+// empty-slug skips, and the SITEMAP_MAX_PAGES cap actually execute.
+//
+// `serverEnv` freezes DISABLE_STRAPI_CMS at module scope, so this has to be its
+// own file — node:test already runs each test file in its own process, which is
+// why no --test-isolation flag is needed.
+process.env.DISABLE_STRAPI_CMS = "false";
+process.env.STRAPI_URL = "http://localhost:1337";
+delete process.env.ENABLE_BINA_PRINT;
+delete process.env.NEXT_PUBLIC_ENABLE_BINA_PRINT;
+
+const SITE_URL = "https://www.mehdi-zare.com";
+
+type Row = Record<string, unknown>;
+
+interface Scenario {
+  articles: Row[];
+  authors: Row[];
+  categories: Row[];
+  tags: Row[];
+  /** What Strapi claims the article catalog spans, to drive the pagination loop. */
+  articlePageCount: number;
+}
+
+function emptyScenario(): Scenario {
+  return { articles: [], authors: [], categories: [], tags: [], articlePageCount: 1 };
+}
+
+let scenario: Scenario = emptyScenario();
+let requestedPaths: string[] = [];
+
+function jsonResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// Stub the single choke point every Strapi read funnels through
+// (fetchAPI -> fetchStrapi -> fetch). This covers URL building and pagination
+// param serialization too, which mocking `@/lib/strapi` would skip.
+globalThis.fetch = (async (input: RequestInfo | URL) => {
+  const url = new URL(String(input));
+  requestedPaths.push(url.pathname);
+
+  const page = Number(url.searchParams.get("pagination[page]") ?? "1");
+  const collection = (rows: Row[], pageCount: number) =>
+    jsonResponse({
+      data: page === 1 ? rows : [],
+      meta: { pagination: { page, pageSize: 100, pageCount } },
+    });
+
+  switch (url.pathname) {
+    case "/api/articles":
+      return collection(scenario.articles, scenario.articlePageCount);
+    case "/api/authors":
+      return collection(scenario.authors, 1);
+    case "/api/categories":
+      return collection(scenario.categories, 1);
+    case "/api/tags":
+      return collection(scenario.tags, 1);
+    default:
+      // Single types (home/about/consulting) only contribute a lastModified.
+      return jsonResponse({ data: { updatedAt: "2026-01-01T00:00:00.000Z" } });
+  }
+}) as typeof fetch;
+
+const { default: sitemap } = await import("../src/app/sitemap.ts");
+
+async function runSitemap(next: Partial<Scenario> = {}) {
+  scenario = { ...emptyScenario(), ...next };
+  requestedPaths = [];
+  const entries = await sitemap();
+  return { entries, urls: entries.map((entry) => entry.url) };
+}
+
+/** Article detail pages only — not /blog, /blog/category/*, or /blog/tag/*. */
+function articleUrls(urls: string[]): string[] {
+  return urls.filter(
+    (url) =>
+      url.startsWith(`${SITE_URL}/blog/`) &&
+      !url.startsWith(`${SITE_URL}/blog/category/`) &&
+      !url.startsWith(`${SITE_URL}/blog/tag/`)
+  );
+}
+
+test("only well-formed article slugs reach the sitemap", async () => {
+  const { entries, urls } = await runSitemap({
+    articles: [
+      { slug: "", updatedAt: "2026-02-01T00:00:00.000Z" },
+      { slug: "   ", updatedAt: "2026-02-01T00:00:00.000Z" },
+      { slug: 123, updatedAt: "2026-02-01T00:00:00.000Z" },
+      { slug: null, updatedAt: "2026-02-01T00:00:00.000Z" },
+      {
+        slug: "valid-post",
+        updatedAt: "2026-02-02T00:00:00.000Z",
+        featuredImage: { url: "/uploads/cover.png" },
+      },
+    ],
+  });
+
+  assert.deepEqual(
+    articleUrls(urls),
+    [`${SITE_URL}/blog/valid-post`],
+    "empty, whitespace-only, numeric, and null slugs must all be skipped"
+  );
+
+  const post = entries.find((entry) => entry.url === `${SITE_URL}/blog/valid-post`);
+  assert.ok(post, "the valid article must be present");
+  assert.equal(
+    post.lastModified instanceof Date ? post.lastModified.toISOString() : post.lastModified,
+    "2026-02-02T00:00:00.000Z",
+    "article lastModified comes from its own updatedAt"
+  );
+  assert.ok(post.images?.length, "a featuredImage must be carried through as an absolute URL");
+});
+
+test("only well-formed author slugs reach the sitemap, and the fallback covers none", async () => {
+  const { urls } = await runSitemap({
+    authors: [{ slug: "" }, { slug: "  " }, { slug: 42 }],
+  });
+
+  assert.deepEqual(
+    urls.filter((url) => url.startsWith(`${SITE_URL}/author/`)),
+    [`${SITE_URL}/author/mehdi-zare`],
+    "all-invalid authors must still leave the default author page in the sitemap"
+  );
+});
+
+test("article pagination stops at SITEMAP_MAX_PAGES", async () => {
+  await runSitemap({ articlePageCount: 99 });
+
+  const articleRequests = requestedPaths.filter((path) => path === "/api/articles").length;
+
+  assert.ok(
+    articleRequests < 99,
+    `pagination must not follow pageCount to the end; made ${articleRequests} requests`
+  );
+  assert.equal(
+    articleRequests,
+    20,
+    "pins SITEMAP_MAX_PAGES — update deliberately if the cap moves"
+  );
+});
+
+test("CMS categories and tags replace the taxonomy fallback", async () => {
+  const { urls } = await runSitemap({
+    categories: [{ slug: "cms-cat", updatedAt: "2026-02-01T00:00:00.000Z" }, { slug: "  " }],
+    tags: [{ slug: "cms-tag", updatedAt: "2026-02-01T00:00:00.000Z" }, { slug: null }],
+  });
+
+  assert.ok(urls.includes(`${SITE_URL}/blog/category/cms-cat`));
+  assert.ok(urls.includes(`${SITE_URL}/blog/tag/cms-tag`));
+  assert.ok(
+    !urls.includes(`${SITE_URL}/blog/category/ai-engineering`),
+    "a healthy CMS must not also emit the taxonomy.json fallback categories"
+  );
+  assert.ok(
+    !urls.includes(`${SITE_URL}/blog/tag/llms`),
+    "a healthy CMS must not also emit the taxonomy.json fallback tags"
+  );
+  assert.deepEqual(
+    urls.filter((url) => url.startsWith(`${SITE_URL}/blog/category/`)),
+    [`${SITE_URL}/blog/category/cms-cat`],
+    "blank CMS category slugs are skipped rather than emitted as /blog/category/"
+  );
+});
+
+test("an empty CMS still falls back to taxonomy categories and tags", async () => {
+  const { urls } = await runSitemap();
+
+  assert.ok(urls.includes(`${SITE_URL}/blog/category/ai-engineering`));
+  assert.ok(urls.includes(`${SITE_URL}/blog/tag/llms`));
+  assert.ok(urls.includes(`${SITE_URL}/author/mehdi-zare`));
+  assert.deepEqual(articleUrls(urls), [], "no articles means no article entries");
+});


### PR DESCRIPTION
Part 1 of #58.

## The gap

`tests/sitemap-route.test.ts` sets `DISABLE_STRAPI_CMS=true` before importing the route. `serverEnv` freezes that at module scope and `fetchStrapi` throws before the `fetch`, so **every CMS-on branch of `sitemap.ts` is dead under the suite** — `mapArticlePages`, `mapAuthorPages`, the empty-slug skips, and the pagination cap.

Someone could invert `if (!slug) continue`, break the pagination guard, or delete the `featuredImage` mapping and CI would stay green. That is the shape of the regression that produced #51 (sitemap.xml 500'd in prod).

## The mechanism

A sibling file that stubs `globalThis.fetch` — the single choke point every Strapi read funnels through (`fetchAPI` → `fetchStrapi` → `fetch`).

- No new flags, no resolver changes, no new dependency.
- Covers URL building and pagination-param serialization too, which mocking `@/lib/strapi` would skip. That's how the cap assertion counts real round-trips.
- It has to be a separate file because `DISABLE_STRAPI_CMS` is frozen at import. node:test already runs each file in its own process, so the `--test-isolation=process` the issue suggested is **not needed** — the two contradictory env values coexist as-is.

## Every assertion is mutation-checked

| Mutation | Result |
|---|---|
| drop the article slug skip | 1 test fails |
| drop the author slug skip | 1 test fails |
| drop the `SITEMAP_MAX_PAGES` guard | 1 test fails |
| drop the author fallback | 2 tests fail |
| drop `featuredImage` mapping | 1 test fails |

## Verification

- `npm test` — 143 pass, 0 fail (was 138)
- `tsc --noEmit` — clean
- `eslint` — clean

Part 2 of #58 (`maxDuration` vs pagination) lands in the stacked refactor PR, which is why this one only refs the issue.

Refs #58

🤖 Generated with [Claude Code](https://claude.com/claude-code)