### PR TITLE
test(web): rewrite the motion scanner on the TypeScript AST

### DIFF
--- a/apps/web/src/lib/__fixtures__/motion-variants.ts
+++ b/apps/web/src/lib/__fixtures__/motion-variants.ts
@@ -1,0 +1,14 @@
+// Test fixture, not application code. Nothing under `src/app` or
+// `src/components` imports this, and nothing should: it deliberately contains
+// the zero-opacity initial state that `tests/motion-visibility.test.ts` forbids
+// in real components.
+//
+// It lives under `src/` on purpose. The motion scanner resolves `variants=`
+// bindings through the tsconfig `paths` mapping, and the only way to prove that
+// mapping is really being read is to import this module as a genuine
+// `@/lib/...` specifier. Repoint `"@/*"` in tsconfig.json and the scanner stops
+// resolving it, which turns the alias test red.
+export const aliasCardVariants = {
+  hidden: { opacity: 0 },
+  visible: { opacity: 1 },
+};

--- a/apps/web/tests/fixtures/motion-scanner/broken-syntax.tsx.txt
+++ b/apps/web/tests/fixtures/motion-scanner/broken-syntax.tsx.txt
@@ -1,0 +1,7 @@
+// Deliberately unparseable — the closing brace of the component is missing.
+// Stored as .txt so `tsc --noEmit` does not try to compile it. The scanner
+// reads it by path, so the extension does not change how it is parsed.
+import { motion } from "framer-motion";
+
+export function BrokenButHiding() {
+  return <motion.div initial={{ opacity: 0 }} />;

--- a/apps/web/tests/fixtures/motion-scanner/factory-variants.tsx
+++ b/apps/web/tests/fixtures/motion-scanner/factory-variants.tsx
@@ -1,0 +1,15 @@
+import { motion } from "framer-motion";
+import type { Variants } from "framer-motion";
+
+// A `variants=` binding the scanner cannot inline. The production scan must
+// report it rather than pass, or a real `variants={createVariants(...)}` in a
+// component would ship a hiding initial unseen.
+function createVariants(input: Variants): Variants {
+  return input;
+}
+
+const cardVariants = createVariants({ hidden: { opacity: 0 } });
+
+export function FactoryVariantsFixture() {
+  return <motion.div initial="hidden" variants={cardVariants} />;
+}

--- a/apps/web/tests/fixtures/motion-scanner/uses-alias-import.tsx
+++ b/apps/web/tests/fixtures/motion-scanner/uses-alias-import.tsx
@@ -1,0 +1,9 @@
+import { motion } from "framer-motion";
+// A genuine `@/lib/...` specifier: `@/*` maps to `./src/*`, so the scanner only
+// finds this module by reading the tsconfig `paths` mapping. Repoint `"@/*"`
+// and the hiding variant below stops resolving, which turns the alias test red.
+import { aliasCardVariants } from "@/lib/__fixtures__/motion-variants";
+
+export function AlwaysRenderedAliasImportHide() {
+  return <motion.div initial="hidden" variants={aliasCardVariants} />;
+}

--- a/apps/web/tests/motion-visibility.test.ts
+++ b/apps/web/tests/motion-visibility.test.ts
@@ -1,24 +1,98 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readFileSync, readdirSync, statSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import ts from "typescript";
 
 // Framer Motion inlines the resolved `initial` state as a `style` attribute
 // during SSR. Any initial state that zeroes out opacity, size, or scale is
 // therefore shipped in the HTML, and the content stays hidden until hydration
 // runs. PR #28 removed that pattern from the homepage; these contracts keep it
 // out of the pages #28 did not cover.
+//
+// The scanner below is a TypeScript AST walk. JSX parentage, module resolution
+// and type-only syntax (`as` / `satisfies`) are things the compiler already
+// models, so the scanner asks it instead of re-deriving them from indexes.
+//
+// ---------------------------------------------------------------------------
+// Known, accepted gaps
+// ---------------------------------------------------------------------------
+// This is a heuristic scanner, not a type checker, and it will never be total.
+// The shapes below are known to be unhandled. None of them occurs anywhere in
+// `src/components` today, and each one is cheap to spot in review.
+//
+// THE RULE: a gap on this list becomes actionable only when a real file under
+// `src/components` actually exhibits the shape. Do not open an issue, and do
+// not widen the scanner, for a shape that exists only in a hypothetical. This
+// file has already generated a dozen issues about itself; that is the treadmill
+// this list exists to stop. When a gap does show up in a real component, fix
+// the component first — the scanner second.
+//
+//  - `initial={IDENT}` where IDENT is a string constant (`const NAME = "hidden"`)
+//    resolves to the identifier's *name*, not its value. Direction: misses a
+//    hiding variant. Writing `initial="hidden"` is the idiom everywhere here.
+//  - `findVariableInitializer` is scope-blind and order-dependent: it takes the
+//    first declaration of a name in file order and ignores shadowing. Two
+//    same-named variants objects in one file resolve to the wrong one.
+//  - a non-motion wrapper carrying an `initial=` prop of its own (`<Foo
+//    initial="x">`) re-roots the inheritance chain even though Framer never
+//    sees that prop. Direction: misses an inherited hiding variant.
+//  - the old scanner's `isInsideDir` project-boundary guard is gone.
+//    `ts.resolveModuleName` can follow a path mapping out of the web package.
+//    It only ever *reads* files, and node_modules is still refused.
+//  - `<AnimatePresence initial={false}>` genuinely suppresses the initial state
+//    of its children (verified against 13.1.1); the scanner treats it as
+//    transparent. Direction: false positives only, so it fails closed.
 
-const COMPONENTS_DIR = resolve(process.cwd(), "src/components");
-const SRC_ROOT = resolve(process.cwd(), "src");
+const CWD = process.cwd();
+const COMPONENTS_DIR = resolve(CWD, "src/components");
+
+/** Compiler options from the real tsconfig, so `paths` (`@/*`) resolve. */
+const COMPILER_OPTIONS: ts.CompilerOptions = (() => {
+  const configPath = join(CWD, "tsconfig.json");
+  const { config, error } = ts.readConfigFile(configPath, ts.sys.readFile);
+  if (error) throw new Error(ts.flattenDiagnosticMessageText(error.messageText, "\n"));
+  return ts.parseJsonConfigFileContent(config, ts.sys, CWD).options;
+})();
 
 interface ScanContext {
+  /** Absolute path of the scanned file; imports only resolve when it is set. */
   filePath?: string;
 }
 
-const ZERO_LITERAL = String.raw`(?:0(?:\.0+)?(?![.\d])|["'\`]0(?:px|%|rem|em)?["'\`])`;
+interface InitialState {
+  /** Source text of the object literal Framer would inline during SSR. */
+  text: string;
+  line: number;
+  /** Under `<AnimatePresence>` and behind a condition that can be false in SSR. */
+  exempt: boolean;
+  conditionallyMounted: boolean;
+  underAnimatePresence: boolean;
+}
 
-const HIDING_VALUE = String.raw`(?:${ZERO_LITERAL}|[^,{}]{0,120}\?\s*${ZERO_LITERAL}|[^,{}]{0,120}:\s*${ZERO_LITERAL})`;
+interface MotionScan {
+  states: InitialState[];
+  /** Fail-closed notes pushed where resolution gave up. */
+  offenders: string[];
+}
+
+type JsxTag = ts.JsxOpeningElement | ts.JsxSelfClosingElement;
+
+// ---------------------------------------------------------------------------
+// Hiding values
+// ---------------------------------------------------------------------------
+
+/** `0`, `0.0`, `.0`, and the quoted forms with any CSS length unit. */
+const ZERO_NUMBER = String.raw`(?:0(?:\.0+)?|\.0+)(?![.\d])`;
+
+const ZERO_UNIT = String.raw`(?:px|%|rem|em|ex|ch|vw|vh|vmin|vmax|svw|svh|lvw|lvh|dvw|dvh|cm|mm|in|pt|pc|q)`;
+
+const ZERO_LITERAL = String.raw`(?:${ZERO_NUMBER}|["'\`]${ZERO_NUMBER}${ZERO_UNIT}?["'\`])`;
+
+// A keyframe array animates from its first entry, and that entry is what SSR
+// inlines: `initial={{ opacity: [0, 1] }}` really does ship `opacity:0`.
+// Only the leading value hides; `[1, 0]` renders `opacity:1`.
+const HIDING_VALUE = String.raw`(?:${ZERO_LITERAL}|\[\s*${ZERO_LITERAL}|[^,{}]{0,120}\?\s*${ZERO_LITERAL}|[^,{}]{0,120}:\s*${ZERO_LITERAL})`;
 
 const HIDING_PROPS = [
   { name: "opacity", pattern: new RegExp(String.raw`\bopacity\s*:\s*${HIDING_VALUE}`) },
@@ -28,6 +102,49 @@ const HIDING_PROPS = [
   { name: "visibility", pattern: /\bvisibility\s*:\s*["']hidden["']/ },
 ];
 
+/** Hiding properties named in a chunk of source text. */
+function hidingHits(text: string): string[] {
+  return HIDING_PROPS.filter((prop) => prop.pattern.test(text)).map((prop) => prop.name);
+}
+
+// ---------------------------------------------------------------------------
+// Parsing and module resolution
+// ---------------------------------------------------------------------------
+
+const VIRTUAL_FILE = join(CWD, "__motion-scanner__.tsx");
+const parsedFiles = new Map<string, ts.SourceFile>();
+
+function parseSource(source: string, filePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    filePath,
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    filePath.endsWith(".ts") ? ts.ScriptKind.TS : ts.ScriptKind.TSX
+  );
+}
+
+function parseFile(filePath: string): ts.SourceFile {
+  const cached = parsedFiles.get(filePath);
+  if (cached) return cached;
+  const parsed = parseSource(readFileSync(filePath, "utf8"), filePath);
+  parsedFiles.set(filePath, parsed);
+  return parsed;
+}
+
+/** Project-local file a specifier points at, via the real tsconfig `paths`. */
+function resolveModuleFile(spec: string, containingFile: string): string | null {
+  const { resolvedModule } = ts.resolveModuleName(
+    spec,
+    containingFile,
+    COMPILER_OPTIONS,
+    ts.sys
+  );
+  if (!resolvedModule || resolvedModule.isExternalLibraryImport) return null;
+  const file = resolvedModule.resolvedFileName;
+  return file.includes("/node_modules/") ? null : file;
+}
+
 function listTsxFiles(dir: string): string[] {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
     const full = join(dir, entry.name);
@@ -36,808 +153,556 @@ function listTsxFiles(dir: string): string[] {
   });
 }
 
-function skipWs(source: string, index: number): number {
-  let i = index;
-  while (i < source.length && /\s/.test(source[i] ?? "")) i += 1;
-  return i;
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(CWD, relativePath), "utf8");
 }
 
-/** Index just past a `'`, `"`, or `` ` ``-quoted span starting at `index`. */
-function skipQuoted(source: string, index: number): number {
-  const quote = source[index];
-  let i = index + 1;
-  while (i < source.length && source[i] !== quote) {
-    i += source[i] === "\\" ? 2 : 1;
+// ---------------------------------------------------------------------------
+// Expression helpers
+// ---------------------------------------------------------------------------
+
+/** Strips the wrappers that carry no runtime value: `(x)`, `x as T`, `x satisfies T`, `x!`. */
+function unwrap(expr: ts.Expression): ts.Expression {
+  let current = expr;
+  while (
+    ts.isParenthesizedExpression(current) ||
+    ts.isAsExpression(current) ||
+    ts.isSatisfiesExpression(current) ||
+    ts.isNonNullExpression(current) ||
+    ts.isTypeAssertionExpression(current)
+  ) {
+    current = current.expression;
   }
-  return i < source.length ? i + 1 : i;
+  return current;
 }
 
-/** Index of the opening quote for the quoted span whose closer is `closeIndex`. */
-function skipQuotedBack(source: string, closeIndex: number): number {
-  const quote = source[closeIndex];
-  let i = closeIndex - 1;
-  while (i >= 0) {
-    if (source[i] === quote) {
-      let slashes = 0;
-      let j = i - 1;
-      while (j >= 0 && source[j] === "\\") {
-        slashes += 1;
-        j -= 1;
-      }
-      if (slashes % 2 === 0) return i;
+function isFalseExpression(expr: ts.Expression | undefined): boolean {
+  return expr !== undefined && unwrap(expr).kind === ts.SyntaxKind.FalseKeyword;
+}
+
+/** Every `const`/`let`/`var` initializer bound to `name`, anywhere in the file. */
+function findVariableInitializer(source: ts.SourceFile, name: string): ts.Expression | null {
+  const matches: ts.Expression[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === name &&
+      node.initializer
+    ) {
+      matches.push(node.initializer);
     }
-    i -= 1;
-  }
-  return 0;
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+  return matches[0] ?? null;
 }
 
-/** Expression immediately before `&&` or `?`, starting after the nearest `{`. */
-function readExpressionBefore(source: string, opIndex: number): string {
-  let end = opIndex;
-  while (end > 0 && /\s/.test(source[end - 1] ?? "")) end -= 1;
+function asObjectLiteral(expr: ts.Expression | null): ts.ObjectLiteralExpression | null {
+  if (!expr) return null;
+  const target = unwrap(expr);
+  return ts.isObjectLiteralExpression(target) ? target : null;
+}
 
-  let i = end - 1;
-  let paren = 0;
-  let brace = 0;
-  let bracket = 0;
+interface ImportBinding {
+  spec: string;
+  exportedName: string;
+}
 
-  while (i >= 0) {
-    const ch = source[i];
-    if (ch === "'" || ch === '"' || ch === "`") {
-      i = skipQuotedBack(source, i) - 1;
+function findImportBinding(source: ts.SourceFile, name: string): ImportBinding | null {
+  for (const statement of source.statements) {
+    if (!ts.isImportDeclaration(statement) || !statement.importClause) continue;
+    const clause = statement.importClause;
+    if (clause.isTypeOnly || !ts.isStringLiteral(statement.moduleSpecifier)) continue;
+    const spec = statement.moduleSpecifier.text;
+
+    if (clause.name && clause.name.text === name) return { spec, exportedName: "default" };
+
+    const bindings = clause.namedBindings;
+    if (!bindings || !ts.isNamedImports(bindings)) continue;
+    for (const element of bindings.elements) {
+      if (element.isTypeOnly || element.name.text !== name) continue;
+      return { spec, exportedName: element.propertyName?.text ?? name };
+    }
+  }
+  return null;
+}
+
+function findDefaultExportObject(source: ts.SourceFile): ts.ObjectLiteralExpression | null {
+  for (const statement of source.statements) {
+    if (!ts.isExportAssignment(statement) || statement.isExportEquals) continue;
+    const target = unwrap(statement.expression);
+    if (ts.isObjectLiteralExpression(target)) return target;
+    if (ts.isIdentifier(target)) return asObjectLiteral(findVariableInitializer(source, target.text));
+  }
+  return null;
+}
+
+/**
+ * The object literal `name` is bound to, following one import hop. `null` means
+ * "cannot prove what this is" — callers must fail closed on it.
+ */
+function resolveVariantsObject(
+  source: ts.SourceFile,
+  name: string,
+  ctx?: ScanContext
+): ts.ObjectLiteralExpression | null {
+  const local = findVariableInitializer(source, name);
+  if (local) return asObjectLiteral(local);
+
+  if (!ctx?.filePath) return null;
+  const binding = findImportBinding(source, name);
+  if (!binding) return null;
+  const modulePath = resolveModuleFile(binding.spec, ctx.filePath);
+  if (!modulePath) return null;
+
+  const imported = parseFile(modulePath);
+  if (binding.exportedName === "default") return findDefaultExportObject(imported);
+  return asObjectLiteral(findVariableInitializer(imported, binding.exportedName));
+}
+
+// ---------------------------------------------------------------------------
+// JSX helpers
+// ---------------------------------------------------------------------------
+
+function tagName(tag: JsxTag): string {
+  return tag.tagName.getText(tag.getSourceFile());
+}
+
+function getAttribute(tag: JsxTag, name: string): ts.JsxAttribute | null {
+  for (const property of tag.attributes.properties) {
+    if (!ts.isJsxAttribute(property)) continue;
+    if (ts.isIdentifier(property.name) && property.name.text === name) return property;
+  }
+  return null;
+}
+
+/** The attribute value as an expression. `undefined` for a bare `foo` / `foo="s"`. */
+function attributeExpression(attr: ts.JsxAttribute): ts.Expression | undefined {
+  const initializer = attr.initializer;
+  if (!initializer) return undefined;
+  if (ts.isStringLiteral(initializer)) return initializer;
+  return ts.isJsxExpression(initializer) ? initializer.expression : undefined;
+}
+
+/** The JSX node whose `.parent` chain leads out of this element. */
+function elementNode(tag: JsxTag): ts.Node {
+  return ts.isJsxOpeningElement(tag) ? tag.parent : tag;
+}
+
+function* ancestorTags(tag: JsxTag): Generator<JsxTag> {
+  let node: ts.Node | undefined = elementNode(tag).parent;
+  while (node) {
+    if (ts.isJsxElement(node)) yield node.openingElement;
+    else if (ts.isJsxSelfClosingElement(node)) yield node;
+    node = node.parent;
+  }
+}
+
+function optsOutOfInherit(tag: JsxTag): boolean {
+  const attr = getAttribute(tag, "inherit");
+  return attr !== null && isFalseExpression(attributeExpression(attr));
+}
+
+// ---------------------------------------------------------------------------
+// `initial` semantics
+// ---------------------------------------------------------------------------
+
+type InitialSpec =
+  /** No `initial` prop: whatever an ancestor resolves applies. */
+  | { kind: "absent" }
+  /** `initial={false}`: this element renders its animate state. */
+  | { kind: "off" }
+  /** `initial={{ ... }}` or an identifier bound to an object literal. */
+  | { kind: "object"; object: ts.ObjectLiteralExpression }
+  /** `initial="hidden"`, `initial={cond ? "a" : "b"}`, `initial={name}`. */
+  | { kind: "names"; names: string[] };
+
+function stringLiteralsIn(expr: ts.Expression): string[] {
+  const names: string[] = [];
+  const visit = (node: ts.Node): void => {
+    if (ts.isTypeNode(node)) return;
+    if (ts.isStringLiteralLike(node)) names.push(node.text);
+    ts.forEachChild(node, visit);
+  };
+  visit(expr);
+  return names;
+}
+
+function initialSpec(tag: JsxTag, source: ts.SourceFile): InitialSpec {
+  const attr = getAttribute(tag, "initial");
+  if (!attr) return { kind: "absent" };
+  const expr = attributeExpression(attr);
+  if (!expr) return { kind: "absent" };
+  if (isFalseExpression(expr)) return { kind: "off" };
+
+  const target = unwrap(expr);
+  if (ts.isObjectLiteralExpression(target)) return { kind: "object", object: target };
+  if (ts.isIdentifier(target)) {
+    if (target.text === "undefined") return { kind: "names", names: [] };
+    const bound = asObjectLiteral(findVariableInitializer(source, target.text));
+    if (bound) return { kind: "object", object: bound };
+    return { kind: "names", names: [target.text] };
+  }
+  return { kind: "names", names: stringLiteralsIn(target) };
+}
+
+/**
+ * Variant names Framer resolves for this element during SSR.
+ *
+ * Verified against framer-motion 13.1.1 with `renderToStaticMarkup`:
+ *
+ *  - `inherit={false}` gates only state arriving from an ancestor. The
+ *    element's own `initial="hidden"` still applies — and still propagates to
+ *    its own descendants, so the element becomes a new root of the chain.
+ *  - `initial={false}` on an intermediate wrapper does NOT stop a descendant
+ *    from inheriting the ancestor's hidden state. Only on the element itself
+ *    does it opt that element out.
+ *  - the nearest ancestor that names a variant wins; wrappers with no `initial`
+ *    of their own, motion or not, are transparent.
+ */
+function ssrVariantNames(tag: JsxTag, source: ts.SourceFile): string[] {
+  const own = initialSpec(tag, source);
+  // The element's own `initial` outranks everything, `inherit` included.
+  if (own.kind === "off" || own.kind === "object") return [];
+  // An `initial` the scanner cannot read a name out of (`initial={props.state}`)
+  // is not proof the element overrode anything, so keep walking.
+  if (own.kind === "names" && own.names.length > 0) return own.names;
+  if (optsOutOfInherit(tag)) return [];
+
+  for (const ancestor of ancestorTags(tag)) {
+    const spec = initialSpec(ancestor, source);
+    // `off` and `object` wrappers are transparent: they neither supply a name
+    // nor stop the ancestor's name from reaching this element.
+    if (spec.kind === "names" && spec.names.length > 0) return spec.names;
+    // A wrapper that supplied no name of its own and refuses inherited state
+    // is where the chain ends.
+    if (optsOutOfInherit(ancestor)) return [];
+  }
+  return [];
+}
+
+function propertyKey(property: ts.ObjectLiteralElementLike): string | null {
+  const name = property.name;
+  if (!name) return null;
+  if (ts.isIdentifier(name) || ts.isStringLiteralLike(name)) return name.text;
+  if (ts.isComputedPropertyName(name) && ts.isStringLiteralLike(name.expression)) {
+    return name.expression.text;
+  }
+  return null;
+}
+
+/** Reporter for anything the scanner refuses to guess about. */
+type Report = (description: string) => void;
+
+/**
+ * Properties of an object literal with `...spread` sources folded in. A spread
+ * the scanner cannot resolve to a literal hides an unknown set of keys, so it
+ * is reported and the caller keeps whatever it could see.
+ */
+function flattenProperties(
+  object: ts.ObjectLiteralExpression,
+  source: ts.SourceFile,
+  ctx: ScanContext | undefined,
+  report: Report,
+  seen = new Set<ts.Node>()
+): ts.ObjectLiteralElementLike[] {
+  if (seen.has(object)) return [];
+  seen.add(object);
+
+  const properties: ts.ObjectLiteralElementLike[] = [];
+  for (const property of object.properties) {
+    if (!ts.isSpreadAssignment(property)) {
+      properties.push(property);
       continue;
     }
-    if (ch === ")") paren += 1;
-    else if (ch === "]") bracket += 1;
-    else if (ch === "}") brace += 1;
-    else if (ch === "(") {
-      if (paren === 0) break;
-      paren -= 1;
-    } else if (ch === "[") {
-      if (bracket === 0) break;
-      bracket -= 1;
-    } else if (ch === "{") {
-      if (brace === 0 && paren === 0 && bracket === 0) {
-        return source.slice(i + 1, end).trim();
-      }
-      brace -= 1;
+    const spread = unwrap(property.expression);
+    const resolved = ts.isObjectLiteralExpression(spread)
+      ? spread
+      : ts.isIdentifier(spread)
+        ? resolveVariantsObject(source, spread.text, ctx)
+        : null;
+    if (!resolved) {
+      report(`unresolved spread {...${spread.getText(spread.getSourceFile())}}`);
+      continue;
     }
-    i -= 1;
+    properties.push(...flattenProperties(resolved, source, ctx, report, seen));
+  }
+  return properties;
+}
+
+/**
+ * Source text Framer would inline for one variant object: its own text plus the
+ * text of every spread it pulls in, so `hidden: { ...hiddenStyles }` is scanned
+ * rather than skipped. Spreads it cannot follow are reported.
+ */
+function variantText(
+  object: ts.ObjectLiteralExpression,
+  source: ts.SourceFile,
+  ctx: ScanContext | undefined,
+  report: Report
+): string {
+  const parts = [object.getText(object.getSourceFile())];
+  const seen = new Set<ts.Node>([object]);
+
+  const visit = (current: ts.ObjectLiteralExpression): void => {
+    for (const property of current.properties) {
+      if (ts.isSpreadAssignment(property)) {
+        const spread = unwrap(property.expression);
+        const resolved = ts.isObjectLiteralExpression(spread)
+          ? spread
+          : ts.isIdentifier(spread)
+            ? resolveVariantsObject(source, spread.text, ctx)
+            : null;
+        if (!resolved) {
+          report(`unresolved spread {...${spread.getText(spread.getSourceFile())}}`);
+          continue;
+        }
+        if (seen.has(resolved)) continue;
+        seen.add(resolved);
+        parts.push(resolved.getText(resolved.getSourceFile()));
+        visit(resolved);
+        continue;
+      }
+      if (!ts.isPropertyAssignment(property)) continue;
+      const value = unwrap(property.initializer);
+      if (ts.isObjectLiteralExpression(value) && !seen.has(value)) {
+        seen.add(value);
+        visit(value);
+      }
+    }
+  };
+
+  visit(object);
+  return parts.join(" ");
+}
+
+/** Object literals a variant key resolves to, including `name: () => ({ ... })`. */
+function variantObjectsFor(
+  variants: ts.ObjectLiteralExpression,
+  name: string,
+  source: ts.SourceFile,
+  ctx: ScanContext | undefined,
+  report: Report
+): ts.ObjectLiteralExpression[] {
+  const objects: ts.ObjectLiteralExpression[] = [];
+  for (const property of flattenProperties(variants, source, ctx, report)) {
+    if (!ts.isPropertyAssignment(property) || propertyKey(property) !== name) continue;
+    const value = unwrap(property.initializer);
+    if (ts.isObjectLiteralExpression(value)) {
+      objects.push(value);
+      continue;
+    }
+    if (
+      (ts.isArrowFunction(value) || ts.isFunctionExpression(value)) &&
+      !ts.isBlock(value.body)
+    ) {
+      const returned = unwrap(value.body);
+      if (ts.isObjectLiteralExpression(returned)) objects.push(returned);
+      else report(`unresolved variant ${name}: ${value.getText(value.getSourceFile())}`);
+      continue;
+    }
+    report(`unresolved variant ${name}: ${value.getText(value.getSourceFile())}`);
+  }
+  return objects;
+}
+
+/**
+ * Objects a `variants=` expression resolves to. Anything the scanner cannot
+ * prove is reported through `onUnresolved` so the scan fails closed.
+ */
+function variantsObjectsFromExpression(
+  expr: ts.Expression,
+  source: ts.SourceFile,
+  ctx: ScanContext | undefined,
+  onUnresolved: (description: string) => void
+): ts.ObjectLiteralExpression[] {
+  const target = unwrap(expr);
+
+  if (ts.isObjectLiteralExpression(target)) return [target];
+
+  if (ts.isIdentifier(target)) {
+    const resolved = resolveVariantsObject(source, target.text, ctx);
+    if (resolved) return [resolved];
+    onUnresolved(target.text);
+    return [];
   }
 
-  return source.slice(Math.max(0, i + 1), end).trim();
+  if (ts.isConditionalExpression(target)) {
+    return [
+      ...variantsObjectsFromExpression(target.whenTrue, source, ctx, onUnresolved),
+      ...variantsObjectsFromExpression(target.whenFalse, source, ctx, onUnresolved),
+    ];
+  }
+
+  onUnresolved(target.getText(source));
+  return [];
 }
+
+// ---------------------------------------------------------------------------
+// Conditional mounts
+// ---------------------------------------------------------------------------
 
 function conditionLooksLikeSsrCollection(condition: string): boolean {
   return /\.length\b|\.size\b|Object\.keys\s*\(|Array\.isArray\s*\(/.test(condition);
 }
 
-/** Returns the balanced `open...close` slice starting at `openIndex`. */
-function readBalanced(source: string, openIndex: number, open: string, close: string): string {
-  let depth = 0;
-
-  for (let i = openIndex; i < source.length; i += 1) {
-    const char = source[i];
-    if (char === "'" || char === '"' || char === "`") {
-      i = skipQuoted(source, i) - 1;
-      continue;
-    }
-    if (char === open) {
-      depth += 1;
-    } else if (char === close) {
-      depth -= 1;
-      if (depth === 0) return source.slice(openIndex, i + 1);
-    }
-  }
-
-  throw new Error(`unbalanced ${open}...${close} starting at index ${openIndex}`);
-}
-
-/** Index of the next `:` not nested in `()`, `{}`, `[]`, or quotes. */
-function findTopLevelColon(source: string, start: number): number {
-  let paren = 0;
-  let brace = 0;
-  let bracket = 0;
-
-  for (let i = start; i < source.length; i += 1) {
-    const ch = source[i];
-    if (ch === "'" || ch === '"' || ch === "`") {
-      i = skipQuoted(source, i) - 1;
-      continue;
-    }
-    if (ch === "(") paren += 1;
-    else if (ch === ")") paren -= 1;
-    else if (ch === "{") brace += 1;
-    else if (ch === "}") brace -= 1;
-    else if (ch === "[") bracket += 1;
-    else if (ch === "]") bracket -= 1;
-    else if (ch === ":" && paren === 0 && brace === 0 && bracket === 0) return i;
-    else if (ch === ";" && paren === 0 && brace === 0 && bracket === 0) return -1;
-  }
-
-  return -1;
-}
-
-function escapeRegExp(value: string): string {
-  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+interface MountContext {
+  conditionallyMounted: boolean;
+  underAnimatePresence: boolean;
+  exempt: boolean;
 }
 
 /**
- * Slice of one JSX element starting at `<`, including a matching close tag
- * or a self-closing `/>`. Attribute expressions `{...}` are skipped so nested
- * braces do not look like tag delimiters.
+ * Whether this element is absent from SSR markup: it must sit under
+ * `<AnimatePresence>` and inside a `{cond && ...}` / ternary branch whose
+ * condition is not a collection check that is already true on the server.
  */
-function readJsxElement(source: string, ltIndex: number): string {
-  if (source[ltIndex] !== "<") {
-    throw new Error(`expected JSX '<' at index ${ltIndex}`);
-  }
-  if (source.startsWith("</", ltIndex)) {
-    throw new Error(`expected opening JSX tag at index ${ltIndex}`);
-  }
+function mountContext(tag: JsxTag, source: ts.SourceFile): MountContext {
+  const conditions: string[] = [];
+  let underAnimatePresence = false;
 
-  const isFragment = source.startsWith("<>", ltIndex);
-  const nameMatch = isFragment ? null : /^[A-Za-z][\w.-]*/.exec(source.slice(ltIndex + 1));
-  if (!isFragment && !nameMatch) {
-    throw new Error(`expected JSX tag name at index ${ltIndex}`);
-  }
+  let child: ts.Node = elementNode(tag);
+  let node: ts.Node | undefined = child.parent;
 
-  const tagName = isFragment ? "" : nameMatch![0];
-  let i = ltIndex + (isFragment ? 2 : 1 + tagName.length);
-
-  const skipExpr = () => {
-    const expr = readBalanced(source, i, "{", "}");
-    i += expr.length;
-  };
-
-  if (!isFragment) {
-    while (i < source.length) {
-      const ch = source[i];
-      if (ch === "{") {
-        skipExpr();
-        continue;
-      }
-      if (ch === "'" || ch === '"' || ch === "`") {
-        i = skipQuoted(source, i);
-        continue;
-      }
-      if (source.startsWith("/>", i)) {
-        return source.slice(ltIndex, i + 2);
-      }
-      if (ch === ">") {
-        i += 1;
-        break;
-      }
-      i += 1;
+  while (node) {
+    if (ts.isJsxElement(node) && tagName(node.openingElement) === "AnimatePresence") {
+      underAnimatePresence = true;
     }
-  }
-
-  const close = isFragment ? "</>" : `</${tagName}>`;
-  const nestedOpen = isFragment ? "<>" : `<${tagName}`;
-  let depth = 1;
-
-  while (i < source.length && depth > 0) {
-    if (source[i] === "{") {
-      skipExpr();
-      continue;
-    }
-    if (source.startsWith(close, i)) {
-      depth -= 1;
-      if (depth === 0) return source.slice(ltIndex, i + close.length);
-      i += close.length;
-      continue;
-    }
-    if (isFragment) {
-      if (source.startsWith("<>", i)) {
-        const nested = readJsxElement(source, i);
-        i += nested.length;
-        continue;
-      }
-    } else if (
-      source.startsWith(nestedOpen, i) &&
-      /[\s>/]/.test(source[i + nestedOpen.length] ?? "")
+    if (
+      ts.isBinaryExpression(node) &&
+      node.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken &&
+      node.right === child
     ) {
-      const nested = readJsxElement(source, i);
-      i += nested.length;
-      continue;
+      conditions.push(node.left.getText(source));
     }
-    i += 1;
-  }
-
-  throw new Error(`unclosed JSX <${tagName || ""}> starting at index ${ltIndex}`);
-}
-
-interface InitialState {
-  text: string;
-  index: number;
-}
-
-const NON_VARIANT_INITIAL = new Set(["false", "true", "null", "undefined"]);
-
-function collectStringNames(text: string): string[] {
-  return [...text.matchAll(/(["'`])(\w+)\1/g)].map((match) => match[2]);
-}
-
-function collectInitialVariantNames(source: string): Set<string> {
-  const names = new Set<string>();
-
-  for (const match of source.matchAll(/initial\s*=\s*(["'`])(\w+)\1/g)) {
-    names.add(match[2]);
-  }
-
-  for (const match of source.matchAll(/initial\s*=\s*\{/g)) {
-    const exprBrace = match.index + match[0].lastIndexOf("{");
-    const inner = skipWs(source, exprBrace + 1);
-    // Inline `initial={{ ... }}` objects can contain string values that are
-    // not variant names (`content: "hidden"`). Only mine names from
-    // expression forms such as `initial={reduced ? "hidden" : "visible"}`.
-    if (source[inner] === "{") continue;
-    const expr = readBalanced(source, exprBrace, "{", "}");
-    for (const name of collectStringNames(expr)) names.add(name);
-  }
-
-  // `initial={start}` names the variants key `start`. Skip `false`/`true` so
-  // `<AnimatePresence initial={false}>` does not search for `false: {`.
-  for (const match of source.matchAll(/initial\s*=\s*\{\s*([A-Za-z_$][\w$]*)\s*\}/g)) {
-    if (!NON_VARIANT_INITIAL.has(match[1])) names.add(match[1]);
-  }
-
-  return names;
-}
-
-function findSameFileObjectLiteral(source: string, ident: string): string | null {
-  if (!/^[A-Za-z_$][\w$]*$/.test(ident)) return null;
-  const pattern = new RegExp(
-    String.raw`\b(?:export\s+)?(?:const|let|var)\s+${escapeRegExp(ident)}(?:\s*:[^=;{]+)?\s*=\s*\{`
-  );
-  const match = pattern.exec(source);
-  if (!match) return null;
-  const braceIndex = source.indexOf("{", match.index + match[0].length - 1);
-  return readBalanced(source, braceIndex, "{", "}");
-}
-
-function isExistingFile(path: string): boolean {
-  try {
-    return existsSync(path) && statSync(path).isFile();
-  } catch {
-    return false;
-  }
-}
-
-function isInsideDir(filePath: string, root: string): boolean {
-  const resolved = resolve(filePath);
-  const resolvedRoot = resolve(root);
-  return resolved === resolvedRoot || resolved.startsWith(`${resolvedRoot}/`);
-}
-
-function resolveImportedModule(fromFile: string, spec: string): string | null {
-  if (!(spec.startsWith(".") || spec.startsWith("@/"))) return null;
-  const base = spec.startsWith("@/")
-    ? join(SRC_ROOT, spec.slice(2))
-    : resolve(dirname(fromFile), spec);
-  for (const candidate of [
-    base,
-    `${base}.ts`,
-    `${base}.tsx`,
-    join(base, "index.ts"),
-    join(base, "index.tsx"),
-  ]) {
-    if (!isInsideDir(candidate, process.cwd())) continue;
-    if (isExistingFile(candidate)) return candidate;
-  }
-  return null;
-}
-
-function findImportBinding(
-  source: string,
-  ident: string
-): { spec: string; exportedName: string } | null {
-  for (const match of source.matchAll(
-    /(?:^|\n)\s*import\s+(type\s+)?(?:[A-Za-z_$][\w$]*\s*,\s*)?\{([^}]*)\}\s+from\s+(['"])([^'"]+)\3/g
-  )) {
-    if (match[1]) continue;
-    const spec = match[4];
-    for (const raw of match[2].split(",")) {
-      const part = raw.trim();
-      if (!part || part.startsWith("type ")) continue;
-      const aliased = /^([A-Za-z_$][\w$]*)\s+as\s+([A-Za-z_$][\w$]*)$/.exec(part);
-      if (aliased && aliased[2] === ident) return { spec, exportedName: aliased[1] };
-      if (part === ident) return { spec, exportedName: ident };
+    if (
+      ts.isConditionalExpression(node) &&
+      (node.whenTrue === child || node.whenFalse === child)
+    ) {
+      conditions.push(node.condition.getText(source));
     }
+    child = node;
+    node = node.parent;
   }
 
-  const defaultImport = new RegExp(
-    String.raw`(?:^|\n)\s*import\s+(?!type\s)${escapeRegExp(ident)}\s+from\s+(['"])([^'"]+)\1`
-  ).exec(source);
-  if (defaultImport) return { spec: defaultImport[2], exportedName: "default" };
-
-  return null;
+  const conditionallyMounted = conditions.length > 0;
+  return {
+    conditionallyMounted,
+    underAnimatePresence,
+    exempt:
+      conditionallyMounted &&
+      underAnimatePresence &&
+      !conditions.some(conditionLooksLikeSsrCollection),
+  };
 }
 
-function findDefaultExportObjectLiteral(source: string): string | null {
-  const literal = /export\s+default\s+\{/.exec(source);
-  if (literal) {
-    const braceIndex = source.indexOf("{", literal.index);
-    return readBalanced(source, braceIndex, "{", "}");
-  }
-  const ident = /export\s+default\s+([A-Za-z_$][\w$]*)/.exec(source);
-  if (!ident) return null;
-  return findSameFileObjectLiteral(source, ident[1]);
+// ---------------------------------------------------------------------------
+// The scan
+// ---------------------------------------------------------------------------
+
+/**
+ * Tags whose props Framer reads. Anything unresolvable on one of these is an
+ * offender; the same shape on a plain `<div>` is nobody's business.
+ */
+function isMotionTag(tag: JsxTag): boolean {
+  const name = tagName(tag);
+  return name.startsWith("motion.") || name === "AnimatePresence";
 }
 
-function findImportedObjectLiteral(
-  source: string,
-  ident: string,
-  fromFile: string
-): string | null {
-  const binding = findImportBinding(source, ident);
-  if (!binding) return null;
-  const modulePath = resolveImportedModule(fromFile, binding.spec);
-  if (!modulePath) return null;
-  const imported = readFileSync(modulePath, "utf8");
-  if (binding.exportedName === "default") return findDefaultExportObjectLiteral(imported);
-  return findSameFileObjectLiteral(imported, binding.exportedName);
-}
-
-function resolveVariantsObject(
-  source: string,
-  ident: string,
-  ctx?: ScanContext
-): string | null {
-  const local = findSameFileObjectLiteral(source, ident);
-  if (local) return local;
-  if (!ctx?.filePath) return null;
-  return findImportedObjectLiteral(source, ident, ctx.filePath);
-}
-
-function collectNamedVariantObjects(source: string, name: string): InitialState[] {
+function scanSource(source: string, ctx?: ScanContext): MotionScan {
+  const parsed = parseSource(source, ctx?.filePath ?? VIRTUAL_FILE);
   const states: InitialState[] = [];
-  const identKey = new RegExp(String.raw`\b${escapeRegExp(name)}\s*:\s*\{`, "g");
-  const computedKey = new RegExp(
-    String.raw`\[\s*(["'\`])${escapeRegExp(name)}\1\s*\]\s*:\s*\{`,
-    "g"
-  );
+  const offenders: string[] = [];
 
-  for (const pattern of [identKey, computedKey]) {
-    for (const match of source.matchAll(pattern)) {
-      const braceIndex = source.indexOf("{", match.index + match[0].length - 1);
-      states.push({
-        text: readBalanced(source, braceIndex, "{", "}"),
-        index: match.index,
-      });
-    }
-  }
+  const lineOf = (node: ts.Node) =>
+    parsed.getLineAndCharacterOfPosition(node.getStart(parsed)).line + 1;
 
-  return states;
-}
+  // One `variants=` binding is walked once per applicable variant name, so the
+  // same unreadable spread can surface more than once. Report it once.
+  const reporter =
+    (node: ts.Node): Report =>
+    (description) => {
+      const message = `line ${lineOf(node)}: ${description}`;
+      if (!offenders.includes(message)) offenders.push(message);
+    };
 
-/**
- * Index of the `<` that opens the JSX tag containing `attrIndex`.
- * `-1` if this `variants=` is not on a tag (`const variants = {` at module scope).
- */
-function findJsxTagStart(source: string, attrIndex: number): number {
-  let i = attrIndex - 1;
-  let brace = 0;
-
-  while (i >= 0) {
-    const ch = source[i];
-    if (ch === "'" || ch === '"' || ch === "`") {
-      i = skipQuotedBack(source, i) - 1;
-      continue;
-    }
-    if (ch === "}") brace += 1;
-    else if (ch === "{") {
-      if (brace > 0) brace -= 1;
-    } else if (ch === "<" && brace === 0 && !source.startsWith("</", i)) {
-      return i;
-    }
-    i -= 1;
-  }
-
-  return -1;
-}
-
-function findOpeningTagEnd(source: string, ltIndex: number): number {
-  let i = ltIndex + 1;
-  while (i < source.length) {
-    if (source[i] === "{") {
-      const expr = readBalanced(source, i, "{", "}");
-      i += expr.length;
-      continue;
-    }
-    if (source[i] === "'" || source[i] === '"' || source[i] === "`") {
-      i = skipQuoted(source, i);
-      continue;
-    }
-    if (source.startsWith("/>", i)) return i + 2;
-    if (source[i] === ">") return i + 1;
-    i += 1;
-  }
-  return source.length;
-}
-
-const VARIANT_EXPR_KEYWORDS = new Set([
-  "as",
-  "satisfies",
-  "typeof",
-  "new",
-  "void",
-  "await",
-  "const",
-  "let",
-  "var",
-]);
-
-function collectIdentNamesFromExpr(expr: string): string[] {
-  const names: string[] = [];
-  const tokens = [...expr.matchAll(/[A-Za-z_$][\w$]*/g)];
-  for (let i = 0; i < tokens.length; i += 1) {
-    const name = tokens[i][0];
-    if (NON_VARIANT_INITIAL.has(name) || VARIANT_EXPR_KEYWORDS.has(name)) continue;
-    const prev = i > 0 ? tokens[i - 1][0] : "";
-    if (prev === "as" || prev === "satisfies") continue;
-    names.push(name);
-  }
-  return names;
-}
-
-interface VariantsBinding {
-  objectText: string;
-  elementStart: number;
-  openingTagEnd: number;
-}
-
-/**
- * Every `variants={ident}` / `variants={{ ... }}` object in the file, tied to
- * the JSX element that carries the attribute.
- */
-function collectVariantsBindings(
-  source: string,
-  ctx?: ScanContext
-): { bindings: VariantsBinding[]; unresolved: string[] } {
-  const bindings: VariantsBinding[] = [];
-  const unresolved: string[] = [];
-
-  for (const match of source.matchAll(/variants\s*=\s*\{/g)) {
-    const elementStart = findJsxTagStart(source, match.index);
-    if (elementStart < 0) continue;
-    const openingTagEnd = findOpeningTagEnd(source, elementStart);
-    if (match.index >= openingTagEnd) continue;
-
-    const exprBrace = match.index + match[0].lastIndexOf("{");
-    const inner = skipWs(source, exprBrace + 1);
-    const objectTexts: string[] = [];
-
-    if (source[inner] === "{") {
-      objectTexts.push(readBalanced(source, exprBrace, "{", "}"));
-    } else {
-      const expr = readBalanced(source, exprBrace, "{", "}");
-      for (const ident of collectIdentNamesFromExpr(expr)) {
-        const obj = resolveVariantsObject(source, ident, ctx);
-        if (obj) objectTexts.push(obj);
-        else unresolved.push(ident);
-      }
-    }
-
-    for (const objectText of objectTexts) {
-      bindings.push({ objectText, elementStart, openingTagEnd });
-    }
-  }
-
-  return { bindings, unresolved };
-}
-
-/** File index of `initial=` on this opening tag that names `name`, if any. */
-function findInitialUsageIndexInTag(
-  source: string,
-  ltIndex: number,
-  openingTagEnd: number,
-  name: string
-): number | null {
-  const tag = source.slice(ltIndex, openingTagEnd);
-
-  for (const match of tag.matchAll(/initial\s*=\s*(["'`])(\w+)\1/g)) {
-    if (match[2] === name && match.index !== undefined) return ltIndex + match.index;
-  }
-
-  for (const match of tag.matchAll(/initial\s*=\s*\{/g)) {
-    if (match.index === undefined) continue;
-    const exprBrace = match.index + match[0].lastIndexOf("{");
-    const absBrace = ltIndex + exprBrace;
-    const inner = skipWs(source, absBrace + 1);
-    if (source[inner] === "{") continue;
-    const expr = readBalanced(source, absBrace, "{", "}");
-    if (collectStringNames(expr).includes(name)) return ltIndex + match.index;
-    const identMatch = /^\{\s*([A-Za-z_$][\w$]*)\s*\}$/.exec(expr);
-    if (identMatch && identMatch[1] === name && !NON_VARIANT_INITIAL.has(name)) {
-      return ltIndex + match.index;
-    }
-  }
-
-  return null;
-}
-
-function tryJsxElementEnd(source: string, ltIndex: number): number {
-  try {
-    return ltIndex + readJsxElement(source, ltIndex).length;
-  } catch {
-    return findOpeningTagEnd(source, ltIndex);
-  }
-}
-
-function collectInitialNameTagStarts(source: string, name: string): number[] {
-  const starts: number[] = [];
-  for (const match of source.matchAll(/initial\s*=/g)) {
-    const tagStart = findJsxTagStart(source, match.index);
-    if (tagStart < 0) continue;
-    const openingTagEnd = findOpeningTagEnd(source, tagStart);
-    if (findInitialUsageIndexInTag(source, tagStart, openingTagEnd, name) != null) {
-      starts.push(tagStart);
-    }
-  }
-  return [...new Set(starts)];
-}
-
-function tagOptsOutOfVariantInherit(
-  source: string,
-  ltIndex: number,
-  openingTagEnd: number
-): boolean {
-  const tag = source.slice(ltIndex, openingTagEnd);
-  return (
-    /\binherit\s*=\s*\{\s*false\s*\}/.test(tag) || /\binitial\s*=\s*\{\s*false\s*\}/.test(tag)
-  );
-}
-
-function namedVariantUsageIndex(
-  source: string,
-  binding: VariantsBinding,
-  name: string,
-  nameTagStarts: number[]
-): number | null {
-  const ownUsage = findInitialUsageIndexInTag(
-    source,
-    binding.elementStart,
-    binding.openingTagEnd,
-    name
-  );
-  if (ownUsage != null) return ownUsage;
-  if (tagOptsOutOfVariantInherit(source, binding.elementStart, binding.openingTagEnd)) {
-    return null;
-  }
-  for (const start of nameTagStarts) {
-    if (start === binding.elementStart) continue;
-    const end = tryJsxElementEnd(source, start);
-    if (binding.elementStart > start && binding.elementStart < end) {
-      return binding.elementStart;
-    }
-  }
-  return null;
-}
-
-/**
- * Every initial state a motion element can resolve during SSR: an inline
- * `initial={{ ... }}` object, a same-file `initial={ident}` object, and
- * named variant objects from a `variants=` binding referenced by
- * `initial="name"` on this element or an ancestor (stagger children).
- * Exemption is keyed at the `initial=` usage when that tag names the
- * variant; otherwise at the `variants=` element.
- */
-function collectInitialStates(source: string, ctx?: ScanContext): InitialState[] {
-  const states: InitialState[] = [];
-
-  for (const match of source.matchAll(/initial\s*=\s*\{/g)) {
-    const exprBrace = match.index + match[0].lastIndexOf("{");
-    const inner = skipWs(source, exprBrace + 1);
-    if (source[inner] === "{") {
-      states.push({
-        text: readBalanced(source, exprBrace, "{", "}"),
-        index: match.index,
-      });
-      continue;
-    }
-    const identMatch = /^[A-Za-z_$][\w$]*/.exec(source.slice(inner));
-    if (!identMatch || NON_VARIANT_INITIAL.has(identMatch[0])) continue;
-    const obj = findSameFileObjectLiteral(source, identMatch[0]);
-    if (obj) {
-      states.push({ text: obj, index: match.index });
-    }
-  }
-
-  const names = collectInitialVariantNames(source);
-  const { bindings } = collectVariantsBindings(source, ctx);
-  for (const name of names) {
-    const nameTagStarts = collectInitialNameTagStarts(source, name);
-    for (const binding of bindings) {
-      const objects = collectNamedVariantObjects(binding.objectText, name);
-      if (objects.length === 0) continue;
-      const index = namedVariantUsageIndex(source, binding, name, nameTagStarts);
-      if (index == null) continue;
-      for (const obj of objects) {
-        states.push({ text: obj.text, index });
-      }
-    }
-  }
-
-  return states;
-}
-
-interface ConditionalRange {
-  start: number;
-  end: number;
-  condition: string;
-}
-
-function collectConditionalRanges(source: string): ConditionalRange[] {
-  const ranges: ConditionalRange[] = [];
-
-  const pushJsxOrGroup = (start: number, condition: string): number => {
-    if (source[start] === "(") {
-      const group = readBalanced(source, start, "(", ")");
-      ranges.push({ start, end: start + group.length, condition });
-      return start + group.length;
-    }
-    if (source[start] === "<") {
-      const jsx = readJsxElement(source, start);
-      ranges.push({ start, end: start + jsx.length, condition });
-      return start + jsx.length;
-    }
-    return start + 1;
+  const record = (text: string, tag: JsxTag) => {
+    states.push({
+      text,
+      line: lineOf(elementNode(tag)),
+      ...mountContext(tag, parsed),
+    });
   };
 
-  let searchFrom = 0;
-  while (searchFrom < source.length) {
-    const and = source.indexOf("&&", searchFrom);
-    if (and === -1) break;
-    const next = skipWs(source, and + 2);
-    if (source[next] === "(" || source[next] === "<") {
-      searchFrom = pushJsxOrGroup(next, readExpressionBefore(source, and));
-    } else {
-      searchFrom = and + 2;
-    }
-  }
-
-  searchFrom = 0;
-  while (searchFrom < source.length) {
-    const q = source.indexOf("?", searchFrom);
-    if (q === -1) break;
-    const prev = source[q - 1];
-    const nextChar = source[q + 1];
-    if (prev === "?" || nextChar === "?" || nextChar === "." || nextChar === ":") {
-      searchFrom = q + 1;
-      continue;
-    }
-    const condition = readExpressionBefore(source, q);
-    const trueStart = skipWs(source, q + 1);
-    let afterTrue: number;
-    if (source[trueStart] === "(" || source[trueStart] === "<") {
-      afterTrue = pushJsxOrGroup(trueStart, condition);
-    } else {
-      const colonAt = findTopLevelColon(source, trueStart);
-      if (colonAt === -1) {
-        searchFrom = q + 1;
+  /**
+   * `<motion.div {...rest} />` can carry an `initial` or `variants` the scanner
+   * never sees. Prove the spread holds neither, or report it.
+   */
+  const checkSpreadAttributes = (tag: JsxTag) => {
+    if (!isMotionTag(tag)) return;
+    for (const property of tag.attributes.properties) {
+      if (!ts.isJsxSpreadAttribute(property)) continue;
+      const spread = unwrap(property.expression);
+      const resolved = ts.isObjectLiteralExpression(spread)
+        ? spread
+        : ts.isIdentifier(spread)
+          ? resolveVariantsObject(parsed, spread.text, ctx)
+          : null;
+      const report = reporter(property);
+      if (!resolved) {
+        report(`unresolved spread {...${spread.getText(parsed)}} on <${tagName(tag)}>`);
         continue;
       }
-      afterTrue = colonAt;
-    }
-    const colon = skipWs(source, afterTrue);
-    if (source[colon] === ":") {
-      const falseStart = skipWs(source, colon + 1);
-      if (source[falseStart] === "(" || source[falseStart] === "<") {
-        searchFrom = pushJsxOrGroup(falseStart, condition);
-        continue;
+      const keys = flattenProperties(resolved, parsed, ctx, report).map(propertyKey);
+      if (keys.includes("initial") || keys.includes("variants")) {
+        report(
+          `spread {...${spread.getText(parsed)}} sets initial/variants on <${tagName(tag)}>`
+        );
       }
     }
-    searchFrom = afterTrue;
-  }
+  };
 
-  return ranges;
-}
+  const visit = (node: ts.Node): void => {
+    if (ts.isJsxOpeningElement(node) || ts.isJsxSelfClosingElement(node)) {
+      const tag: JsxTag = node;
+      checkSpreadAttributes(tag);
 
-/**
- * True when `index` sits inside a conditionally mounted JSX region:
- * `{cond && ( ... )}`, `{cond && <jsx />}`, or either branch of a ternary
- * that starts with `(` or `<`.
- */
-function isInsideConditionalMount(source: string, index: number): boolean {
-  return collectConditionalRanges(source).some(
-    (range) => index >= range.start && index < range.end
-  );
-}
-
-function collectAnimatePresenceRanges(source: string): Array<[number, number]> {
-  const ranges: Array<[number, number]> = [];
-  const open = "<AnimatePresence";
-  const close = "</AnimatePresence>";
-  let searchFrom = 0;
-
-  while (searchFrom < source.length) {
-    const start = source.indexOf(open, searchFrom);
-    if (start === -1) break;
-    const afterName = start + open.length;
-    if (source[afterName] && !/[\s>/]/.test(source[afterName])) {
-      searchFrom = afterName;
-      continue;
-    }
-
-    let i = afterName;
-    let selfClosing = false;
-    while (i < source.length) {
-      if (source[i] === "{") {
-        const expr = readBalanced(source, i, "{", "}");
-        i += expr.length;
-        continue;
+      const own = initialSpec(tag, parsed);
+      if (own.kind === "object") {
+        record(variantText(own.object, parsed, ctx, reporter(own.object)), tag);
       }
-      if (source[i] === "'" || source[i] === '"' || source[i] === "`") {
-        i = skipQuoted(source, i);
-        continue;
-      }
-      if (source.startsWith("/>", i)) {
-        selfClosing = true;
-        i += 2;
-        break;
-      }
-      if (source[i] === ">") {
-        i += 1;
-        break;
-      }
-      i += 1;
-    }
 
-    if (selfClosing) {
-      searchFrom = i;
-      continue;
-    }
-
-    let depth = 1;
-    let cursor = i;
-    while (cursor < source.length && depth > 0) {
-      const nextOpen = source.indexOf(open, cursor);
-      const nextClose = source.indexOf(close, cursor);
-      if (nextClose === -1) {
-        throw new Error(`unclosed AnimatePresence starting at index ${start}`);
-      }
-      if (nextOpen !== -1 && nextOpen < nextClose) {
-        const afterNested = nextOpen + open.length;
-        if (!source[afterNested] || /[\s>/]/.test(source[afterNested])) {
-          depth += 1;
-          cursor = afterNested;
-          continue;
+      const variantsAttr = getAttribute(tag, "variants");
+      const variantsExpr = variantsAttr ? attributeExpression(variantsAttr) : undefined;
+      if (variantsExpr) {
+        const report = reporter(variantsExpr);
+        const objects = variantsObjectsFromExpression(variantsExpr, parsed, ctx, (description) =>
+          report(`unresolved variants={${description}}`)
+        );
+        const names = ssrVariantNames(tag, parsed);
+        for (const object of objects) {
+          for (const name of names) {
+            for (const variant of variantObjectsFor(object, name, parsed, ctx, report)) {
+              record(variantText(variant, parsed, ctx, report), tag);
+            }
+          }
         }
-        cursor = afterNested;
-        continue;
       }
-      depth -= 1;
-      cursor = nextClose + close.length;
     }
+    ts.forEachChild(node, visit);
+  };
 
-    ranges.push([start, cursor]);
-    searchFrom = start + open.length;
-  }
-
-  return ranges;
+  visit(parsed);
+  return { states, offenders };
 }
 
-function isInsideAnimatePresence(source: string, index: number): boolean {
-  return collectAnimatePresenceRanges(source).some(([start, end]) => index >= start && index < end);
+function collectInitialStates(source: string, ctx?: ScanContext): InitialState[] {
+  return scanSource(source, ctx).states;
 }
 
-/**
- * Hiding initials are ignored only when they sit in a conditional mount
- * and under AnimatePresence, and the condition is not a collection/length
- * check that can be true during SSR.
- */
-function isExemptHidingInitial(source: string, index: number): boolean {
-  if (!isInsideAnimatePresence(source, index)) return false;
-  const range = collectConditionalRanges(source).find(
-    (candidate) => index >= candidate.start && index < candidate.end
-  );
-  if (!range) return false;
-  if (conditionLooksLikeSsrCollection(range.condition)) return false;
-  return true;
-}
-
-function hidingHits(state: string): string[] {
-  return HIDING_PROPS.filter((prop) => prop.pattern.test(state)).map((prop) => prop.name);
+function hidingStates(source: string, ctx?: ScanContext): InitialState[] {
+  return collectInitialStates(source, ctx).filter((state) => hidingHits(state.text).length > 0);
 }
 
 function hidingOpacityStates(source: string, ctx?: ScanContext): InitialState[] {
@@ -846,21 +711,646 @@ function hidingOpacityStates(source: string, ctx?: ScanContext): InitialState[] 
   );
 }
 
-function readSource(relativePath: string): string {
-  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+/**
+ * Everything wrong with one file: hiding initials that ship during SSR, plus
+ * every `variants=` the scanner could not resolve. Both live in one list so the
+ * production scan cannot silently drop the fail-closed half.
+ */
+function findHidingOffenders(source: string, ctx?: ScanContext): string[] {
+  const scan = scanSource(source, ctx);
+  const offenders = [...scan.offenders];
+
+  for (const state of scan.states) {
+    if (state.exempt) continue;
+    for (const prop of hidingHits(state.text)) {
+      offenders.push(`line ${state.line}: ${prop} in ${state.text.replace(/\s+/g, " ")}`);
+    }
+  }
+
+  return offenders;
 }
+
+/**
+ * `ts.createSourceFile` error-recovers instead of throwing, and a tree built
+ * out of a broken file scans as "nothing to see here". A real component that
+ * does not parse is a fail-closed offender, not a pass. (Snippet sources in the
+ * unit tests are deliberate fragments, so this is checked per real file.)
+ */
+function parseErrorOffenders(filePath: string, source: string): string[] {
+  const parsed = parseSource(source, filePath) as ts.SourceFile & {
+    parseDiagnostics?: readonly ts.Diagnostic[];
+  };
+  const diagnostics = parsed.parseDiagnostics ?? [];
+  return diagnostics.slice(0, 1).map((diagnostic) => {
+    const line =
+      diagnostic.start === undefined
+        ? 0
+        : parsed.getLineAndCharacterOfPosition(diagnostic.start).line + 1;
+    return `line ${line}: does not parse, so the scan cannot see it — ${ts.flattenDiagnosticMessageText(diagnostic.messageText, " ")}`;
+  });
+}
+
+/** The per-file step the directory scan runs, shared so fixtures exercise it. */
+function scanFile(filePath: string, label: string): string[] {
+  const source = readFileSync(filePath, "utf8");
+  return [...parseErrorOffenders(filePath, source), ...findHidingOffenders(source, { filePath })].map(
+    (offender) => `${label}: ${offender}`
+  );
+}
+
+function fixture(name: string): string {
+  return resolve(CWD, "tests/fixtures/motion-scanner", name);
+}
+
+// ---------------------------------------------------------------------------
+// Scanner contracts
+// ---------------------------------------------------------------------------
 
 test("the hiding-initial scanner still sees Navbar's interaction-only panel", () => {
   const navbar = readSource("src/components/layout/Navbar.tsx");
-  const hits = collectInitialStates(navbar).filter((state) => hidingHits(state.text).length > 0);
   assert.ok(
-    hits.some((state) => {
+    hidingStates(navbar).some((state) => {
       const props = hidingHits(state.text);
       return props.includes("opacity") && props.includes("height");
     }),
     "scanner no longer sees Navbar's hiding initial; the per-node helper is now a blind skip"
   );
 });
+
+test("inline hiding initials are collected; a non-motion object is not", () => {
+  const inline = `<motion.div initial={{ opacity: 0 }} />`;
+  assert.equal(hidingOpacityStates(inline).length, 1);
+
+  const styleMap = `
+    const css = { hidden: { opacity: 0 } };
+    <div style={css.hidden} />
+  `;
+  assert.equal(collectInitialStates(styleMap).length, 0);
+});
+
+test("initial={ident} resolves a same-file object literal", () => {
+  const source = `
+    const hidden = { opacity: 0 };
+    <motion.div initial={hidden} />
+  `;
+  assert.equal(
+    hidingOpacityStates(source).length,
+    1,
+    "const hidden = { opacity: 0 } plus initial={hidden} must be visible"
+  );
+});
+
+test("hiding values cover zero literals, quoted zeros, and either ternary branch", () => {
+  assert.ok(hidingHits("{ opacity: 0.0 }").includes("opacity"));
+  assert.ok(hidingHits("{ opacity: '0' }").includes("opacity"));
+  assert.ok(hidingHits('{ scale: "0" }').includes("scale"));
+  assert.ok(hidingHits("{ width: 0.0 }").includes("width"));
+  assert.ok(hidingHits("{ height: 0.00 }").includes("height"));
+  assert.ok(hidingHits("{ opacity: visible ? 1 : 0 }").includes("opacity"));
+  assert.ok(hidingHits("{ opacity: visible ? 0 : 1 }").includes("opacity"));
+  assert.ok(hidingHits('{ visibility: "hidden" }').includes("visibility"));
+  assert.equal(hidingHits("{ opacity: 0.5 }").length, 0);
+  assert.equal(hidingHits("{ scale: 0.25 }").length, 0);
+  assert.equal(hidingHits("{ opacity: visible ? 1 : 1 }").length, 0);
+  assert.equal(hidingHits('{ visibility: "visible" }').length, 0);
+});
+
+test("leading-dot zeros and viewport-unit zeros hide too", () => {
+  assert.ok(hidingHits("{ opacity: .0 }").includes("opacity"));
+  assert.ok(hidingHits("{ opacity: .00 }").includes("opacity"));
+  for (const unit of ["vw", "vh", "svh", "dvh", "ch", "rem", "px", "%"]) {
+    assert.ok(hidingHits(`{ width: "0${unit}" }`).includes("width"), unit);
+  }
+  assert.equal(hidingHits("{ opacity: .5 }").length, 0);
+  assert.equal(hidingHits('{ width: "100vw" }').length, 0);
+});
+
+test("a keyframe array hides when its first entry is zero", () => {
+  // Verified against framer-motion 13.1.1: initial={{ opacity: [0, 1] }} ships
+  // style="opacity:0", scale:[0,1] ships transform:scale(0), and
+  // width:["0%","100%"] ships width:0%. A trailing zero renders the first entry.
+  assert.ok(hidingHits("{ opacity: [0, 1] }").includes("opacity"));
+  assert.ok(hidingHits("{ scale: [0, 1] }").includes("scale"));
+  assert.ok(hidingHits('{ width: ["0%", "100%"] }').includes("width"));
+  assert.equal(hidingHits("{ opacity: [1, 0] }").length, 0);
+  assert.equal(hidingHits("{ scale: [0.95, 1] }").length, 0);
+
+  const inline = `<motion.div initial={{ opacity: [0, 1] }} />`;
+  assert.equal(hidingOpacityStates(inline).length, 1);
+});
+
+test("named variants are collected through every initial= spelling", () => {
+  const cases = [
+    `<motion.div initial="hidden" variants={variants} />`,
+    `<motion.div initial={"hidden"} variants={variants} />`,
+    `<motion.div initial={reduced ? "hidden" : "visible"} variants={variants} />`,
+  ];
+
+  for (const usage of cases) {
+    const source = `const variants = { hidden: { opacity: 0 }, visible: { y: 0 } };\n${usage}`;
+    assert.equal(hidingOpacityStates(source).length, 1, usage);
+  }
+
+  const identName = `
+    const variants = { start: { opacity: 0 } };
+    <motion.div initial={start} variants={variants} />
+  `;
+  assert.equal(
+    hidingOpacityStates(identName).length,
+    1,
+    "initial={start} names the start variant when start is not a local object"
+  );
+
+  const computedKey = `
+    const variants = { ["hidden"]: { opacity: 0 } };
+    <motion.div initial="hidden" variants={variants} />
+  `;
+  assert.equal(hidingOpacityStates(computedKey).length, 1);
+
+  const factoryVariant = `
+    const variants = { hidden: (i: number) => ({ opacity: 0, delay: i }) };
+    <motion.div initial="hidden" variants={variants} />
+  `;
+  assert.equal(
+    hidingOpacityStates(factoryVariant).length,
+    1,
+    "a variant written as a custom-value function still renders opacity 0 on the server"
+  );
+});
+
+test("a variants object is only read through the element that binds it", () => {
+  const leftoverMap = `
+    const css = { hidden: { opacity: 0 } };
+    const variants = { hidden: { opacity: 0 } };
+    <motion.div initial="hidden" variants={variants} />
+  `;
+  assert.equal(
+    hidingOpacityStates(leftoverMap).length,
+    1,
+    "style-map hidden: { opacity: 0 } must not be treated as a motion initial"
+  );
+
+  const inlineObjectInitial = `
+    const css = { hidden: { opacity: 0 } };
+    <motion.div initial={{ content: "hidden", y: 24 }} />
+  `;
+  assert.equal(
+    hidingOpacityStates(inlineObjectInitial).length,
+    0,
+    'content: "hidden" must not collect a stray hidden: { opacity: 0 } object'
+  );
+
+  const presenceFalse = `
+    const css = { false: { opacity: 0 } };
+    <AnimatePresence initial={false}>
+      <motion.div />
+    </AnimatePresence>
+  `;
+  assert.equal(collectInitialStates(presenceFalse).length, 0);
+});
+
+test("always-rendered named hiding variants stay offenders", () => {
+  const source = `
+    const cardVariants = { hidden: { opacity: 0 } };
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  const hiding = hidingOpacityStates(source);
+  assert.equal(hiding.length, 1);
+  assert.equal(hiding[0].exempt, false);
+});
+
+test("typed variants objects are still collected", () => {
+  const typed = `
+    const cardVariants: Variants = { hidden: { opacity: 0 } };
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  assert.equal(hidingOpacityStates(typed).length, 1);
+});
+
+test("a resolvable spread inside a variants object is followed", () => {
+  const source = `
+    const base = { hidden: { opacity: 0 } };
+    const cardVariants = { ...base, visible: { opacity: 1 } };
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  assert.equal(
+    hidingOpacityStates(source).length,
+    1,
+    "hidden: { opacity: 0 } arrives through ...base and still ships"
+  );
+  assert.deepEqual(findHidingOffenders(source).filter((o) => o.includes("unresolved")), []);
+});
+
+test("a resolvable spread inside a variant value is followed", () => {
+  const source = `
+    const hiddenStyles = { opacity: 0 };
+    const cardVariants = { hidden: { ...hiddenStyles, y: 24 } };
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  assert.equal(
+    hidingOpacityStates(source).length,
+    1,
+    "the spread source is part of what Framer inlines, so it must be scanned"
+  );
+});
+
+test("an unresolvable spread inside a variants object fails closed", () => {
+  const inMap = `
+    const cardVariants = { ...makeBase(), hidden: { y: 24 } };
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  assert.deepEqual(
+    findHidingOffenders(inMap).map((offender) => offender.replace(/^line \d+: /, "")),
+    ["unresolved spread {...makeBase()}"],
+    "an unreadable spread can carry any variant key, including a hiding one"
+  );
+
+  const inValue = `
+    const cardVariants = { hidden: { ...makeHidden(), y: 24 } };
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  assert.deepEqual(
+    findHidingOffenders(inValue).map((offender) => offender.replace(/^line \d+: /, "")),
+    ["unresolved spread {...makeHidden()}"],
+    "an unreadable spread inside the variant value can carry opacity: 0"
+  );
+});
+
+test("a variant key bound to something unreadable fails closed", () => {
+  const source = `
+    const cardVariants = { hidden: buildHidden() };
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  assert.deepEqual(
+    findHidingOffenders(source).map((offender) => offender.replace(/^line \d+: /, "")),
+    ["unresolved variant hidden: buildHidden()"]
+  );
+});
+
+test("JSX spread attributes on a motion element fail closed", () => {
+  const unresolvable = `<motion.div {...rest} />`;
+  assert.deepEqual(
+    findHidingOffenders(unresolvable).map((offender) => offender.replace(/^line \d+: /, "")),
+    ["unresolved spread {...rest} on <motion.div>"],
+    "a spread the scanner cannot read may carry initial= or variants="
+  );
+
+  const carriesInitial = `
+    const motionProps = { initial: { opacity: 0 } };
+    <motion.div {...motionProps} />
+  `;
+  assert.deepEqual(
+    findHidingOffenders(carriesInitial).map((offender) => offender.replace(/^line \d+: /, "")),
+    ["spread {...motionProps} sets initial/variants on <motion.div>"]
+  );
+
+  const provablySafe = `
+    const layoutProps = { className: "grid", id: "x" };
+    <motion.div {...layoutProps} />
+  `;
+  assert.deepEqual(findHidingOffenders(provablySafe), []);
+
+  const plainElement = `<div {...rest} />`;
+  assert.deepEqual(
+    findHidingOffenders(plainElement),
+    [],
+    "Framer never reads props off a plain <div>, so its spreads are not our business"
+  );
+});
+
+test("variants={ident as Type} and {ident satisfies Type} resolve the ident", () => {
+  for (const expr of ["cardVariants as Variants", "cardVariants satisfies Variants", "(cardVariants)"]) {
+    const source = `
+      const cardVariants = { hidden: { opacity: 0 } };
+      <motion.div initial="hidden" variants={${expr}} />
+    `;
+    assert.deepEqual(findHidingOffenders(source).filter((o) => o.includes("unresolved")), [], expr);
+    assert.equal(hidingOpacityStates(source).length, 1, expr);
+  }
+});
+
+test("a module-scope const variants = {} is not a JSX binding", () => {
+  const source = `
+    const variants = { hidden: { opacity: 0 } };
+    <motion.div initial="hidden" variants={variants} />
+  `;
+  assert.deepEqual(
+    findHidingOffenders(source).filter((offender) => offender.includes("unresolved")),
+    []
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed resolution (#62)
+// ---------------------------------------------------------------------------
+
+test("factory variants={ident} fail closed", () => {
+  const source = `
+    const cardVariants = createVariants({ hidden: { opacity: 0 } });
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  assert.deepEqual(
+    findHidingOffenders(source).map((offender) => offender.replace(/^line \d+: /, "")),
+    ["unresolved variants={cardVariants}"],
+    "createVariants({ hidden }) is not inlined; fail closed instead of collecting"
+  );
+  assert.equal(hidingOpacityStates(source).length, 0);
+});
+
+test("an undeclared variants={ident} fails closed", () => {
+  const source = `
+    <motion.div initial="hidden" variants={cardVariants} />
+    const variants = { leftover: { opacity: 0 } };
+  `;
+  assert.deepEqual(
+    findHidingOffenders(source).map((offender) => offender.replace(/^line \d+: /, "")),
+    ["unresolved variants={cardVariants}"]
+  );
+});
+
+test("the production scan path reports an unresolved variants={ident}", () => {
+  // Same `scanFile` the directory scan below runs, so the fail-closed branch
+  // cannot rot out of the production wiring while CI stays green.
+  const offenders = scanFile(fixture("factory-variants.tsx"), "factory-variants.tsx");
+  assert.deepEqual(
+    offenders.map((offender) => offender.replace(/^(.*?): line \d+: /, "$1: ")),
+    ["factory-variants.tsx: unresolved variants={cardVariants}"]
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Imported variants (#61)
+// ---------------------------------------------------------------------------
+
+test("imported named variants objects are collected", () => {
+  const file = fixture("uses-import.tsx");
+  const ctx = { filePath: file };
+  const source = readFileSync(file, "utf8");
+  const hiding = hidingOpacityStates(source, ctx);
+
+  assert.equal(hiding.length, 1, "import { cardVariants } from ./imported-variants must resolve");
+  assert.equal(hiding[0].exempt, false);
+  assert.equal(hidingHits(hiding[0].text).includes("scale"), false);
+  assert.deepEqual(findHidingOffenders(source, ctx).filter((o) => o.includes("unresolved")), []);
+});
+
+test("imported default variants objects are collected", () => {
+  const file = fixture("uses-default-import.tsx");
+  const ctx = { filePath: file };
+  const source = readFileSync(file, "utf8");
+  const hiding = hidingOpacityStates(source, ctx);
+
+  assert.equal(hiding.length, 1, "import fadeVariants from ./imported-variants must resolve default");
+  assert.ok(
+    hidingHits(hiding[0].text).includes("scale"),
+    "default export payload must not collide with the named cardVariants export"
+  );
+  assert.deepEqual(findHidingOffenders(source, ctx).filter((o) => o.includes("unresolved")), []);
+});
+
+test("@/ alias imports resolve through the tsconfig paths mapping", () => {
+  const file = fixture("uses-alias-import.tsx");
+  const ctx = { filePath: file };
+  const source = readFileSync(file, "utf8");
+
+  // The specifier must be one the mapping actually has to rewrite. A `..` that
+  // climbs back out of the mapped segment resolves the same no matter what
+  // `@/*` points at, which would make this test decorative.
+  const spec = /from "(@\/[^"]+)"/.exec(source)?.[1];
+  assert.ok(spec, "the alias fixture must import through @/");
+  assert.ok(
+    !spec.includes(".."),
+    `${spec} escapes the mapped segment, so repointing @/* would not break it`
+  );
+  assert.equal(
+    resolveModuleFile(spec, file),
+    resolve(CWD, "src/lib/__fixtures__/motion-variants.ts"),
+    "@/lib/... must land under src/ via the tsconfig paths mapping"
+  );
+  assert.equal(
+    hidingOpacityStates(source, ctx).length,
+    1,
+    "a broken paths mapping would resolve nothing and this hiding variant would vanish"
+  );
+  assert.deepEqual(findHidingOffenders(source, ctx).filter((o) => o.includes("unresolved")), []);
+});
+
+test("a component that does not parse is an offender, not a pass", () => {
+  // ts.createSourceFile error-recovers, so a broken file otherwise scans as
+  // clean and its hiding initial ships unnoticed.
+  const offenders = scanFile(fixture("broken-syntax.tsx.txt"), "broken-syntax.tsx");
+  assert.match(
+    offenders[0] ?? "",
+    /^broken-syntax\.tsx: line \d+: does not parse/,
+    "an unparseable component must be reported before anything the broken tree happens to show"
+  );
+});
+
+test("an unresolvable import fails closed", () => {
+  const file = fixture("uses-import.tsx");
+  const source = `
+    import { cardVariants } from "@/does/not/exist";
+    <motion.div initial="hidden" variants={cardVariants} />
+  `;
+  assert.deepEqual(
+    findHidingOffenders(source, { filePath: file }).map((o) => o.replace(/^line \d+: /, "")),
+    ["unresolved variants={cardVariants}"]
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Variant inheritance (#59)
+// ---------------------------------------------------------------------------
+
+test("stagger children inherit a parent's named initial", () => {
+  const source = `
+    const containerVariants = { hidden: {} };
+    const childVariants = { hidden: { opacity: 0 } };
+    <motion.div variants={containerVariants} initial="hidden">
+      <motion.div variants={childVariants} />
+    </motion.div>
+  `;
+  const hiding = hidingOpacityStates(source);
+  assert.equal(hiding.length, 1);
+  assert.equal(
+    hiding[0].exempt,
+    false,
+    "Hero/ClientLogos-style children have no initial= of their own and are always rendered"
+  );
+});
+
+test("a stagger child under AnimatePresence keys its exemption off the child", () => {
+  const source = `
+    const containerVariants = { hidden: {} };
+    const childVariants = { hidden: { opacity: 0 } };
+    <motion.div variants={containerVariants} initial="hidden">
+      <AnimatePresence>
+        {open && <motion.div variants={childVariants} />}
+      </AnimatePresence>
+    </motion.div>
+  `;
+  const hiding = hidingOpacityStates(source);
+  assert.equal(hiding.length, 1);
+  assert.equal(hiding[0].exempt, true);
+});
+
+test("sibling variants= objects are not stagger children", () => {
+  const source = `
+    const leftover = { hidden: { opacity: 0 } };
+    const containerVariants = { hidden: {} };
+    const childVariants = { hidden: { opacity: 0 } };
+    <motion.div variants={containerVariants} initial="hidden">
+      <motion.div variants={childVariants} />
+    </motion.div>
+    <motion.div variants={leftover} />
+  `;
+  const hiding = hidingOpacityStates(source);
+  assert.equal(hiding.length, 1, "the stagger child is an offender; the later sibling is not");
+});
+
+test("initial={false} and inherit={false} on the element opt it out", () => {
+  for (const optOut of ["initial={false}", "inherit={false}"]) {
+    const source = `
+      const containerVariants = { hidden: {} };
+      const childVariants = { hidden: { opacity: 0 } };
+      <motion.div variants={containerVariants} initial="hidden">
+        <motion.div variants={childVariants} ${optOut} />
+      </motion.div>
+    `;
+    assert.equal(hidingOpacityStates(source).length, 0, optOut);
+  }
+});
+
+test("inherit={false} gates inherited state only, never the element's own initial=", () => {
+  // framer-motion 13.1.1 checks `props.inherit !== false` for *inherited*
+  // state. renderToStaticMarkup on the shape below really does emit
+  // <section style="opacity:0"> around real content.
+  const own = `
+    const fade = { hidden: { opacity: 0 }, visible: { opacity: 1 } };
+    <motion.section inherit={false} initial="hidden" animate="visible" variants={fade}>
+      <p>real content</p>
+    </motion.section>
+  `;
+  assert.equal(
+    hidingOpacityStates(own).length,
+    1,
+    "inherit={false} does not cancel this element's own initial=\"hidden\""
+  );
+
+  const underParent = `
+    const containerVariants = { hidden: {}, visible: {} };
+    const fade = { hidden: { opacity: 0 }, visible: { opacity: 1 } };
+    <motion.div variants={containerVariants} initial="visible">
+      <motion.section inherit={false} initial="hidden" variants={fade}>
+        <p>real content</p>
+      </motion.section>
+    </motion.div>
+  `;
+  assert.equal(hidingOpacityStates(underParent).length, 1);
+
+  // ...and such an element becomes a new root: its own name propagates down.
+  const reroots = `
+    const containerVariants = { hidden: {}, visible: {} };
+    const childVariants = { hidden: { opacity: 0 } };
+    <motion.div variants={containerVariants} initial="visible">
+      <motion.section inherit={false} initial="hidden" variants={containerVariants}>
+        <motion.div variants={childVariants} />
+      </motion.section>
+    </motion.div>
+  `;
+  assert.equal(
+    hidingOpacityStates(reroots).length,
+    1,
+    "the inherit={false} element re-roots the chain at its own hidden"
+  );
+
+  // The opt-out only bites when the element supplies no name of its own.
+  const noOwnInitial = `
+    const containerVariants = { hidden: {} };
+    const fade = { hidden: { opacity: 0 } };
+    <motion.div variants={containerVariants} initial="hidden">
+      <motion.section inherit={false} variants={fade}>
+        <p>real content</p>
+      </motion.section>
+    </motion.div>
+  `;
+  assert.equal(hidingOpacityStates(noOwnInitial).length, 0);
+});
+
+test("an intermediate inherit={false} stops the chain but initial={false} does not", () => {
+  const nested = (wrapper: string) => `
+    const containerVariants = { hidden: {} };
+    const childVariants = { hidden: { opacity: 0 } };
+    <motion.div variants={containerVariants} initial="hidden">
+      <motion.div ${wrapper}>
+        <motion.div variants={childVariants} />
+      </motion.div>
+    </motion.div>
+  `;
+
+  assert.equal(
+    hidingOpacityStates(nested("inherit={false}")).length,
+    0,
+    "inherit={false} cuts the variant chain for the whole subtree"
+  );
+  // Checked against framer-motion 13.1.1 with renderToStaticMarkup: the
+  // grandchild below really does ship style="opacity:0". An intermediate
+  // initial={false} only silences the wrapper itself.
+  assert.equal(
+    hidingOpacityStates(nested("initial={false}")).length,
+    1,
+    "initial={false} on a wrapper does not stop descendants from inheriting hidden"
+  );
+  assert.equal(
+    hidingOpacityStates(nested("")).length,
+    1,
+    "a plain wrapper is transparent to variant inheritance"
+  );
+});
+
+test("the nearest ancestor naming a variant wins", () => {
+  const source = `
+    const containerVariants = { hidden: {}, visible: {} };
+    const childVariants = { hidden: { opacity: 0 }, visible: { opacity: 1 } };
+    <motion.div variants={containerVariants} initial="hidden">
+      <motion.div variants={containerVariants} initial="visible">
+        <motion.div variants={childVariants} />
+      </motion.div>
+    </motion.div>
+  `;
+  assert.equal(
+    hidingOpacityStates(source).length,
+    0,
+    'the wrapper re-roots the chain at "visible"; the grandchild is never hidden'
+  );
+});
+
+test("an initial= the scanner cannot name does not shield an inherited variant", () => {
+  const source = `
+    const containerVariants = { hidden: {} };
+    const childVariants = { hidden: { opacity: 0 } };
+    <motion.div variants={containerVariants} initial="hidden">
+      <motion.div variants={childVariants} initial={props.state} />
+    </motion.div>
+  `;
+  assert.equal(
+    hidingOpacityStates(source).length,
+    1,
+    "initial={props.state} may be undefined at runtime; keep inheriting instead of passing"
+  );
+});
+
+test("variants= with no initial anywhere resolves nothing", () => {
+  const source = `
+    const childVariants = { hidden: { opacity: 0 } };
+    <motion.div variants={childVariants} animate="visible" />
+  `;
+  assert.equal(collectInitialStates(source).length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Conditional mounts
+// ---------------------------------------------------------------------------
 
 test("conditionally mounted hiding initials are ignored; always-rendered ones are not", () => {
   const source = `
@@ -877,227 +1367,87 @@ test("conditionally mounted hiding initials are ignored; always-rendered ones ar
   const always = states.find((state) => !/height/.test(state.text));
   const conditional = states.find((state) => /height/.test(state.text));
   assert.ok(always && conditional);
-  assert.equal(isInsideConditionalMount(source, always.index), false);
-  assert.equal(isInsideConditionalMount(source, conditional.index), true);
-  assert.equal(isExemptHidingInitial(source, always.index), false);
-  assert.equal(isExemptHidingInitial(source, conditional.index), true);
+  assert.equal(always.conditionallyMounted, false);
+  assert.equal(always.exempt, false);
+  assert.equal(conditional.conditionallyMounted, true);
+  assert.equal(conditional.exempt, true);
 });
 
-test("parenthesized && without AnimatePresence is not exempt", () => {
+test("a conditional mount without AnimatePresence is not exempt", () => {
   const source = `
-    {items.length && (
+    {mobileMenuOpen && (
       <motion.div initial={{ opacity: 0 }} />
     )}
   `;
   const states = collectInitialStates(source);
   assert.equal(states.length, 1);
-  assert.equal(isInsideConditionalMount(source, states[0].index), true);
-  assert.equal(isInsideAnimatePresence(source, states[0].index), false);
-  assert.equal(isExemptHidingInitial(source, states[0].index), false);
+  assert.equal(states[0].conditionallyMounted, true);
+  assert.equal(states[0].underAnimatePresence, false);
+  assert.equal(states[0].exempt, false);
 });
 
-test("unparenthesized && JSX and ternaries are conditional mounts", () => {
-  const unparen = `
-    {mobileMenuOpen && <motion.div initial={{ opacity: 0 }} />}
-  `;
-  const unparenStates = collectInitialStates(unparen);
-  assert.equal(unparenStates.length, 1);
-  assert.equal(isInsideConditionalMount(unparen, unparenStates[0].index), true);
-  assert.equal(isExemptHidingInitial(unparen, unparenStates[0].index), false);
+test("&& and both ternary branches are conditional mounts", () => {
+  const mounts = [
+    "{mobileMenuOpen && <motion.div initial={{ opacity: 0 }} />}",
+    "{mobileMenuOpen && (<motion.div initial={{ opacity: 0 }} />)}",
+    "{isOpen ? (<motion.div initial={{ opacity: 0 }} />) : null}",
+    "{isOpen ? null : <motion.div initial={{ opacity: 0 }} />}",
+    "{isOpen && <section><motion.div initial={{ opacity: 0 }} /></section>}",
+    // Non-JSX branches: when the condition is false the list never renders, so
+    // these are mounts too. The old index-range scanner only recognised a
+    // branch that started with `(` or `<`.
+    "{isOpen && items.map((i) => <motion.div key={i} initial={{ opacity: 0 }} />)}",
+    "{isOpen ? items.map((i) => <motion.div key={i} initial={{ opacity: 0 }} />) : null}",
+  ];
 
-  const ternary = `
-    {isOpen ? (
-      <motion.div initial={{ opacity: 0 }} />
-    ) : null}
-  `;
-  const ternaryStates = collectInitialStates(ternary);
-  assert.equal(ternaryStates.length, 1);
-  assert.equal(isInsideConditionalMount(ternary, ternaryStates[0].index), true);
-  assert.equal(isExemptHidingInitial(ternary, ternaryStates[0].index), false);
+  for (const mount of mounts) {
+    const bare = collectInitialStates(mount);
+    assert.equal(bare.length, 1, mount);
+    assert.equal(bare[0].conditionallyMounted, true, mount);
+    assert.equal(bare[0].exempt, false, mount);
 
-  const ternaryFalse = `
-    {isOpen ? null : <motion.div initial={{ opacity: 0 }} />}
-  `;
-  const falseStates = collectInitialStates(ternaryFalse);
-  assert.equal(falseStates.length, 1);
-  assert.equal(isInsideConditionalMount(ternaryFalse, falseStates[0].index), true);
+    const wrapped = collectInitialStates(`<AnimatePresence>${mount}</AnimatePresence>`);
+    assert.equal(wrapped.length, 1, mount);
+    assert.equal(wrapped[0].exempt, true, mount);
+  }
 });
 
-test("unparenthesized && JSX and ternaries under AnimatePresence are exempt", () => {
-  const unparen = `
+test("collection checks under AnimatePresence are not exempt", () => {
+  const mounts = [
+    "{items.length && (<motion.div initial={{ opacity: 0 }} />)}",
+    "{items.length && <motion.div initial={{ opacity: 0 }} />}",
+    "{items.length ? (<motion.div initial={{ opacity: 0 }} />) : null}",
+    "{Object.keys(items).length && (<motion.div initial={{ opacity: 0 }} />)}",
+    "{items.size && (<motion.div initial={{ opacity: 0 }} />)}",
+    "{Array.isArray(items) && (<motion.div initial={{ opacity: 0 }} />)}",
+    "{open && items.length > 0 && (<motion.div initial={{ opacity: 0 }} />)}",
+  ];
+
+  for (const mount of mounts) {
+    const states = collectInitialStates(`<AnimatePresence>${mount}</AnimatePresence>`);
+    assert.equal(states.length, 1, mount);
+    assert.equal(states[0].conditionallyMounted, true, mount);
+    assert.equal(states[0].underAnimatePresence, true, mount);
+    assert.equal(
+      states[0].exempt,
+      false,
+      `${mount} can be true during SSR; AnimatePresence does not hide it`
+    );
+  }
+});
+
+test("inline variants={{}} follow the element's own initial= usage", () => {
+  const source = `
     <AnimatePresence>
-      {mobileMenuOpen && <motion.div initial={{ opacity: 0 }} />}
-    </AnimatePresence>
-  `;
-  const unparenStates = collectInitialStates(unparen);
-  assert.equal(unparenStates.length, 1);
-  assert.equal(isExemptHidingInitial(unparen, unparenStates[0].index), true);
-
-  const ternary = `
-    <AnimatePresence initial={false}>
-      {isOpen ? (
-        <motion.div initial={{ opacity: 0 }} />
-      ) : null}
-    </AnimatePresence>
-  `;
-  const ternaryStates = collectInitialStates(ternary);
-  assert.equal(ternaryStates.length, 1);
-  assert.equal(isExemptHidingInitial(ternary, ternaryStates[0].index), true);
-
-  const ternaryFalse = `
-    <AnimatePresence>
-      {isOpen ? null : <motion.div initial={{ opacity: 0 }} />}
-    </AnimatePresence>
-  `;
-  const falseStates = collectInitialStates(ternaryFalse);
-  assert.equal(falseStates.length, 1);
-  assert.equal(isExemptHidingInitial(ternaryFalse, falseStates[0].index), true);
-});
-
-test("initial={ { ... } } with space or newline is still collected", () => {
-  const space = `<motion.div initial={ { opacity: 0 } } />`;
-  const newline = `<motion.div initial={\n  { opacity: 0 }\n} />`;
-
-  assert.equal(collectInitialStates(space).length, 1);
-  assert.equal(collectInitialStates(newline).length, 1);
-  assert.ok(hidingHits(collectInitialStates(space)[0].text).includes("opacity"));
-  assert.ok(hidingHits(collectInitialStates(newline)[0].text).includes("opacity"));
-});
-
-test("named variants referenced by initial= are collected", () => {
-  const source = `
-    const variants = { start: { opacity: 0 } };
-    <motion.div initial="start" variants={variants} />
-  `;
-  const states = collectInitialStates(source);
-  assert.ok(
-    states.some((state) => hidingHits(state.text).includes("opacity")),
-    "initial=\"start\" with start: { opacity: 0 } must be visible to the scanner"
-  );
-
-  const quoted = `
-    const variants = { start: { opacity: 0 } };
-    <motion.div initial={"start"} variants={variants} />
-  `;
-  assert.ok(collectInitialStates(quoted).some((state) => hidingHits(state.text).includes("opacity")));
-
-  const ident = `
-    const variants = { start: { opacity: 0 } };
-    <motion.div initial={start} variants={variants} />
-  `;
-  assert.ok(
-    collectInitialStates(ident).some((state) => hidingHits(state.text).includes("opacity")),
-    "initial={start} must collect the start: { opacity: 0 } variant"
-  );
-
-  const presenceFalse = `
-    const css = { false: { opacity: 0 } };
-    <AnimatePresence initial={false}>
-      <motion.div />
-    </AnimatePresence>
-  `;
-  assert.equal(collectInitialStates(presenceFalse).length, 0);
-});
-
-test("a non-motion hidden object is not treated as an initial", () => {
-  const source = `
-    const css = { hidden: { opacity: 0 } };
-    <div style={css.hidden} />
-  `;
-  assert.equal(collectInitialStates(source).length, 0);
-});
-
-test("opacity 0.0 and quoted zero count as hiding", () => {
-  assert.ok(hidingHits("{ opacity: 0.0 }").includes("opacity"));
-  assert.ok(hidingHits("{ opacity: '0' }").includes("opacity"));
-  assert.ok(hidingHits('{ scale: "0" }').includes("scale"));
-  assert.ok(hidingHits("{ width: 0.0 }").includes("width"));
-  assert.ok(hidingHits("{ height: 0.00 }").includes("height"));
-  assert.equal(hidingHits("{ opacity: 0.5 }").length, 0);
-  assert.equal(hidingHits("{ scale: 0.25 }").length, 0);
-});
-
-test("braces inside strings do not truncate an initial object", () => {
-  const source = `<motion.div initial={{ content: "}", opacity: 0 }} />`;
-  const states = collectInitialStates(source);
-  assert.equal(states.length, 1);
-  assert.ok(
-    hidingHits(states[0].text).includes("opacity"),
-    "a quoted } before opacity: 0 must not hide the rest of the object from the scanner"
-  );
-});
-
-test("initial={ident} resolves a same-file object literal", () => {
-  const source = `
-    const hidden = { opacity: 0 };
-    <motion.div initial={hidden} />
-  `;
-  assert.ok(
-    collectInitialStates(source).some((state) => hidingHits(state.text).includes("opacity")),
-    "const hidden = { opacity: 0 } plus initial={hidden} must be visible"
-  );
-});
-
-test("ternary initial= collects string variant names", () => {
-  const source = `
-    const variants = { hidden: { opacity: 0 }, visible: { y: 0 } };
-    <motion.div initial={reduced ? "hidden" : "visible"} variants={variants} />
-  `;
-  assert.ok(
-    collectInitialStates(source).some((state) => hidingHits(state.text).includes("opacity")),
-    "initial={reduced ? \"hidden\" : \"visible\"} must collect hidden: { opacity: 0 }"
-  );
-});
-
-test("computed variant keys matching initial= are collected", () => {
-  const source = `
-    const variants = { ["hidden"]: { opacity: 0 } };
-    <motion.div initial="hidden" variants={variants} />
-  `;
-  assert.ok(
-    collectInitialStates(source).some((state) => hidingHits(state.text).includes("opacity")),
-    '["hidden"]: { opacity: 0 } must be visible when initial="hidden"'
-  );
-});
-
-test("module-scope named variants key exemption off initial= usage, not the definition", () => {
-  const source = `
-    const variants = { hidden: { opacity: 0 } };
-    <AnimatePresence>
-      {open && (
-        <motion.div initial="hidden" variants={variants} />
-      )}
+      {open && <motion.div initial="hidden" variants={{ hidden: { opacity: 0 } }} />}
     </AnimatePresence>
   `;
   const hiding = hidingOpacityStates(source);
   assert.equal(hiding.length, 1);
-  assert.equal(
-    isExemptHidingInitial(source, hiding[0].index),
-    true,
-    "the definition is module-scope; the initial=\"hidden\" usage is the conditional mount"
-  );
+  assert.equal(hiding[0].exempt, true);
 });
 
-test("a leftover CSS hidden map is not collected when initial= references a variants= object", () => {
-  const source = `
-    const css = { hidden: { opacity: 0 } };
-    const variants = { hidden: { opacity: 0 } };
-    <AnimatePresence>
-      {open && (
-        <motion.div initial="hidden" variants={variants} />
-      )}
-    </AnimatePresence>
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(
-    hiding.length,
-    1,
-    "style-map hidden: { opacity: 0 } must not be treated as a motion initial"
-  );
-  assert.equal(isExemptHidingInitial(source, hiding[0].index), true);
-});
-
-test("always-rendered and conditional initial= usages are keyed separately", () => {
+test("always-rendered and conditional usages of one variants object are keyed separately", () => {
   const source = `
     const variants = { hidden: { opacity: 0 } };
     <motion.div initial="hidden" variants={variants} />
@@ -1106,306 +1456,19 @@ test("always-rendered and conditional initial= usages are keyed separately", () 
     </AnimatePresence>
   `;
   const hiding = hidingOpacityStates(source);
-  const exempt = hiding.filter((state) => isExemptHidingInitial(source, state.index));
-  const offenders = hiding.filter((state) => !isExemptHidingInitial(source, state.index));
-  assert.equal(offenders.length, 1, "the always-rendered initial=\"hidden\" stays an offender");
-  assert.equal(exempt.length, 1, "the conditional usage must not inherit the definition index");
+  assert.equal(hiding.filter((state) => state.exempt).length, 1);
+  assert.equal(hiding.filter((state) => !state.exempt).length, 1);
 });
 
-test("variants={cardVariants} is collected, not only const variants =", () => {
-  const source = `
-    const cardVariants = { hidden: { opacity: 0 } };
-    <AnimatePresence>
-      {open && (
-        <motion.div initial="hidden" variants={cardVariants} />
-      )}
-    </AnimatePresence>
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(hiding.length, 1);
-  assert.equal(isExemptHidingInitial(source, hiding[0].index), true);
-});
-
-test("typed const variants objects are still collected", () => {
-  const source = `
-    const cardVariants: Variants = { hidden: { opacity: 0 } };
-    <motion.div initial="hidden" variants={cardVariants} />
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(
-    hiding.length,
-    1,
-    "const cardVariants: Variants = { hidden: { opacity: 0 } } must resolve through variants={cardVariants}"
-  );
-  assert.equal(isExemptHidingInitial(source, hiding[0].index), false);
-});
-
-test("spread hidden keys on const ident = { are collected", () => {
-  const source = `
-    const cardVariants = { ...base, hidden: { opacity: 0 } };
-    <motion.div initial="hidden" variants={cardVariants} />
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(hiding.length, 1, "hidden: { opacity: 0 } inside a spread object must be collected");
-  assert.equal(isExemptHidingInitial(source, hiding[0].index), false);
-});
-
-test("imported named variants objects are collected", () => {
-  const file = resolve(process.cwd(), "tests/fixtures/motion-scanner/uses-import.tsx");
-  const source = readFileSync(file, "utf8");
-  const ctx = { filePath: file };
-  const hiding = hidingOpacityStates(source, ctx);
-  assert.equal(hiding.length, 1, "import { cardVariants } from ./motion must resolve the object");
-  assert.equal(isExemptHidingInitial(source, hiding[0].index), false);
-  assert.equal(hidingHits(hiding[0].text).includes("scale"), false);
-  assert.deepEqual(collectVariantsBindings(source, ctx).unresolved, []);
-});
-
-test("imported default variants objects are collected", () => {
-  const file = resolve(process.cwd(), "tests/fixtures/motion-scanner/uses-default-import.tsx");
-  const source = readFileSync(file, "utf8");
-  const ctx = { filePath: file };
-  const hiding = hidingOpacityStates(source, ctx);
-  assert.equal(hiding.length, 1, "import fadeVariants from ./motion must resolve export default");
-  assert.equal(isExemptHidingInitial(source, hiding[0].index), false);
-  assert.ok(
-    hidingHits(hiding[0].text).includes("scale"),
-    "default export payload must not collide with the named cardVariants export"
-  );
-  assert.deepEqual(collectVariantsBindings(source, ctx).unresolved, []);
-});
-
-test("const variants = { property keys are not unresolved JSX bindings", () => {
-  const before = `
-    const variants = { hidden: { opacity: 0 } };
-    <motion.div initial="hidden" variants={variants} />
-  `;
-  assert.deepEqual(collectVariantsBindings(before).unresolved, []);
-  assert.equal(hidingOpacityStates(before).length, 1);
-
-  const after = `
-    <motion.div initial="hidden" variants={cardVariants} />
-    const variants = { leftover: { opacity: 0 } };
-  `;
-  assert.deepEqual(collectVariantsBindings(after).unresolved, ["cardVariants"]);
-});
-
-test("factory variants={ident} fail closed when the object is not a literal", () => {
-  const source = `
-    const cardVariants = createVariants({ hidden: { opacity: 0 } });
-    <motion.div initial="hidden" variants={cardVariants} />
-  `;
-  assert.deepEqual(collectVariantsBindings(source).unresolved, ["cardVariants"]);
-  assert.equal(
-    hidingOpacityStates(source).length,
-    0,
-    "createVariants({ hidden }) is not inlined; fail closed instead of collecting"
-  );
-});
-
-test("variants={ident as Type} still resolves ident and skips the type name", () => {
-  const source = `
-    const cardVariants = { hidden: { opacity: 0 } };
-    <motion.div initial="hidden" variants={cardVariants as Variants} />
-  `;
-  assert.deepEqual(collectVariantsBindings(source).unresolved, []);
-  assert.equal(hidingOpacityStates(source).length, 1);
-});
-
-test("always-rendered named hiding variants stay offenders", () => {
-  const source = `
-    const cardVariants = { hidden: { opacity: 0 } };
-    <motion.div initial="hidden" variants={cardVariants} />
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(hiding.length, 1);
-  assert.equal(isExemptHidingInitial(source, hiding[0].index), false);
-});
-
-test("stagger children inherit named-variant collection from a parent initial=", () => {
-  const source = `
-    const containerVariants = { hidden: {} };
-    const childVariants = { hidden: { opacity: 0 } };
-    <motion.div variants={containerVariants} initial="hidden">
-      <AnimatePresence>
-        {open && <motion.div variants={childVariants} />}
-      </AnimatePresence>
-    </motion.div>
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(hiding.length, 1);
-  assert.equal(
-    isExemptHidingInitial(source, hiding[0].index),
-    true,
-    "childVariants.hidden is used via parent initial=\"hidden\"; exemption keys off the child element"
-  );
-});
-
-test("always-rendered stagger children with hiding named variants stay offenders", () => {
-  const source = `
-    const containerVariants = { hidden: {} };
-    const childVariants = { hidden: { opacity: 0 } };
-    <motion.div variants={containerVariants} initial="hidden">
-      <motion.div variants={childVariants} />
-    </motion.div>
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(hiding.length, 1);
-  assert.equal(
-    isExemptHidingInitial(source, hiding[0].index),
-    false,
-    "Hero/ClientLogos-style children have no initial=; collection keys off the child tag, which is always rendered"
-  );
-});
-
-test("unrelated sibling variants= leftover is not collected from a file-global name", () => {
-  const source = `
-    const leftover = { hidden: { opacity: 0 } };
-    const containerVariants = { hidden: {} };
-    <motion.div variants={containerVariants} initial="hidden" />
-    <motion.div variants={leftover} />
-  `;
-  assert.equal(
-    hidingOpacityStates(source).length,
-    0,
-    "leftover is not a stagger child of the initial=\"hidden\" node"
-  );
-});
-
-test("leftover sibling after a stagger parent with self-closing same-name child is not collected", () => {
-  const source = `
-    const leftover = { hidden: { opacity: 0 } };
-    const containerVariants = { hidden: {} };
-    const childVariants = { hidden: { opacity: 0 } };
-    <motion.div variants={containerVariants} initial="hidden">
-      <motion.div variants={childVariants} />
-    </motion.div>
-    <motion.div variants={leftover} />
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(hiding.length, 1, "stagger child remains an offender; leftover sibling is not");
-  assert.equal(
-    isExemptHidingInitial(source, hiding[0].index),
-    false,
-    "Hero/ClientLogos-style children have no initial=; collection keys off the child tag"
-  );
-});
-
-test("nested child with initial={false} does not inherit a parent hiding name", () => {
-  const source = `
-    const containerVariants = { hidden: {} };
-    const childVariants = { hidden: { opacity: 0 } };
-    <motion.div variants={containerVariants} initial="hidden">
-      <motion.div variants={childVariants} initial={false} />
-    </motion.div>
-  `;
-  assert.equal(
-    hidingOpacityStates(source).length,
-    0,
-    "initial={false} opts the child out of inherited hidden"
-  );
-});
-
-test("nested child with inherit={false} does not inherit a parent hiding name", () => {
-  const source = `
-    const containerVariants = { hidden: {} };
-    const childVariants = { hidden: { opacity: 0 } };
-    <motion.div variants={containerVariants} initial="hidden">
-      <motion.div variants={childVariants} inherit={false} />
-    </motion.div>
-  `;
-  assert.equal(
-    hidingOpacityStates(source).length,
-    0,
-    "inherit={false} opts the child out of inherited hidden"
-  );
-});
-
-test("inline variants={{}} hiding objects follow the element's initial= usage", () => {
-  const source = `
-    <AnimatePresence>
-      {open && <motion.div initial="hidden" variants={{ hidden: { opacity: 0 } }} />}
-    </AnimatePresence>
-  `;
-  const hiding = hidingOpacityStates(source);
-  assert.equal(hiding.length, 1);
-  assert.equal(isExemptHidingInitial(source, hiding[0].index), true);
-});
-
-test("variants={ { ... } } with space or newline is still collected", () => {
-  const space = `<motion.div initial="hidden" variants={ { hidden: { opacity: 0 } } } />`;
-  const newline = `<motion.div initial="hidden" variants={\n  { hidden: { opacity: 0 } }\n} />`;
-
-  const spaceHiding = hidingOpacityStates(space);
-  const newlineHiding = hidingOpacityStates(newline);
-  assert.equal(spaceHiding.length, 1, "space after variants={ must still see hidden: { opacity: 0 }");
-  assert.equal(newlineHiding.length, 1, "newline after variants={ must still see hidden: { opacity: 0 }");
-  assert.equal(isExemptHidingInitial(space, spaceHiding[0].index), false);
-  assert.equal(isExemptHidingInitial(newline, newlineHiding[0].index), false);
-});
-
-test("a hiding zero on either side of a ternary property is collected", () => {
-  assert.ok(hidingHits("{ opacity: visible ? 1 : 0 }").includes("opacity"));
-  assert.ok(hidingHits("{ opacity: visible ? 0 : 1 }").includes("opacity"));
-  assert.equal(hidingHits("{ opacity: visible ? 1 : 1 }").length, 0);
-});
-
-test("quoted strings inside inline initial objects are not variant names", () => {
-  const source = `
-    const css = { hidden: { opacity: 0 } };
-    <motion.div initial={{ content: "hidden", y: 24 }} />
-  `;
-  assert.equal(
-    collectInitialStates(source).filter((state) => hidingHits(state.text).includes("opacity"))
-      .length,
-    0,
-    'content: "hidden" must not collect a stray hidden: { opacity: 0 } object'
-  );
-});
-
-test("collection .length under AnimatePresence is not exempt", () => {
-  const cases = [
-    "{items.length && (<motion.div initial={{ opacity: 0 }} />)}",
-    "{items.length && <motion.div initial={{ opacity: 0 }} />}",
-    "{items.length ? (<motion.div initial={{ opacity: 0 }} />) : null}",
-    "{Object.keys(items).length && (<motion.div initial={{ opacity: 0 }} />)}",
-    "{items.size && (<motion.div initial={{ opacity: 0 }} />)}",
-    "{Array.isArray(items) && (<motion.div initial={{ opacity: 0 }} />)}",
-  ];
-
-  for (const mount of cases) {
-    const source = `<AnimatePresence>${mount}</AnimatePresence>`;
-    const states = collectInitialStates(source);
-    assert.equal(states.length, 1, mount);
-    assert.equal(isInsideConditionalMount(source, states[0].index), true, mount);
-    assert.equal(isInsideAnimatePresence(source, states[0].index), true, mount);
-    assert.equal(
-      isExemptHidingInitial(source, states[0].index),
-      false,
-      `${mount} can be true during SSR; AnimatePresence does not hide it`
-    );
-  }
-});
+// ---------------------------------------------------------------------------
+// Site contracts
+// ---------------------------------------------------------------------------
 
 test("no component ships an SSR initial state that hides its content", () => {
   const offenders: string[] = [];
 
   for (const file of listTsxFiles(COMPONENTS_DIR)) {
-    const key = relative(COMPONENTS_DIR, file);
-    const source = readFileSync(file, "utf8");
-    const ctx = { filePath: file };
-    const { unresolved } = collectVariantsBindings(source, ctx);
-    for (const ident of unresolved) {
-      offenders.push(`${key}: unresolved variants={${ident}}`);
-    }
-
-    for (const state of collectInitialStates(source, ctx)) {
-      if (isExemptHidingInitial(source, state.index)) continue;
-
-      for (const prop of hidingHits(state.text)) {
-        offenders.push(`${key}: ${prop} in ${state.text.replace(/\s+/g, " ")}`);
-      }
-    }
+    offenders.push(...scanFile(file, relative(COMPONENTS_DIR, file)));
   }
 
   assert.deepEqual(
@@ -1419,13 +1482,13 @@ test("no component ships an SSR initial state that hides its content", () => {
 
 test("Navbar and FAQ hiding initials sit on conditionally mounted nodes under AnimatePresence", () => {
   for (const key of ["layout/Navbar.tsx", "consulting/FAQ.tsx"]) {
-    const source = readSource(`src/components/${key}`);
-    const hiding = collectInitialStates(source).filter((state) => hidingHits(state.text).length > 0);
+    const file = join(COMPONENTS_DIR, key);
+    const hiding = hidingStates(readFileSync(file, "utf8"), { filePath: file });
 
     assert.ok(hiding.length > 0, `${key} should still have a detectable hiding initial`);
     for (const state of hiding) {
       assert.ok(
-        isExemptHidingInitial(source, state.index),
+        state.exempt,
         `${key} hiding initial is not behind \`{cond &&\` / ternary under AnimatePresence. ` +
           `That pair is the SSR-absent contract; add the wrapper or drop the hiding initial:\n  ${state.text}`
       );


### PR DESCRIPTION
Closes #59. Closes #61. Closes #62. Closes #63.

Replaces the hand-rolled regex/character TSX parser in `tests/motion-visibility.test.ts` with a `ts.createSourceFile` AST walk. `typescript@5.9.3` was already in devDependencies — **no new dependency**.

## Why a rewrite instead of four fixes

All four open issues are requests to teach the parser one more shape. I checked every one against `src/components` first: imported variants, `@/`-aliased variants, factory/unresolved bindings, `satisfies`, intermediate `inherit={false}` — **zero occurrences of any of them**. They are branches of the test's own parser, not defects in the site.

The AST models JSX parentage and module resolution directly, so the four stop being special cases:

| Issue | Regex approach | AST approach |
|---|---|---|
| #59 intermediate `inherit={false}` | ~200 lines reconstructing parentage from string indexes | `node.parent` walk |
| #61 `@/` alias imports | hand-rolled `join(SRC_ROOT, spec.slice(2))` | `ts.resolveModuleName` reading the real tsconfig `paths` |
| #62 unresolved `variants={ident}` | separate `unresolved` array whose wiring can rot | `resolveIdent() === null` reports inline at the call site |
| #63 `as` / `satisfies` | token-lookbehind keyword table | one `unwrap()` over `As`/`Satisfies`/`Paren`/`NonNull`/`TypeAssertion` |

## Two issue premises were wrong, and are corrected here

- **#59 states the failure mode is a harmless false positive.** It isn't. Probing framer-motion 13.1.1 with `renderToStaticMarkup`: an intermediate `inherit={false}` *does* cut the chain, but an intermediate `initial={false}` does **not** — the descendant genuinely ships `style="opacity:0"`. Both are modelled per the library, not per the issue.
- **#62's suggested fix does not compile** under `pnpm typecheck` (TS2307/TS2304, both reproduced). Solved differently: the production scan path is driven through the same `scanFile()` a fixture exercises, so the wiring is pinned without a real offender under `src/components`.

## Reviewed adversarially, and it found real bugs

A 26-agent review with a 2,200-case old-vs-new differential found **zero cases where the old scanner flags an offender and the new one is clean**. It also found 12 genuine defects, all fixed:

- **`inherit={false}` discarded the element's own `initial="name"`** — a real fail-open. framer gates only *inherited* context (`index-BuO47Yrm.js:389`); a subtree root would have shipped `opacity:0` undetected.
- **The first `@/` fixture pinned nothing** — `@/../tests/…` cancels the mapped segment before the filesystem is touched, so `@/*` could point at a nonexistent directory and stay green. That is exactly the regression #61 asked us to prevent. Now a genuine `@/lib/…` specifier, plus an assertion that the specifier contains no `..`.
- **A file that fails to parse scanned as "no offenders"** — `ts.createSourceFile` error-recovers silently. A regression against the old character parser. Now reads `parseDiagnostics` and fails closed.
- Fail-closed on unresolvable JSX spread attributes and spreads inside variants objects/values; keyframe-array initials (`opacity: [0, 1]` renders `opacity:0` — verified); leading-dot and viewport-unit zeros (`.0`, `"0vw"`); `visibility` and non-JSX conditional branches now asserted.

**Every guard is mutation-checked** — removed in turn, 12/12 caught by exactly the intended test. Four offenders planted into real components (Hero `opacity:0`, CareerTimeline hidden variant, ClientLogos `width:0`, TrackRecord `scale:0`) all turn the suite red.

## Honest accounting on size

The rewrite alone was 1524 → 1181 lines. Fixing the review findings put ~400 back: **final 1524 → 1587, slightly larger than what it replaced.** The parser shrank (839 → 769); the guard surface grew (685 → 818). If the pitch was "delete 1,100 lines," that did not happen — what happened is the parser became a real AST walk and a dozen verified fail-opens got closed.

## The part that matters most

A comment block now documents five accepted gaps with their direction of failure, headed by a tripwire rule:

> A gap becomes actionable only when a real file under `src/components` exhibits the shape. Fix the component first, the scanner second.

This file has generated **12 issues about itself** (#40, #43, #44, #46, #47, #49, #52, #53 closed; #59, #61, #62, #63 here) against **two real bugs** it ever caught (#30, #31). Four of the last six PRs before this one were scanner hardening that changed zero production files. The rule is the actual deliverable.

## Verification

- `npm test` — **161 pass, 0 fail** (rebased on current `main`, includes #68/#69)
- `tsc --noEmit` — clean · `eslint` — clean · `next build` — exit 0
- Old vs new over real `src/components`: both `[]`

## Note

`pnpm --filter=web exec tsc` has a destructive side effect in this repo — it re-runs install, prunes `packages/shared/*` and rewrites `pnpm-lock.yaml`. Use `./node_modules/.bin/tsc` instead.

Closes #59
Closes #61
Closes #62
Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)