### PR TITLE
fix(web): keep partial CMS pages when a later page fails

### DIFF
--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -56,23 +56,28 @@ const SITEMAP_ARTICLE_FIELDS = {
   populate: { featuredImage: { fields: ["url"] } },
 } as const;
 
-function getAllArticlesForSitemap(): Promise<Article[]> {
-  return fetchAllPages(getArticles, "articles", {
-    ...SITEMAP_ARTICLE_FIELDS,
-    sort: "publishedAt:desc",
-  });
+function getAllArticlesForSitemap(deadlineMs?: number): Promise<Article[]> {
+  return fetchAllPages(
+    getArticles,
+    "articles",
+    {
+      ...SITEMAP_ARTICLE_FIELDS,
+      sort: "publishedAt:desc",
+    },
+    { deadlineMs }
+  );
 }
 
-function getAllAuthorsForSitemap(): Promise<Author[]> {
-  return fetchAllPages(getAuthors, "authors", { sort: "updatedAt:desc" });
+function getAllAuthorsForSitemap(deadlineMs?: number): Promise<Author[]> {
+  return fetchAllPages(getAuthors, "authors", { sort: "updatedAt:desc" }, { deadlineMs });
 }
 
-function getAllCategoriesForSitemap(): Promise<Category[]> {
-  return fetchAllPages(getCategories, "categories", { sort: "order:asc" });
+function getAllCategoriesForSitemap(deadlineMs?: number): Promise<Category[]> {
+  return fetchAllPages(getCategories, "categories", { sort: "order:asc" }, { deadlineMs });
 }
 
-function getAllTagsForSitemap(): Promise<Tag[]> {
-  return fetchAllPages(getTags, "tags", { sort: "name:asc" });
+function getAllTagsForSitemap(deadlineMs?: number): Promise<Tag[]> {
+  return fetchAllPages(getTags, "tags", { sort: "name:asc" }, { deadlineMs });
 }
 
 interface TaxonomyCategoryNode {
@@ -286,6 +291,7 @@ function mapAuthorPages(authors: Author[], now: Date): MetadataRoute.Sitemap {
 }
 
 async function buildCmsSitemap(now: Date, showBinaPrint: boolean): Promise<MetadataRoute.Sitemap> {
+  const deadlineMs = Date.now() + SITEMAP_DEADLINE_MS;
   const degradedSources: string[] = [];
   const pageTimestamps = {
     home: now,
@@ -316,10 +322,10 @@ async function buildCmsSitemap(now: Date, showBinaPrint: boolean): Promise<Metad
   const [timestampResult, articlesResult, authorsResult, categoriesResult, tagsResult] =
     await Promise.allSettled([
       timestampWork,
-      getAllArticlesForSitemap(),
-      getAllAuthorsForSitemap(),
-      getAllCategoriesForSitemap(),
-      getAllTagsForSitemap(),
+      getAllArticlesForSitemap(deadlineMs),
+      getAllAuthorsForSitemap(deadlineMs),
+      getAllCategoriesForSitemap(deadlineMs),
+      getAllTagsForSitemap(deadlineMs),
     ]);
 
   if (timestampResult.status === "rejected") {

--- a/apps/web/src/lib/strapi.ts
+++ b/apps/web/src/lib/strapi.ts
@@ -16,7 +16,7 @@ import { serverEnv } from "@/lib/server-env";
 
 const STRAPI_URL = serverEnv.strapiUrl;
 const STRAPI_API_TOKEN = serverEnv.strapiApiToken;
-const STRAPI_TIMEOUT_MS = 15_000;
+export const STRAPI_TIMEOUT_MS = 15_000;
 const STRAPI_DISABLED = serverEnv.strapiDisabled;
 const DEFAULT_REVALIDATE_SECONDS = 600;
 
@@ -182,26 +182,59 @@ const PAGE_SIZE = 100;
  */
 export const STRAPI_MAX_PAGES = 20;
 
+export interface FetchAllPagesOptions {
+  /** Unix ms. Do not start another page that cannot finish before this instant. */
+  deadlineMs?: number;
+}
+
 /**
  * Walk a collection page by page (caller supplies `sort`), stopping at
  * STRAPI_MAX_PAGES. Truncation is logged rather than silent so a catalog that
  * outgrows the cap shows up in logs instead of quietly dropping sitemap URLs
  * or generateStaticParams entries. Caller pagination is ignored; the helper
  * always requests PAGE_SIZE with withCount.
+ *
+ * A later-page failure returns rows already collected instead of dropping them.
+ * `deadlineMs` skips a further page when remaining time cannot cover
+ * STRAPI_TIMEOUT_MS.
  */
 export async function fetchAllPages<T>(
   fetchPage: (params: FetchAPIParams) => Promise<StrapiCollectionResponse<T>>,
   label: string,
-  params: Omit<FetchAPIParams, "pagination"> = {}
+  params: Omit<FetchAPIParams, "pagination"> = {},
+  options: FetchAllPagesOptions = {}
 ): Promise<T[]> {
   const items: T[] = [];
   let page = 1;
 
   while (true) {
-    const response = await fetchPage({
-      ...params,
-      pagination: { page, pageSize: PAGE_SIZE, withCount: true },
-    });
+    if (
+      page > 1 &&
+      options.deadlineMs != null &&
+      Date.now() + STRAPI_TIMEOUT_MS >= options.deadlineMs
+    ) {
+      console.warn(
+        `[strapi] ${label}: stopping pagination to honor caller deadline; returning ${items.length} row(s)`
+      );
+      break;
+    }
+
+    let response: StrapiCollectionResponse<T>;
+    try {
+      response = await fetchPage({
+        ...params,
+        pagination: { page, pageSize: PAGE_SIZE, withCount: true },
+      });
+    } catch (error) {
+      if (items.length > 0) {
+        console.warn(
+          `[strapi] ${label}: page ${page} failed after ${items.length} row(s); returning partial results`,
+          error
+        );
+        return items;
+      }
+      throw error;
+    }
 
     if (!Array.isArray(response.data)) {
       throw new StrapiRequestError(

--- a/apps/web/tests/sitemap-cms-on.test.ts
+++ b/apps/web/tests/sitemap-cms-on.test.ts
@@ -25,6 +25,8 @@ interface Scenario {
   tags: Row[];
   /** What Strapi claims the article catalog spans, to drive the pagination loop. */
   articlePageCount: number;
+  /** Article pagination[page] that should fail (504), to pin partial results. */
+  failArticlePage?: number;
 }
 
 function emptyScenario(): Scenario {
@@ -74,6 +76,9 @@ globalThis.fetch = (async (input: RequestInfo | URL) => {
 
   switch (url.pathname) {
     case "/api/articles":
+      if (scenario.failArticlePage != null && page === scenario.failArticlePage) {
+        return new Response("gateway timeout", { status: 504, statusText: "Gateway Timeout" });
+      }
       return collection(scenario.articles, scenario.articlePageCount);
     case "/api/authors":
       return collection(scenario.authors, 1);
@@ -189,6 +194,20 @@ test("article pagination stops at STRAPI_MAX_PAGES", async () => {
     articlePages,
     Array.from({ length: 20 }, (_, index) => String(index + 1)),
     "pins STRAPI_MAX_PAGES and pagination[page] serialization — update deliberately if the cap moves"
+  );
+});
+
+test("a later article page failure keeps page-1 URLs instead of dropping the catalog", async () => {
+  const { urls } = await runSitemap({
+    articles: [{ slug: "page-one", updatedAt: "2026-02-02T00:00:00.000Z" }],
+    articlePageCount: 3,
+    failArticlePage: 2,
+  });
+
+  assert.deepEqual(
+    articleUrls(urls),
+    [`${SITE_URL}/blog/page-one`],
+    "page 1 must survive a timeout on page 2 rather than serving a zero-article fallback"
   );
 });
 

--- a/apps/web/tests/strapi-fetch-all-pages.test.ts
+++ b/apps/web/tests/strapi-fetch-all-pages.test.ts
@@ -4,7 +4,9 @@ import assert from "node:assert/strict";
 process.env.DISABLE_STRAPI_CMS = "false";
 process.env.STRAPI_URL = "http://localhost:1337";
 
-const { fetchAllPages, STRAPI_MAX_PAGES } = await import("../src/lib/strapi.ts");
+const { fetchAllPages, STRAPI_MAX_PAGES, STRAPI_TIMEOUT_MS } = await import(
+  "../src/lib/strapi.ts"
+);
 
 test("fetchAllPages stops when Strapi reports no further pages", async () => {
   const pages: number[] = [];
@@ -67,6 +69,56 @@ test("fetchAllPages forces withCount so pageCount is requested", async () => {
   );
 
   assert.equal(withCount, true);
+});
+
+test("fetchAllPages returns earlier pages when a later page fails", async (t) => {
+  const warnings: string[] = [];
+  t.mock.method(console, "warn", (...args: unknown[]) => {
+    warnings.push(String(args[0] ?? ""));
+  });
+
+  const items = await fetchAllPages(
+    async (params) => {
+      const page = params.pagination?.page ?? 0;
+      if (page >= 2) {
+        throw new Error("page 2 timed out");
+      }
+      return {
+        data: [{ id: page, slug: "page-one" }],
+        meta: { pagination: { page, pageSize: 100, pageCount: 3, total: 3 } },
+      };
+    },
+    "articles"
+  );
+
+  assert.deepEqual(items, [{ id: 1, slug: "page-one" }]);
+  assert.match(warnings.join("\n"), /page 2 failed after 1 row\(s\); returning partial results/);
+});
+
+test("fetchAllPages does not start another page that cannot finish before deadlineMs", async (t) => {
+  const pages: number[] = [];
+  const warnings: string[] = [];
+  t.mock.method(console, "warn", (...args: unknown[]) => {
+    warnings.push(String(args[0] ?? ""));
+  });
+
+  const items = await fetchAllPages(
+    async (params) => {
+      const page = params.pagination?.page ?? 0;
+      pages.push(page);
+      return {
+        data: [{ id: page }],
+        meta: { pagination: { page, pageSize: 100, pageCount: 5, total: 5 } },
+      };
+    },
+    "articles",
+    {},
+    { deadlineMs: Date.now() + STRAPI_TIMEOUT_MS - 1 }
+  );
+
+  assert.deepEqual(pages, [1], "page 2 would need a full STRAPI_TIMEOUT_MS and must not start");
+  assert.deepEqual(items, [{ id: 1 }]);
+  assert.match(warnings.join("\n"), /stopping pagination to honor caller deadline/);
 });
 
 test("fetchAllPages rejects non-array collection data", async () => {


### PR DESCRIPTION
Closes #67.

## Why

The 16s sitemap race discarded page-1 articles if page 2 timed out, then cached a zero-post sitemap for up to an hour (`revalidate = 3600`). #58 asked to keep what was fetched.

## What

- `fetchAllPages` returns rows already collected when a later page fails
- `deadlineMs` skips starting a page that cannot finish within `STRAPI_TIMEOUT_MS`
- Sitemap collectors pass `Date.now() + SITEMAP_DEADLINE_MS`
- The isolate `Promise.race` stays as last-resort protection

## Tests

- Unit: later-page failure keeps page 1; deadline skips page 2
- CMS-on: 504 on article page 2 still emits `/blog/page-one`

## Test plan

- [x] `pnpm --filter=web exec tsc --noEmit`
- [x] `pnpm --filter=web test` (156 pass)
- [x] eslint