### PR TITLE
fix(web): keep sitemap locs when image mapping throws

### DIFF
--- a/apps/web/src/app/author/[slug]/page.tsx
+++ b/apps/web/src/app/author/[slug]/page.tsx
@@ -34,7 +34,8 @@ export async function generateStaticParams() {
   try {
     const authors = await getAllAuthors();
     return authors.map((author) => ({ slug: author.slug }));
-  } catch {
+  } catch (error) {
+    console.warn("[author] generateStaticParams: CMS listing failed; skipping static paths", error);
     return [];
   }
 }

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -44,7 +44,8 @@ export async function generateStaticParams() {
     return articles.map((article) => ({
       slug: article.slug,
     }));
-  } catch {
+  } catch (error) {
+    console.warn("[blog] generateStaticParams: CMS listing failed; skipping static paths", error);
     return [];
   }
 }

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -248,18 +248,19 @@ function mapArticlePages(articles: Article[], now: Date): MetadataRoute.Sitemap 
   for (const article of articles) {
     const slug = normalizeSlug(article.slug);
     if (!slug) continue;
+    let imageUrl: string | undefined;
     try {
-      const imageUrl = toAbsoluteMediaUrl(article.featuredImage?.url);
-      pages.push({
-        url: `${SITE_URL}/blog/${slug}`,
-        lastModified: safeDate(article.updatedAt, now),
-        changeFrequency: "weekly",
-        priority: 0.7,
-        images: imageUrl ? [imageUrl] : undefined,
-      });
-    } catch {
-      // Skip a malformed row; do not fail the whole sitemap.
+      imageUrl = toAbsoluteMediaUrl(article.featuredImage?.url);
+    } catch (error) {
+      console.warn(`[sitemap] skipping featuredImage for /blog/${slug}`, error);
     }
+    pages.push({
+      url: `${SITE_URL}/blog/${slug}`,
+      lastModified: safeDate(article.updatedAt, now),
+      changeFrequency: "weekly",
+      priority: 0.7,
+      images: imageUrl ? [imageUrl] : undefined,
+    });
   }
   return pages;
 }
@@ -269,18 +270,19 @@ function mapAuthorPages(authors: Author[], now: Date): MetadataRoute.Sitemap {
   for (const author of authors) {
     const slug = normalizeSlug(author.slug);
     if (!slug) continue;
+    let imageUrl: string | undefined;
     try {
-      const imageUrl = toAbsoluteMediaUrl(author.profileImage?.url);
-      pages.push({
-        url: `${SITE_URL}/author/${slug}`,
-        lastModified: safeDate(author.updatedAt, now),
-        changeFrequency: "monthly",
-        priority: 0.6,
-        images: imageUrl ? [imageUrl] : undefined,
-      });
-    } catch {
-      // Skip a malformed row; do not fail the whole sitemap.
+      imageUrl = toAbsoluteMediaUrl(author.profileImage?.url);
+    } catch (error) {
+      console.warn(`[sitemap] skipping profileImage for /author/${slug}`, error);
     }
+    pages.push({
+      url: `${SITE_URL}/author/${slug}`,
+      lastModified: safeDate(author.updatedAt, now),
+      changeFrequency: "monthly",
+      priority: 0.6,
+      images: imageUrl ? [imageUrl] : undefined,
+    });
   }
   return pages;
 }

--- a/apps/web/tests/sitemap-cms-on.test.ts
+++ b/apps/web/tests/sitemap-cms-on.test.ts
@@ -147,6 +147,22 @@ test("only well-formed article slugs reach the sitemap", async () => {
   );
 });
 
+test("a malformed featuredImage still emits the article loc", async () => {
+  const { entries, urls } = await runSitemap({
+    articles: [
+      {
+        slug: "valid-post",
+        updatedAt: "2026-02-02T00:00:00.000Z",
+        featuredImage: { url: 123 },
+      },
+    ],
+  });
+
+  assert.deepEqual(articleUrls(urls), [`${SITE_URL}/blog/valid-post`]);
+  const post = entries.find((entry) => entry.url === `${SITE_URL}/blog/valid-post`);
+  assert.equal(post?.images, undefined);
+});
+
 test("only well-formed author slugs reach the sitemap, and the fallback covers none", async () => {
   const { urls } = await runSitemap({
     authors: [{ slug: "" }, { slug: "  " }, { slug: 42 }],


### PR DESCRIPTION
Closes #66.

## Why

`mapArticlePages` / `mapAuthorPages` wrapped image URL construction **and** `pages.push` in one try. A malformed `featuredImage.url` dropped the loc with no log. `generateStaticParams` returned `[]` on CMS failure with no deploy-log signal.

## What

- Catch image errors only; still emit the article/author URL
- Log generateStaticParams CMS listing failures

Independent of #67 (partial pagination).

## Tests

- CMS-on: `featuredImage.url: 123` still emits `/blog/valid-post` without `images`

## Test plan

- [x] `pnpm --filter=web exec tsc --noEmit`
- [x] `pnpm --filter=web test` (154 pass)
- [x] eslint