### PR TITLE
fix: run typecheck through turbo and align page titles (#72)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,7 @@
 1. Keep all agent/project instructions in this file.
 2. Do not duplicate instruction content in `CLAUDE.md`.
 3. If instructions change, update `AGENTS.md` only.
+
+## Typecheck
+
+Run `pnpm typecheck` (Turbo) or `pnpm --filter=<pkg> typecheck`. Never `pnpm --filter=* exec tsc` — in this repo that can re-run install, prune `packages/shared/*`, and rewrite `pnpm-lock.yaml`. Do not add `typescript` as a root devDependency; each package that typechecks already has it.

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,8 +40,8 @@ tasks:
     cmd: pnpm turbo lint
 
   typecheck:
-    desc: Run TypeScript type checking on web app
-    cmd: pnpm --filter=web exec tsc --noEmit
+    desc: Run TypeScript type checking across the workspace
+    cmd: pnpm typecheck
 
   test:
     desc: Run web and repo script tests
@@ -55,7 +55,7 @@ tasks:
     desc: Run required checks before pushing changes
     cmds:
       - pnpm --filter=web lint
-      - pnpm --filter=web exec tsc --noEmit
+      - pnpm typecheck
       - pnpm test
       - pnpm --filter=web build
 

--- a/apps/cms/.gitignore
+++ b/apps/cms/.gitignore
@@ -82,7 +82,7 @@ ssl
 nbproject
 public/uploads/*
 !public/uploads/.gitkeep
-.tsbuildinfo
+*.tsbuildinfo
 .eslintcache
 
 ############################

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -11,14 +11,15 @@
     "develop": "strapi develop",
     "start": "strapi start",
     "strapi": "strapi",
+    "typecheck": "tsc --noEmit",
     "seed": "npx tsx scripts/seed.ts",
     "upgrade": "npx @strapi/upgrade latest",
     "upgrade:dry": "npx @strapi/upgrade latest --dry"
   },
   "dependencies": {
-    "@strapi/plugin-cloud": "5.52.1",
-    "@strapi/plugin-users-permissions": "5.52.1",
-    "@strapi/strapi": "5.52.1",
+    "@strapi/plugin-cloud": "5.52.2",
+    "@strapi/plugin-users-permissions": "5.52.2",
+    "@strapi/strapi": "5.52.2",
     "better-sqlite3": "13.0.3",
     "pg": "^8.23.0",
     "react": "^18.3.1",

--- a/apps/web/AUDIT_REPORT.md
+++ b/apps/web/AUDIT_REPORT.md
@@ -40,7 +40,7 @@ Scope: `apps/web` implementation quality, accessibility, and SEO consistency.
 ## Validation Executed
 
 - `pnpm --filter=web lint` ✅
-- `pnpm --filter=web exec tsc --noEmit` ✅
+- `pnpm --filter=web typecheck` ✅
 - `pnpm --filter=web test` ✅
 - `pnpm --filter=web build` ✅
 - `task pre-push` ✅

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -6,7 +6,7 @@ Next.js App Router frontend for the public portfolio.
 
 - `pnpm --filter=web dev`
 - `pnpm --filter=web lint`
-- `pnpm --filter=web exec tsc --noEmit`
+- `pnpm --filter=web typecheck` (or `pnpm typecheck` from the repo root; do not invoke `tsc` via `pnpm exec`)
 - `pnpm --filter=web test`
 - `pnpm --filter=web build`
 - `pnpm --filter=web posthog:push-dashboard`

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit",
     "test": "node --experimental-strip-types --import ./tests/register-ts-resolver.mjs --test tests/*.test.ts",
     "posthog:push-dashboard": "node ./scripts/posthog/push-dashboard.mjs"
   },
@@ -15,8 +16,8 @@
     "@strapi/blocks-react-renderer": "^1.0.2",
     "clsx": "^2.1.1",
     "framer-motion": "^13.1.1",
-    "next": "16.3.2",
-    "posthog-js": "^1.418.11",
+    "next": "16.3.3",
+    "posthog-js": "^1.420.0",
     "react": "19.2.8",
     "react-dom": "19.2.8",
     "react-syntax-highlighter": "^16.1.1",
@@ -32,7 +33,7 @@
     "@types/react-dom": "^19.2.5",
     "@types/react-syntax-highlighter": "^15.5.13",
     "eslint": "^9.39.5",
-    "eslint-config-next": "16.3.2",
+    "eslint-config-next": "16.3.3",
     "tailwindcss": "^4.3.3",
     "typescript": "^5.9.3"
   }

--- a/apps/web/pnpm-workspace.yaml
+++ b/apps/web/pnpm-workspace.yaml
@@ -3,6 +3,7 @@ allowBuilds:
   sharp: true
   unrs-resolver: true
 minimumReleaseAgeExclude:
-  - '@posthog/core@1.48.8'
-  - '@posthog/types@1.405.1'
-  - posthog-js@1.418.11
+  - '@posthog/core@1.48.11'
+  - '@posthog/types@1.406.2'
+  - posthog-js@1.420.0
+  - '@posthog/browser-common@0.6.0'

--- a/apps/web/src/app/blog/page.tsx
+++ b/apps/web/src/app/blog/page.tsx
@@ -1,16 +1,14 @@
 import type { Metadata } from "next";
 import { BlogListPageContent } from "@/components/blog/BlogListPageContent";
-import { getBlogListingData } from "@/lib/blog-listing";
+import { BLOG_PAGE_DESCRIPTION, getBlogListingData } from "@/lib/blog-listing";
 import { getSiteProfile } from "@/lib/site-profile";
 import { buildPageMetadata, toPersonId } from "@/lib/seo";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const siteProfile = await getSiteProfile();
-
   return buildPageMetadata({
     pathname: "/blog",
     title: "Blog",
-    description: siteProfile.siteDescription,
+    description: BLOG_PAGE_DESCRIPTION,
     type: "website",
     keywords: [
       "production AI engineering",
@@ -34,7 +32,7 @@ export default async function BlogPage() {
       categories={categories}
       pagination={pagination}
       pageTitle="Blog"
-      pageDescription={siteProfile.siteDescription}
+      pageDescription={BLOG_PAGE_DESCRIPTION}
       canonicalPath="/blog"
       canonicalAuthorId={toPersonId(siteProfile.author.profilePath)}
     />

--- a/apps/web/src/app/blog/page/[page]/page.tsx
+++ b/apps/web/src/app/blog/page/[page]/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { notFound, redirect } from "next/navigation";
 import { BlogListPageContent } from "@/components/blog/BlogListPageContent";
 import {
+  BLOG_PAGE_DESCRIPTION,
   BLOG_PAGE_SIZE,
   getBlogListingData,
   parsePositivePageNumber,
@@ -37,13 +38,12 @@ export async function generateStaticParams(): Promise<Array<{ page: string }>> {
 export async function generateMetadata({ params }: BlogArchivePageProps): Promise<Metadata> {
   const { page: rawPage } = await params;
   const currentPage = parsePositivePageNumber(rawPage);
-  const siteProfile = await getSiteProfile();
 
   const pageNumberLabel = currentPage && currentPage > 1 ? ` - Page ${currentPage}` : "";
   const metadata = buildPageMetadata({
     pathname: "/blog",
     title: `Blog${pageNumberLabel}`,
-    description: siteProfile.siteDescription,
+    description: BLOG_PAGE_DESCRIPTION,
     type: "website",
     keywords: [
       "production AI engineering",
@@ -88,7 +88,7 @@ export default async function BlogArchivePage({ params }: BlogArchivePageProps) 
       categories={categories}
       pagination={pagination}
       pageTitle="Blog"
-      pageDescription={siteProfile.siteDescription}
+      pageDescription={BLOG_PAGE_DESCRIPTION}
       canonicalPath="/blog"
       canonicalAuthorId={toPersonId(siteProfile.author.profilePath)}
     />

--- a/apps/web/src/app/contact/page.tsx
+++ b/apps/web/src/app/contact/page.tsx
@@ -20,7 +20,7 @@ export async function generateMetadata(): Promise<Metadata> {
 
   return buildPageMetadata({
     pathname: "/contact",
-    title: "Contact",
+    title: "Get in Touch",
     description: siteProfile.contactPrompt,
     type: "website",
     keywords: [

--- a/apps/web/src/lib/blog-listing.ts
+++ b/apps/web/src/lib/blog-listing.ts
@@ -2,6 +2,9 @@ import { getArticles, getCategories } from "@/lib/strapi";
 
 export const BLOG_PAGE_SIZE = 9;
 
+export const BLOG_PAGE_DESCRIPTION =
+  "Writing on production AI systems, LLM architecture, and shipping AI in finance, defense, healthcare, and enterprise.";
+
 export function buildBlogPageUrl(page: number): string {
   return page > 1 ? `/blog/page/${page}` : "/blog";
 }

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -206,6 +206,37 @@ export function resolveCanonicalUrl(pathname: string, canonicalUrl?: string): st
   return forceCanonicalHost(pathname, siteUrl);
 }
 
+/**
+ * Document / Open Graph / Twitter title. Nested routes otherwise pick up the
+ * layout `title.template` for `<title>` only, leaving og:title as the short
+ * page name. Absolute titles keep those three in sync.
+ */
+export function composeDocumentTitle(title: string, siteName = SITE_NAME): string {
+  const trimmed = title.trim();
+  if (!trimmed || trimmed === siteName) {
+    return siteName;
+  }
+
+  if (
+    trimmed.endsWith(` | ${siteName}`) ||
+    trimmed.endsWith(` — ${siteName}`) ||
+    trimmed.endsWith(` - ${siteName}`)
+  ) {
+    return trimmed;
+  }
+
+  if (
+    trimmed.startsWith(`${siteName} `) ||
+    trimmed.startsWith(`${siteName}—`) ||
+    trimmed.startsWith(`${siteName} –`) ||
+    trimmed.startsWith(`${siteName} -`)
+  ) {
+    return trimmed;
+  }
+
+  return `${trimmed} | ${siteName}`;
+}
+
 export function normalizeRobotsValue(value?: string): string | undefined {
   if (!value?.trim()) {
     return undefined;
@@ -299,23 +330,24 @@ export function buildPageMetadata({
   keywords,
 }: BuildPageMetadataOptions): Metadata {
   const resolvedTitle = seo?.metaTitle ?? title;
+  const documentTitle = composeDocumentTitle(resolvedTitle);
   const resolvedDescription = seo?.metaDescription ?? description;
   const canonical = resolveCanonicalUrl(pathname, seo?.canonicalURL);
   const robots = normalizeRobotsValue(seo?.metaRobots);
   const resolvedImage = seo?.metaImage ?? image;
   const images =
-    toMetadataImages(resolvedImage, resolvedTitle) ??
+    toMetadataImages(resolvedImage, documentTitle) ??
     [
       {
         url: toAbsoluteUrl("/opengraph-image", getSiteUrl()),
         width: 1200,
         height: 630,
-        alt: resolvedTitle,
+        alt: documentTitle,
       },
     ];
 
   const metadata: Metadata = {
-    title: resolvedTitle,
+    title: { absolute: documentTitle },
     description: resolvedDescription,
     keywords: seo?.keywords ?? keywords,
     alternates: {
@@ -324,7 +356,7 @@ export function buildPageMetadata({
     openGraph: {
       type,
       url: canonical,
-      title: resolvedTitle,
+      title: documentTitle,
       description: resolvedDescription,
       siteName: SITE_NAME,
       images,
@@ -333,7 +365,7 @@ export function buildPageMetadata({
     },
     twitter: {
       card: "summary_large_image",
-      title: resolvedTitle,
+      title: documentTitle,
       description: resolvedDescription,
       images,
     },

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -206,6 +206,8 @@ export function resolveCanonicalUrl(pathname: string, canonicalUrl?: string): st
   return forceCanonicalHost(pathname, siteUrl);
 }
 
+const TITLE_SEPARATORS = [" | ", " — ", " – ", " - "] as const;
+
 /**
  * Document / Open Graph / Twitter title. Nested routes otherwise pick up the
  * layout `title.template` for `<title>` only, leaving og:title as the short
@@ -217,19 +219,15 @@ export function composeDocumentTitle(title: string, siteName = SITE_NAME): strin
     return siteName;
   }
 
-  if (
-    trimmed.endsWith(` | ${siteName}`) ||
-    trimmed.endsWith(` — ${siteName}`) ||
-    trimmed.endsWith(` - ${siteName}`)
-  ) {
+  if (TITLE_SEPARATORS.some((separator) => trimmed.endsWith(`${separator}${siteName}`))) {
     return trimmed;
   }
 
   if (
     trimmed.startsWith(`${siteName} `) ||
     trimmed.startsWith(`${siteName}—`) ||
-    trimmed.startsWith(`${siteName} –`) ||
-    trimmed.startsWith(`${siteName} -`)
+    trimmed.startsWith(`${siteName}–`) ||
+    trimmed.startsWith(`${siteName}-`)
   ) {
     return trimmed;
   }
@@ -329,7 +327,7 @@ export function buildPageMetadata({
   modifiedTime,
   keywords,
 }: BuildPageMetadataOptions): Metadata {
-  const resolvedTitle = seo?.metaTitle ?? title;
+  const resolvedTitle = seo?.metaTitle?.trim() || title;
   const documentTitle = composeDocumentTitle(resolvedTitle);
   const resolvedDescription = seo?.metaDescription ?? description;
   const canonical = resolveCanonicalUrl(pathname, seo?.canonicalURL);

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -9,6 +9,8 @@ test("metadata builder keeps canonical URL + social metadata defaults", () => {
   assert.match(source, /resolveCanonicalUrl/);
   assert.match(source, /card: "summary_large_image"/);
   assert.match(source, /alternates:\s*{\s*canonical/);
+  assert.match(source, /composeDocumentTitle/);
+  assert.match(source, /title:\s*\{\s*absolute:\s*documentTitle/);
 });
 
 test("website JSON-LD supports canonical overrides", () => {

--- a/apps/web/tests/seo-jsonld.test.ts
+++ b/apps/web/tests/seo-jsonld.test.ts
@@ -58,11 +58,30 @@ test("composeDocumentTitle keeps homepage titles that already lead with the site
     composeDocumentTitle("Mehdi Zare — Principal AI Engineer · CFA Charterholder"),
     "Mehdi Zare — Principal AI Engineer · CFA Charterholder",
   );
+  assert.equal(
+    composeDocumentTitle("Mehdi Zare—Principal AI Engineer"),
+    "Mehdi Zare—Principal AI Engineer",
+  );
 });
 
 test("composeDocumentTitle appends the site name to short inner-page titles", () => {
   assert.equal(composeDocumentTitle("About"), "About | Mehdi Zare");
   assert.equal(composeDocumentTitle("Get in Touch"), "Get in Touch | Mehdi Zare");
+});
+
+test("composeDocumentTitle does not double-append when the site name is already a suffix", () => {
+  assert.equal(composeDocumentTitle("About | Mehdi Zare"), "About | Mehdi Zare");
+  assert.equal(
+    composeDocumentTitle("AI Engineering — Mehdi Zare"),
+    "AI Engineering — Mehdi Zare",
+  );
+  assert.equal(composeDocumentTitle("About – Mehdi Zare"), "About – Mehdi Zare");
+  assert.equal(composeDocumentTitle("About - Mehdi Zare"), "About - Mehdi Zare");
+});
+
+test("composeDocumentTitle treats blank or exact site-name titles as the site name", () => {
+  assert.equal(composeDocumentTitle("   "), "Mehdi Zare");
+  assert.equal(composeDocumentTitle("Mehdi Zare"), "Mehdi Zare");
 });
 
 test("buildPageMetadata uses the composed title for document, Open Graph, and Twitter", () => {
@@ -74,6 +93,20 @@ test("buildPageMetadata uses the composed title for document, Open Graph, and Tw
   assert.deepEqual(metadata.title, { absolute: "About | Mehdi Zare" });
   assert.equal(metadata.openGraph?.title, "About | Mehdi Zare");
   assert.equal(metadata.twitter?.title, "About | Mehdi Zare");
+});
+
+test("buildPageMetadata ignores blank CMS metaTitle and composes the page title", () => {
+  const metadata = buildPageMetadata({
+    pathname: "/about",
+    title: "About",
+    description: "About page",
+    seo: {
+      id: 1,
+      metaTitle: "   ",
+    },
+  });
+  assert.deepEqual(metadata.title, { absolute: "About | Mehdi Zare" });
+  assert.equal(metadata.openGraph?.title, "About | Mehdi Zare");
 });
 
 // ── Person JSON-LD ─────────────────────────────────────────────────────

--- a/apps/web/tests/seo-jsonld.test.ts
+++ b/apps/web/tests/seo-jsonld.test.ts
@@ -10,6 +10,8 @@ const {
   buildBlogPostingJsonLd,
   buildBlogJsonLd,
   buildFAQJsonLd,
+  buildPageMetadata,
+  composeDocumentTitle,
   resolveCanonicalUrl,
 } = await import("../src/lib/seo.ts");
 
@@ -49,6 +51,29 @@ test("resolveCanonicalUrl forces configured canonical host for absolute override
     "https://mehdi-zare.com/blog/category/ai-engineering"
   );
   assert.equal(result, "https://www.mehdi-zare.com/blog/category/ai-engineering");
+});
+
+test("composeDocumentTitle keeps homepage titles that already lead with the site name", () => {
+  assert.equal(
+    composeDocumentTitle("Mehdi Zare — Principal AI Engineer · CFA Charterholder"),
+    "Mehdi Zare — Principal AI Engineer · CFA Charterholder",
+  );
+});
+
+test("composeDocumentTitle appends the site name to short inner-page titles", () => {
+  assert.equal(composeDocumentTitle("About"), "About | Mehdi Zare");
+  assert.equal(composeDocumentTitle("Get in Touch"), "Get in Touch | Mehdi Zare");
+});
+
+test("buildPageMetadata uses the composed title for document, Open Graph, and Twitter", () => {
+  const metadata = buildPageMetadata({
+    pathname: "/about",
+    title: "About",
+    description: "About page",
+  });
+  assert.deepEqual(metadata.title, { absolute: "About | Mehdi Zare" });
+  assert.equal(metadata.openGraph?.title, "About | Mehdi Zare");
+  assert.equal(metadata.twitter?.title, "About | Mehdi Zare");
 });
 
 // ── Person JSON-LD ─────────────────────────────────────────────────────

--- a/package.json
+++ b/package.json
@@ -11,13 +11,13 @@
     "lint": "turbo lint",
     "dev:web": "turbo dev --filter=web",
     "dev:cms": "turbo dev --filter=cms",
-    "typecheck": "pnpm --filter=web exec tsc --noEmit",
+    "typecheck": "turbo typecheck",
     "test": "pnpm --filter=web test && node --test 'scripts/*.test.mjs'",
     "prepare": "[ -d .git ] && husky || true"
   },
   "devDependencies": {
     "husky": "^9.1.7",
-    "turbo": "^2.10.11"
+    "turbo": "^2.10.12"
   },
-  "packageManager": "pnpm@11.23.0+sha512.f00082e5b283a199b74e079da28d155c008fe232f44c8a06ea7ddfa014ecf719fc362f790ecc67b28106ddac2afb24c49a9a079159da560b2ce7d1e98efd11af"
+  "packageManager": "pnpm@11.24.0+sha512.bd27e345e976dcb0be0b7a1228217b049a817e21b1f355c90dbe7dc46671895a8bc1e6d06c24554505ea93ea0b45f489a27ec1bfbc8de6a9659fca0f16fa0000"
 }

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -6,6 +6,7 @@
   "types": "src/index.ts",
   "scripts": {
     "build": "tsc",
+    "typecheck": "tsc --noEmit",
     "lint": "echo 'no lint configured'"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,20 +43,20 @@ importers:
         specifier: ^9.1.7
         version: 9.1.7
       turbo:
-        specifier: ^2.10.11
-        version: 2.10.11
+        specifier: ^2.10.12
+        version: 2.10.12
 
   apps/cms:
     dependencies:
       '@strapi/plugin-cloud':
-        specifier: 5.52.1
-        version: 5.52.1(280a9a116abfd8b1c166cd8530339838)
+        specifier: 5.52.2
+        version: 5.52.2(7d7f64eb933e74d4211c4911e1c7cc7e)
       '@strapi/plugin-users-permissions':
-        specifier: 5.52.1
-        version: 5.52.1(1a35c6986392e808adcfe1e1199d3166)
+        specifier: 5.52.2
+        version: 5.52.2(c329d053f1620f341c80324a3cb09393)
       '@strapi/strapi':
-        specifier: 5.52.1
-        version: 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@swc/core@1.15.11(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(clean-css@5.3.3)(debug@4.4.3(supports-color@5.5.0))(esbuild@0.28.2)(html-minifier-terser@6.1.0)(jiti@2.7.0)(koa@2.16.4(supports-color@5.5.0))(lightningcss@1.32.0)(pg@8.23.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(terser@5.46.0)(ts-toolbelt@9.6.0)(tsx@4.23.12)(type-fest@4.41.0)(uglify-js@3.19.3)(yaml@2.9.0)
+        specifier: 5.52.2
+        version: 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@swc/core@1.15.11(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(clean-css@5.3.3)(debug@4.4.3(supports-color@5.5.0))(esbuild@0.28.2)(html-minifier-terser@6.1.0)(jiti@2.7.0)(koa@2.16.4(supports-color@5.5.0))(lightningcss@1.32.0)(pg@8.23.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(terser@5.46.0)(ts-toolbelt@9.6.0)(tsx@4.23.12)(type-fest@4.41.0)(uglify-js@3.19.3)(yaml@2.9.0)
       better-sqlite3:
         specifier: 13.0.3
         version: 13.0.3
@@ -107,11 +107,11 @@ importers:
         specifier: ^13.1.1
         version: 13.1.1(@types/react@19.2.18)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       next:
-        specifier: 16.3.2
-        version: 16.3.2(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+        specifier: 16.3.3
+        version: 16.3.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
       posthog-js:
-        specifier: ^1.418.11
-        version: 1.418.11
+        specifier: ^1.420.0
+        version: 1.420.0(@types/react@19.2.18)(react@19.2.8)
       react:
         specifier: 19.2.8
         version: 19.2.8
@@ -144,8 +144,8 @@ importers:
         specifier: ^9.39.5
         version: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-config-next:
-        specifier: 16.3.2
-        version: 16.3.2(@typescript-eslint/parser@8.56.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
+        specifier: 16.3.3
+        version: 16.3.3(@typescript-eslint/parser@8.56.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3)
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -1058,60 +1058,60 @@ packages:
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
-  '@next/env@16.3.2':
-    resolution: {integrity: sha512-8k4YoG8cM7LWlkfzGNYCRBbFNlernLiMw4s0btVl+CmmWqn3VpYypA72/5Feb1UWdxe6tHqr5KHP4p4Y4m9luA==}
+  '@next/env@16.3.3':
+    resolution: {integrity: sha512-U2eYQRwXj+dsqxV79zFqExDdatnNY/ZWc2nsJU1p/OgT7fd3dXwlF6OjYaFQCfMoeTA19PWq+wVmYgimVA+V+g==}
 
-  '@next/eslint-plugin-next@16.3.2':
-    resolution: {integrity: sha512-z+HW1cZgt8QhByw8p2EbxF94AImgsKIYUbtSkA7Zld2T9yrKAlys4jNOcAOCtv6csX2CoA/5qCVyesL5pHmJ0A==}
+  '@next/eslint-plugin-next@16.3.3':
+    resolution: {integrity: sha512-pbEh30vvjKpDoTAmo1v3q2uM4JUi8QaEBpbmjWvGfoec2jLghy/WNtvzAT0bk+Ik9oz6etjt4YjXEk4BQnicCw==}
 
-  '@next/swc-darwin-arm64@16.3.2':
-    resolution: {integrity: sha512-ib5Llm93YCKoKWDh6ZaHq6QWTuOZ2bRkSnUwMmX8dsRIOkBNL1vVlSiUKSfixPL9SSh9pvukzqajk/klkn5vqg==}
+  '@next/swc-darwin-arm64@16.3.3':
+    resolution: {integrity: sha512-8Hiv32QJPwdV6KYJ8meR9SBA061tQqnIKTJDocvOXlEQqib0xMFpzArosuffFUUc0sslbh7QQ8a3Yey1QV8EIw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.3.2':
-    resolution: {integrity: sha512-qd98fX2+I5nYJDioW2o7nSjoxM5KvWdeDefM80igia4+C/qSIEhH4MhTE+hO/7qKM7W37/Mq+dOWp8UePSyLHw==}
+  '@next/swc-darwin-x64@16.3.3':
+    resolution: {integrity: sha512-A1lgKgwVchRYmSe467zdwhxT9040dd8lH+o65sL5Jet8fjB4kegw/rDyPIpYVRb6jAqwXFOJpjIXJLxQKLiE3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.3.2':
-    resolution: {integrity: sha512-vqsgb6FAOzcrCccsLXiKtAy5t8EzO+uOazuFaSkQxeY0tNONG3vpHYy8pyBafcI5SNFPTeyard6yTr6SzNGo2A==}
+  '@next/swc-linux-arm64-gnu@16.3.3':
+    resolution: {integrity: sha512-bf0FIssMFueU2dm7vQEWWxk0c8UjKTdW0yzuh0sQsD8pf1+KCLDdaqhYZNMYGmXwEOiHAUzgBKudovIlcvvBjg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.3.2':
-    resolution: {integrity: sha512-xIe1eujfHUB2XcxHGddxJyu6TJRPjC5NpIkQYB/32ESkt5VkQyIAjmLRS38c+s6QY+qjtY/4KarVDzXRuD7lZQ==}
+  '@next/swc-linux-arm64-musl@16.3.3':
+    resolution: {integrity: sha512-W7viwCk9JY/cAkdz/A273rd5bb3RgT/IHwR7Upv90tunjBWNtAAhGhoecHh+teRNRSinuAFmE+l7fwZ4YKkrXg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.3.2':
-    resolution: {integrity: sha512-Fe0SA2j8X0kmc3aveuHD7UktO3AE2+mH3LguP60vGbz7u0z+MrDXbeb5iZFYAwR7EzzzXJ2Yk966w9mGTFMqfA==}
+  '@next/swc-linux-x64-gnu@16.3.3':
+    resolution: {integrity: sha512-0W46zw1N3ODpI6n0GeivHvvob1pooozgZVqy65k0mh4/7vr+FbY9+WpHzNVXjHipJf/A3FDheBG19H1s5A25rA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.3.2':
-    resolution: {integrity: sha512-TFBipb+gyesI/2Ve4zVu7kGltBWN/R466G5/1gtt2lECfc22G1pjkTxu68Q9aFcOaXiRGTQfvDbQQFe7mYgxiQ==}
+  '@next/swc-linux-x64-musl@16.3.3':
+    resolution: {integrity: sha512-H4mBso8ZTMBPtdT0PN0pBx2ayTvQuTuvS6qT13d77yVFJXAPCxkyIhLTmdMaGTJs0krQYI/qpzdHijCeihXhbg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.3.2':
-    resolution: {integrity: sha512-rVtmnNpBYIosDnKD/96dKxFsJnwnn1WRGG/HioSe8XCm2ksSHNrd2R6+hSjvTBxeMNhJ9pYeu/90cWB1nQLuNA==}
+  '@next/swc-win32-arm64-msvc@16.3.3':
+    resolution: {integrity: sha512-cTMUJpcEGmeywofCUfhR+rSsoE33+rVPnPEYNTNdLNlsOeEg/vktOsKUSTb28vUGqD2jkm4Zaskcwn7OCI6FQg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.3.2':
-    resolution: {integrity: sha512-H4Y2o2/JcHu8LtwzD5CXfHhwxwz8gfsx2HXDEw46Mtev5xHnEmB7HNtZtmriw5ReUOjRtcDqo7XSbU01FT9NlA==}
+  '@next/swc-win32-x64-msvc@16.3.3':
+    resolution: {integrity: sha512-2VR4cTBzHXaBjnGsuH6GyJjENzQOmHeAh11uY1iUhjm3j5dEUrVJuUj+VL78jaGi/Dik8xS76zEj18BsFhlVZQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -1184,20 +1184,17 @@ packages:
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@posthog/browser-common@0.5.0':
-    resolution: {integrity: sha512-8DaxVZS1bQPbA514RePurLNbYjei3P4jhnC206DwVv5XThmZM3QdlsXenI2ujE3pLbgQ79hYn9o1Kda8I3WK/Q==}
+  '@posthog/browser-common@0.6.0':
+    resolution: {integrity: sha512-d6yBE7VeoU3JTpaab3CaCoDCseh0Ytx7sTe0v2ZxhtHNxoKk7rdqr92+bUz9F1T2CuJO5/OTkes4HWT2VHNrTA==}
 
-  '@posthog/core@1.47.0':
-    resolution: {integrity: sha512-LW62V+9yx7G7mLd+EYpwW0PiaPZI8XRJ1tLuhw+9fXHpugLp8XQD5JuCQ2kIXvoUfyx1DpKfGQY3dUnzMOIn7Q==}
+  '@posthog/core@1.48.11':
+    resolution: {integrity: sha512-fvKbxGaUM8RuCDB1jdhSqAHYjk42INfJDWT1KVezn74sCrfnr1YaUafxzmcS+87D5FzbA2tu7IT0GQRV2WkkRg==}
 
-  '@posthog/core@1.48.8':
-    resolution: {integrity: sha512-LAOBOjMQrQmgcbZxnubl74l2GQd5OWqxCJJ8mzcWdZRWbfO6Y/A6E3fqWjDtm68hY4LxC/bbopG60cxZW8cfWw==}
+  '@posthog/types@1.405.3':
+    resolution: {integrity: sha512-HApKJSYfwo/z2KIVB98E/8XwEL3pTXawBp0AB7FKRVtStz9hizRlaO6n9RR7sjgXLnOLvqj++CGsZb8rQbOS2g==}
 
-  '@posthog/types@1.402.3':
-    resolution: {integrity: sha512-nnqKIGUqggeNbCZg6of/hYN+4shYZUoPFkILIIpYq0p9HDX8PgOrnrtBAUH8kr1MOmDh2nm+fY5Ceks7A5y6BQ==}
-
-  '@posthog/types@1.405.1':
-    resolution: {integrity: sha512-JvaR4ChUKUk7qSTG58vKN2Br6es9riFF5mvlu7YGcwbB476vfyTO0o/TBh+zE88QhsfxnE5Tr/jKxI+e1v3Q5A==}
+  '@posthog/types@1.406.2':
+    resolution: {integrity: sha512-RNNoKD7+ZD2v5uzIDp1SOKK1CseZ+YgNPRYCoPlVKuu+wTB/Tb41JCprMjX9E24gPcsdDg8B47dsEsmO0nwEfw==}
 
   '@radix-ui/number@1.0.1':
     resolution: {integrity: sha512-T5gIdVO2mmPW3NNhjNgEP3cqMXjXL9UbO0BzWcXfvdBs+BohbQxvd/K5hSVKmn9/lbTdsQVKbUcP5WLCwvUbBg==}
@@ -2022,8 +2019,8 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
-  '@strapi/admin@5.52.1':
-    resolution: {integrity: sha512-biV3Zca0L3mYfqgmu+2LkwdSFahDXPVnzmEmWnfq6v6GnIoD4DfI4mLZt/BFL0pTIefL6swwSagcxoQGyJMl9g==}
+  '@strapi/admin@5.52.2':
+    resolution: {integrity: sha512-SNEfJ/pBFlpabkXfgB9j+0idhflP8MrNPCd1Wfn2DKVqoxX5stKo6HJUrf1Hv+2gVBOtNlK4pQh61zpuDHFtXQ==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/data-transfer': ^5.0.0
@@ -2039,13 +2036,13 @@ packages:
       react: ^18.0.0 || ^19.0.0
       react-dom: ^18.0.0 || ^19.0.0
 
-  '@strapi/cloud-cli@5.52.1':
-    resolution: {integrity: sha512-hv/j20tooeeRGyWc0XFksG4DvcV5/7pf0Z23Yc7ZkHFm2OZrq76O49tmq1ovQCcOA1ZIaqglzQPpYPULu0Z+3w==}
+  '@strapi/cloud-cli@5.52.2':
+    resolution: {integrity: sha512-ZJRAxxI2JInTw11aYWsYv2xcp6lPvJIqxyTfX5qHQu8ct+AS+FSH4Z/Hzsh1aQyb6HuZtcqsRt9es5l9cx8KAQ==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     hasBin: true
 
-  '@strapi/content-manager@5.52.1':
-    resolution: {integrity: sha512-7kFkUbPUJ7ia6KvpWA0KCJU1xnZBU2JcnsugnxCsXm2PTSHv933151AiwCX6BbVuLYF4hejoaYiYKJ3pJIB4KA==}
+  '@strapi/content-manager@5.52.2':
+    resolution: {integrity: sha512-G7yN46kchS32IBjpe7dTogdxae1VEzCGae4fKLrfLJtWxBF//Kgk0PvA4Grs4GaDMDwxzEH93RbqJYRkEOytlg==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/admin': ^5.0.0
@@ -2054,8 +2051,8 @@ packages:
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/content-releases@5.52.1':
-    resolution: {integrity: sha512-3AmoEbgPec+K198dbbDKtcQpNBskl6citoMiJB1EGv3r8GTC4C0NxSqGmZhbFd90bpD49zH7TYhzeJVn8/PDDQ==}
+  '@strapi/content-releases@5.52.2':
+    resolution: {integrity: sha512-1+xH0t0+MNtTYzc/Zlik1XAoaKwfTwWfLW/PZ9gTnfeP3xdrBVH1bMd9SCk7/NiZ1NW6v/HVa1IT5JB79pAKrw==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/admin': ^5.0.0
@@ -2065,8 +2062,8 @@ packages:
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/content-type-builder@5.52.1':
-    resolution: {integrity: sha512-zwC9laBmlaUKntEdl6Pg4sdZ46cUfpndJfhbQEiZUY0jFxsGqpS+C2xAfSXC5NQ6IUSDW9fHGnRBe+Q8ux/rNg==}
+  '@strapi/content-type-builder@5.52.2':
+    resolution: {integrity: sha512-HT9bSZaFDIwUqKbP4Q6hcPnE6rcxkf+UiP2CJEjR+nca8MpJ4Z+QApqNLqv3XfxJrsrXKyiSat+LCynDwuq67Q==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/admin': ^5.0.0
@@ -2075,16 +2072,16 @@ packages:
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/core@5.52.1':
-    resolution: {integrity: sha512-QGiSTamFYzaR9jY3vYLmrRU6U3TztumXoJMYW7GorsH5WU3pRXYHqcbcafH9ZfX0QBDmZFcmNavcdUGOvbKoJw==}
+  '@strapi/core@5.52.2':
+    resolution: {integrity: sha512-3sPBzMFwy9Cc8LavYCN57yFJwPj+46A9wAg/wyggXwoAMwblYlO0Vnr1VQoZtmgOElm0vjrWLmNP03H8s1HYOg==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/data-transfer@5.52.1':
-    resolution: {integrity: sha512-XmwJxylmiizhtb0Jk5YQa2kCV6klpWg8wgLms/lhccsniR2IA7iGATsarFAQGbxfcl39aNkyVPpH2IZIisFatg==}
+  '@strapi/data-transfer@5.52.2':
+    resolution: {integrity: sha512-mex9yzp63ZPFEQgxdjy0Hti3NBZuy9SamzDGy5ZZUWl3BvXDNVmSeOwunN+QKR9s9RH7oHZ8yqcoQcRexColXQ==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/database@5.52.1':
-    resolution: {integrity: sha512-mknnMwQV47DWTIP9+WGK4R3g0t4vOJ/fEwB4FpUrayAapTGdnZP9H0/nsssz+AM2EhzSVrY0bF8LUKNlnA4fCw==}
+  '@strapi/database@5.52.2':
+    resolution: {integrity: sha512-sFaN0QpF3n2loi2DoSDGKiO9AWLoxkObZTeOH4u+cLLN2ow/th524XAv0FUlwzNXOurzdu71fuS9lUcRR+X6kA==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
   '@strapi/design-system@2.2.4':
@@ -2095,8 +2092,8 @@ packages:
       react-dom: ^18.0.0
       styled-components: ^6.0.0
 
-  '@strapi/email@5.52.1':
-    resolution: {integrity: sha512-VxXp0APA/qLCU3YCTo0oQRrpkv0L//ZToAkBUrHg/+QZii1ICo9qj5r8m7x/cUVUL+5KoBWSrwjG57oCFnDTUg==}
+  '@strapi/email@5.52.2':
+    resolution: {integrity: sha512-Qoxk6iFuxzGcrMgOimgVDENMlIKZB6a0haPWCm2nRfsgHk/rb1BHq5o/PWGU296nLxCDK1EvnLQhta3hoDQh2A==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/admin': ^5.0.0
@@ -2106,12 +2103,12 @@ packages:
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/generators@5.52.1':
-    resolution: {integrity: sha512-0r3MwArmWlGPARwnJKA9MdGrEKXealjb8zLN7UIfyW38gzeKAsEIYIAv9kjNtiNleS2CnsQk3OUlhV+vqkb+6A==}
+  '@strapi/generators@5.52.2':
+    resolution: {integrity: sha512-PCFSiR/gwz9PyidwW3ixWFfgXDJZCxSvXz4irInPEWVsiyZy6gcAqTPdp2eZL1ieXo1Q4ojFxlq1HwkHQFPXRg==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/i18n@5.52.1':
-    resolution: {integrity: sha512-rm50RKXwtPv/9Yb6wQAQ1LK5Rj0EuH3UqPZsyS1RyVrYA8sFnL8kKn7LY37ISJVcq/heJrW8Q7BNBfoQabbu8g==}
+  '@strapi/i18n@5.52.2':
+    resolution: {integrity: sha512-xRHUhn/N9Y+KRBypoWOWevS/1GY3zYvqVIijTPkHpXWmqIrYOkMvUa08O41hBr6PdODlDpVAWjKTnRYfYo/Xag==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/admin': ^5.0.0
@@ -2128,20 +2125,20 @@ packages:
       react-dom: ^18.0.0
       styled-components: ^6.0.0
 
-  '@strapi/logger@5.52.1':
-    resolution: {integrity: sha512-E4e6ftWbHje8SUIAz7ylBj7sowDCcGOGJWmPXB0nS7coGg35mBCuElsbtFGyTY15BJOgtXyln8vXExvHCsJHlA==}
+  '@strapi/logger@5.52.2':
+    resolution: {integrity: sha512-Zo5VwgT/I/Y+hbeL54/uunTNSPzDiO1inaYmMoQsDf0txSwf72P+Wr4KlzXWyuVuq7wSaBPjCBOfaVsdlG9tTQ==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/openapi@5.52.1':
-    resolution: {integrity: sha512-OI8Mcbq/hLZ9thkcQVuLeQ6ToEZt0tgxR6R9UeWG+G2B+dkfNjZDc9cIbsfqKOk02xtvaJye7ShyQQWWcancJw==}
+  '@strapi/openapi@5.52.2':
+    resolution: {integrity: sha512-pPmo07nkSV+ZtAH7xT2fxEl+HVMPUgASaVIZnVAN83HMTcc9uODOBydoaRgNLxii+bgUCrG/XZwGpTYE1IXS3A==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/permissions@5.52.1':
-    resolution: {integrity: sha512-60w8IoTNs1A4fBezM8ONmf1b+TJLIxD9a62Hb3l04ARmjda7MuK6w6ynlWnLPKKpC/eQG0ek3HpCoG/2HyFgTw==}
+  '@strapi/permissions@5.52.2':
+    resolution: {integrity: sha512-LfAwGpm0O97VYLHZij/xL5GHwlztR+bS9kEpfryag8vA/ccZEY4nvuWUHdClR27qNe7ku5p3jaE0xQ+pHVhuAA==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/plugin-cloud@5.52.1':
-    resolution: {integrity: sha512-l5AZ03hhU4cz3ow1Cqvf8d6cJLMrDEjeHa0Jz90ObFygKVo4v3rSBL3WT++X8BZnBQRT6rGj5RrSMwTxL5bggw==}
+  '@strapi/plugin-cloud@5.52.2':
+    resolution: {integrity: sha512-wP7earSjFZhpVlixdI6/4TBA5uhgGFkNrV0hFW7A68NIbXwqr1VX9Fc0dzIsfJ2XkOQcLt54MGdTDKr//ypUtg==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/admin': ^5.0.0
@@ -2151,26 +2148,27 @@ packages:
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/plugin-users-permissions@5.52.1':
-    resolution: {integrity: sha512-nuo8Wmep7aFllDLWjtqZsjs07wo2BkIQ6QbKBSdS4BkwE6nn7baD8Gi9xDIANIdPaqjiRj0C5eMyFThAgnF3vQ==}
+  '@strapi/plugin-users-permissions@5.52.2':
+    resolution: {integrity: sha512-8zaIzuXTxl/r/xd9gcWa2RyO9rGefy4huFSdixrJvqXxIBNNGCXSZxuAjUiGhLFKB4ewTg3PQM7x4nW9xt2BsQ==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
+      '@strapi/admin': ^5.0.0
       '@strapi/strapi': ^5.0.0
       react: ^17.0.0 || ^18.0.0
       react-dom: ^17.0.0 || ^18.0.0
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/provider-email-sendmail@5.52.1':
-    resolution: {integrity: sha512-KcxGvGahbZYlOhhmnWLEoXlwbIe7PrFr8bERmPULOWTc46SXue9NrKpnto1N6dQn3duV1nbBxNc5lTWB9jRjzg==}
+  '@strapi/provider-email-sendmail@5.52.2':
+    resolution: {integrity: sha512-DywVHIBRs35F63TclOpg9ub6Pih7SutYMGgsu70YM2puX9y1eqq2XzKem2ZYtKAf7BTkpdSifotwM7UUUuGzPA==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/provider-upload-local@5.52.1':
-    resolution: {integrity: sha512-p1bxq5opmSCChz6zi/MbV99kSSc9k/k4kfrrIO9ig6rBLcLWHAIGpDh5nohQVrRiPQuK89fSwE8HHI8DoZ+qlw==}
+  '@strapi/provider-upload-local@5.52.2':
+    resolution: {integrity: sha512-0beNUrg7gnNQBoMW6xAJL0UpQjhziJfXg9Ub7Fyse2819jBocSBMPcV+ghEv3G3Z5DpElrkHHYaGnQ1KH0H3Sg==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/review-workflows@5.52.1':
-    resolution: {integrity: sha512-d2YOGRcbNkynq6FISGyNu4m7VbNuikwt3AKxt0CwtlEKg9rsleUFhLV67J9kYvstd698V2Wd6StLfKeV8S0bHw==}
+  '@strapi/review-workflows@5.52.2':
+    resolution: {integrity: sha512-+cYy/R83h5fuTvuudL4boeN7TYi+BdfvwrubB2E+u/hmDCndqrMdvo8HCXSsleXYpVCt1SQ9oozDfLL2azI9sQ==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/admin': ^5.0.0
@@ -2181,8 +2179,8 @@ packages:
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/strapi@5.52.1':
-    resolution: {integrity: sha512-GKOFGodBwD+7IiUrQTYmBU1Xaw0BM/vu/Tc6HUwviPNX+FGE8JBd7uoeND08Cqln60nwdxmQPVeeJQOl3bLHlw==}
+  '@strapi/strapi@5.52.2':
+    resolution: {integrity: sha512-ugc28uWlIAD4FcBIWmeC50hzXnyhuBszK7/WqDAByBvWnZCTr0lXHs8E5sgqzSebZ9aan76ut50ssMAEmu/itA==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     hasBin: true
     peerDependencies:
@@ -2191,12 +2189,12 @@ packages:
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/types@5.52.1':
-    resolution: {integrity: sha512-bAfzovdj/uiWrYba/x3IMj3BS6H5T/l/+TLxNaQnd4oFb0i5o0zjb8IRglQF6t2n41mv2j4EhbBhx25pJaj/ww==}
+  '@strapi/types@5.52.2':
+    resolution: {integrity: sha512-DdSh8UpA7yVuChUyre4dn4R5D+BodVlcPo7ePQBpm0dN9hUDQIwODfh+97+tfrOLDAYfMw/50NHqpxRp8qm92g==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
-  '@strapi/typescript-utils@5.52.1':
-    resolution: {integrity: sha512-IbhU0jIXfhFO4kKbKsCWugb3rp/2uIFEBEX7Y//reWk9r4aFWPW4XC3jNbI4n4ebMtrBusyh3D+EAUKbkuavWg==}
+  '@strapi/typescript-utils@5.52.2':
+    resolution: {integrity: sha512-A7En7Qunn3HiBPfiSqafI3wtzG3kXFsnaASC6kaGICOOA3H6XgJLHyySet9vdIUjTqjrlW4Lt4uzedAAdWq1AA==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
   '@strapi/ui-primitives@2.2.4':
@@ -2205,8 +2203,8 @@ packages:
       react: ^18.0.0
       react-dom: ^18.0.0
 
-  '@strapi/upload@5.52.1':
-    resolution: {integrity: sha512-3ygEN9DmxDVNfVpnAGGhu6Apgsvv15Vhbw+ZFkYC7TEQJlh9qi12oZkttZO8KEKfASmtjCTWOOMVfJhDyGKL0g==}
+  '@strapi/upload@5.52.2':
+    resolution: {integrity: sha512-7K6/JazUr2zVPngUA9KtArbEial8yIgiYW8opkJExj1QkThmzINDMOJhDhQGz8Z6twzgXvrtKBOHphlMa6wpnA==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
     peerDependencies:
       '@strapi/admin': ^5.0.0
@@ -2215,8 +2213,8 @@ packages:
       react-router-dom: ^6.30.3
       styled-components: ^6.0.0
 
-  '@strapi/utils@5.52.1':
-    resolution: {integrity: sha512-bx4c0PHJgSEfOKOj5Wgl+/5cSs0DEwdm3JsDLyZnDAzTjrINlWR6lrrZyYn1HFiv55BYccD7+EoWX8eIpkSe/g==}
+  '@strapi/utils@5.52.2':
+    resolution: {integrity: sha512-d5QJZD77FsTlga+Q8NwUL+kxSJE6DkzlrHYEaAmU6ySkcigIFFAyKSVv3BIQhK9ZOZzt793HxhUyKftO2sHenQ==}
     engines: {node: '>=20.0.0 <=26.x.x', npm: '>=6.0.0'}
 
   '@swc/core-darwin-arm64@1.15.11':
@@ -2294,9 +2292,6 @@ packages:
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
-
-  '@swc/helpers@0.5.18':
-    resolution: {integrity: sha512-TXTnIcNJQEKwThMMqBXsZ4VGAza6bvN4pa41Rkqoio6QBKMvo+5lexeTMScGCIxtzgQJzElcvIltani+adC5PQ==}
 
   '@swc/helpers@0.5.23':
     resolution: {integrity: sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==}
@@ -2437,33 +2432,33 @@ packages:
   '@tokenizer/token@0.3.0':
     resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
 
-  '@turbo/darwin-64@2.10.11':
-    resolution: {integrity: sha512-v3R+1R/Ysozyo+p7Ri8MCIbndOvYt3DgPFrGLhrhQHfvyvbxyH3WyJj+A/2JTNmNleuAlh3JUyCV0iSVHIONTA==}
+  '@turbo/darwin-64@2.10.12':
+    resolution: {integrity: sha512-9nKgKoF6ZOUsM+or0OtNf+TTJSfGvDNP7ZFv/ZGWVwOSCkumyctQiTeHwB4UNljHTnC41AqylgbunLDHoccNrA==}
     cpu: [x64]
     os: [darwin]
 
-  '@turbo/darwin-arm64@2.10.11':
-    resolution: {integrity: sha512-R0a0CvGAeYYsBgPIgFNB3agGXh6qukjduNhFlwVVX1Ss2IdBJLXmgjytNGmo084bLKS0B6UdLRwKhXMHKKaObQ==}
+  '@turbo/darwin-arm64@2.10.12':
+    resolution: {integrity: sha512-H4Elb1jqTZVeIC9bbcNwjSzemZ6RegoTOVHeuV5Osirt2Z8UguTyisMEkvZjPVZgMeN9J4ERZBFad40tFnkb7w==}
     cpu: [arm64]
     os: [darwin]
 
-  '@turbo/linux-64@2.10.11':
-    resolution: {integrity: sha512-dGlY2vg7jpsLjGS1bf9sD/cw1sGMAYbeHGQKGRFxd5Zaj+Ufbj8cNXl/vIit8ueCU97zhL/znn60ZV5iSfZAxw==}
+  '@turbo/linux-64@2.10.12':
+    resolution: {integrity: sha512-lr7KIotukvjZwEXiFSYAeOH3BWzjFVBbSzTbv0fuGFsNukYyH0+g1hB5ecqnJkgkYU+KHEMG1edOhnjiKON1wQ==}
     cpu: [x64]
     os: [android, linux]
 
-  '@turbo/linux-arm64@2.10.11':
-    resolution: {integrity: sha512-eSP9+jjsSCBs2x0QpJZlp49dSD1EIMwXH7PsMIhdWk7w6IThhuKJ+jL95JQ2IW7tRjRmdh8gKcKQtrHLD5R5lA==}
+  '@turbo/linux-arm64@2.10.12':
+    resolution: {integrity: sha512-f0pZDTtvzB5SuNwuXBaKbZHUCMCukgc8nMlHEuvLmj91Fzec+MEbr3cAvGNor5htEDqZnO6Lxt9N/GPI/77oGA==}
     cpu: [arm64]
     os: [android, linux]
 
-  '@turbo/windows-64@2.10.11':
-    resolution: {integrity: sha512-4aD7edogJ8arK8DOyvjTI2KKwmchD5M/WM4BZgidrtFf7aSgn8Ce2rJnDwmriw980c2cKlHnhXtlGy38VtKB8g==}
+  '@turbo/windows-64@2.10.12':
+    resolution: {integrity: sha512-SDOueJRjS/QcykWf2KCRtTLmIl5YMKsLbXkXQGhDwcTXvKXZiS5ih5lBl/gkwZIpYFjqA/rAlfMzlAFcVHNe0g==}
     cpu: [x64]
     os: [win32]
 
-  '@turbo/windows-arm64@2.10.11':
-    resolution: {integrity: sha512-m8tJkIrTrbQ9O1uHxV0GUq623Zg1678xGna8eMsy4KbygUX/wVFgdZDYV/AxyoyaW/U7nyKoBvaDVwm22p9xqA==}
+  '@turbo/windows-arm64@2.10.12':
+    resolution: {integrity: sha512-0i0mVUa4kKk+/B3RwEwPMf9CB+T7ul56hn5FFHNA4VUNTOoLBEd6aNf3FaKfCatDNZ6cicCEf6if9QUTVyzzcA==}
     cpu: [arm64]
     os: [win32]
 
@@ -3852,8 +3847,8 @@ packages:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
 
-  eslint-config-next@16.3.2:
-    resolution: {integrity: sha512-gTABOJmyc6pEgSX1Z1VOjBxkSmo5Hkdj+ePclDf8HLGTsnVWzgtDdrOeQrAnUkf0JNJJhwPuXrsIwmFZRKJLoQ==}
+  eslint-config-next@16.3.3:
+    resolution: {integrity: sha512-teqtsR26tnlfXFHfVLTM/4tzEzU8DMu6GS1sddZzhfGzgd2f2ofbgDUcsk6cssSCzX6Tk6fmWifJcdANSdPJrw==}
     peerDependencies:
       eslint: '>=9.0.0'
       typescript: '>=3.3.1'
@@ -5295,10 +5290,6 @@ packages:
   markdown-it-sup@1.0.0:
     resolution: {integrity: sha512-E32m0nV9iyhRR7CrhnzL5msqic7rL1juWre6TQNxsnApg7Uf+F97JOKxUijg5YwXz86lZ0mqfOnutoryyNdntQ==}
 
-  markdown-it@14.2.0:
-    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
-    hasBin: true
-
   markdown-it@14.3.0:
     resolution: {integrity: sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==}
     hasBin: true
@@ -5621,8 +5612,8 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
-  next@16.3.2:
-    resolution: {integrity: sha512-/ZCaubUy17Lld1SiPWxuPbCk2ihqAxF2QNQaPZeEaEb7t1I58qhsJN187D7AfpapHAqUPXH0f/thtdW9dWgWFg==}
+  next@16.3.3:
+    resolution: {integrity: sha512-tuRTx1nQ/yVw83cwJBo9F+njGUgMn3UHQycreWHB8XsStvvAh1AthbI8/4IpKnFaF58F+iSiHejYOlMQ/eq83g==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -6057,8 +6048,16 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
-  posthog-js@1.418.11:
-    resolution: {integrity: sha512-pthAWcPDt2m++m1x9fn2y1uxTE6MM+BF2hegWjgPsvgEMZqaihhxOQRGxqTQy2+TMWp1ut/CRb2UqtsTJ84/Tg==}
+  posthog-js@1.420.0:
+    resolution: {integrity: sha512-tIfyJhOCD177n6s5k+0thh7US2x7ZYD0rLJlOIYikDXtjpMIqeSILuZckVedlX9kuZSdpUQvRqoQZpGx4iCqbw==}
+    peerDependencies:
+      '@types/react': '>=16.8.0'
+      react: '>=16.8.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      react:
+        optional: true
 
   preact@10.29.7:
     resolution: {integrity: sha512-DCHYrK/B10yUD3ZjLfhZ3WIE/9Vf9VFUODcRE2dRomTYDpJk6z6L9wecSfhfE6M9ZTHUdyQkoC46arIDhEV84Q==}
@@ -7040,8 +7039,8 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo@2.10.11:
-    resolution: {integrity: sha512-yQfwQVoRXwOuyX1LxiJFBFNg6VfuYh+/RyZLd82+isgyLkBXw3S5XRRzvcck1FAjSCG5sVyLd+O1eDMvYa3J7g==}
+  turbo@2.10.12:
+    resolution: {integrity: sha512-AswgMPnpOoaVZHrrSBejETzEbuIA69OVGwfkHwfrY0A23VjWXBANzgq9+OymWOHAIArB7D1+1z498WY8fGg1Jw==}
     hasBin: true
 
   type-check@0.4.0:
@@ -7356,10 +7355,6 @@ packages:
   webpack-hot-middleware@2.26.1:
     resolution: {integrity: sha512-khZGfAeJx6I8K9zKohEWWYN6KDlVw2DHownoe+6Vtwj1LP9WFgegXnVMSkZ/dBEBtXFwrkkydsaPFlB7f8wU2A==}
 
-  webpack-sources@3.3.4:
-    resolution: {integrity: sha512-7tP1PdV4vF+lYPnkMR0jMY5/la2ub5Fc/8VQrrU+lXkiM6C4TjVfGw7iKfyhnTQOsD+6Q/iKw0eFciziRgD58Q==}
-    engines: {node: '>=10.13.0'}
-
   webpack-sources@3.5.1:
     resolution: {integrity: sha512-jyuiGJdtvY434z5bUZrjz67v76/ePNvFZTp9Mdz29IlH4+GPsgyGjiv0fKI+M7BdkU6ADjulUcKAd3tUK3WlEw==}
     engines: {node: '>=10.13.0'}
@@ -7439,18 +7434,6 @@ packages:
   write-file-atomic@5.0.1:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
-
-  ws@8.21.1:
-    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   ws@8.21.2:
     resolution: {integrity: sha512-54dMVAo4WIe6SKy3vBgN+9bJZqqQ8IMRevAkOLQALhi49qkkQDQfWdAZ8KQlXiEabw88ARXXdUrlvtbKQX+aKw==}
@@ -8404,15 +8387,15 @@ snapshots:
 
   '@internationalized/date@3.12.1':
     dependencies:
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.23
 
   '@internationalized/date@3.5.4':
     dependencies:
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.23
 
   '@internationalized/number@3.5.3':
     dependencies:
-      '@swc/helpers': 0.5.18
+      '@swc/helpers': 0.5.23
 
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
@@ -8546,37 +8529,37 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.3.2': {}
+  '@next/env@16.3.3': {}
 
-  '@next/eslint-plugin-next@16.3.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))':
+  '@next/eslint-plugin-next@16.3.3(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       fast-glob: 3.3.1
     transitivePeerDependencies:
       - eslint
 
-  '@next/swc-darwin-arm64@16.3.2':
+  '@next/swc-darwin-arm64@16.3.3':
     optional: true
 
-  '@next/swc-darwin-x64@16.3.2':
+  '@next/swc-darwin-x64@16.3.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.3.2':
+  '@next/swc-linux-arm64-gnu@16.3.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.3.2':
+  '@next/swc-linux-arm64-musl@16.3.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.3.2':
+  '@next/swc-linux-x64-gnu@16.3.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.3.2':
+  '@next/swc-linux-x64-musl@16.3.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.3.2':
+  '@next/swc-win32-arm64-msvc@16.3.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.3.2':
+  '@next/swc-win32-x64-msvc@16.3.3':
     optional: true
 
   '@noble/hashes@1.8.0': {}
@@ -8630,22 +8613,18 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@posthog/browser-common@0.5.0':
+  '@posthog/browser-common@0.6.0':
     dependencies:
-      '@posthog/core': 1.47.0
-      '@posthog/types': 1.402.3
+      '@posthog/core': 1.48.11
+      '@posthog/types': 1.406.2
 
-  '@posthog/core@1.47.0':
+  '@posthog/core@1.48.11':
     dependencies:
-      '@posthog/types': 1.402.3
+      '@posthog/types': 1.405.3
 
-  '@posthog/core@1.48.8':
-    dependencies:
-      '@posthog/types': 1.405.1
+  '@posthog/types@1.405.3': {}
 
-  '@posthog/types@1.402.3': {}
-
-  '@posthog/types@1.405.1': {}
+  '@posthog/types@1.406.2': {}
 
   '@radix-ui/number@1.0.1':
     dependencies:
@@ -9438,20 +9417,20 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
-  '@strapi/admin@5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.3.4(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
+  '@strapi/admin@5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.3.4(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
     dependencies:
       '@casl/ability': 6.7.5
       '@internationalized/date': 3.12.1
       '@radix-ui/react-context': 1.0.1(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
-      '@strapi/data-transfer': 5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/data-transfer': 5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/permissions': 5.52.1(ts-toolbelt@9.6.0)
-      '@strapi/types': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/typescript-utils': 5.52.1
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/permissions': 5.52.2(ts-toolbelt@9.6.0)
+      '@strapi/types': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/typescript-utils': 5.52.2
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       '@testing-library/dom': 10.4.1
       '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
@@ -9536,20 +9515,20 @@ snapshots:
       - tedious
       - ts-toolbelt
 
-  '@strapi/admin@5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
+  '@strapi/admin@5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
     dependencies:
       '@casl/ability': 6.7.5
       '@internationalized/date': 3.12.1
       '@radix-ui/react-context': 1.0.1(@types/react@18.3.31)(react@18.3.1)
       '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
-      '@strapi/data-transfer': 5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/data-transfer': 5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/permissions': 5.52.1(ts-toolbelt@9.6.0)
-      '@strapi/types': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/typescript-utils': 5.52.1
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/permissions': 5.52.2(ts-toolbelt@9.6.0)
+      '@strapi/types': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/typescript-utils': 5.52.2
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       '@testing-library/dom': 10.4.1
       '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
@@ -9640,9 +9619,9 @@ snapshots:
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
 
-  '@strapi/cloud-cli@5.52.1(@types/node@24.13.3)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
+  '@strapi/cloud-cli@5.52.2(@types/node@24.13.3)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
     dependencies:
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       axios: 1.19.0(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)
       boxen: 5.1.2
       chalk: 4.1.2
@@ -9668,7 +9647,7 @@ snapshots:
       - supports-color
       - ts-toolbelt
 
-  '@strapi/content-manager@5.52.1(afd44853dbf2ffe1f1bbe4ed2c61a667)':
+  '@strapi/content-manager@5.52.2(026d46ea60b097d9b199ffffba82790a)':
     dependencies:
       '@casl/ability': 6.7.5
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9677,11 +9656,11 @@ snapshots:
       '@radix-ui/react-toolbar': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
       '@sindresorhus/slugify': 1.1.0
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/types': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       codemirror5: codemirror@5.65.21
       date-fns: 2.30.0
       dompurify: 3.4.13
@@ -9743,16 +9722,16 @@ snapshots:
       - ts-toolbelt
       - typescript
 
-  '@strapi/content-releases@5.52.1(524beedee4e3d98688d47c7e6633c17d)':
+  '@strapi/content-releases@5.52.2(aeb372c11bf8aa5a5770505d22d2b188)':
     dependencies:
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/content-manager': 5.52.1(afd44853dbf2ffe1f1bbe4ed2c61a667)
-      '@strapi/database': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/content-manager': 5.52.2(026d46ea60b097d9b199ffffba82790a)
+      '@strapi/database': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/types': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       date-fns: 2.30.0
       date-fns-tz: 2.0.1(date-fns@2.30.0)
       formik: 2.4.9(@types/react@18.3.31)(react@18.3.1)
@@ -9788,7 +9767,7 @@ snapshots:
       - ts-toolbelt
       - typescript
 
-  '@strapi/content-type-builder@5.52.1(93abde7e3858f89b08d8ed82130ac58a)':
+  '@strapi/content-type-builder@5.52.2(31f6413113ed61d6b0df92ef9aff89e2)':
     dependencies:
       '@ai-sdk/react': 2.0.212(react@18.3.1)(zod@3.25.76)
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -9797,11 +9776,11 @@ snapshots:
       '@dnd-kit/utilities': 3.2.2(react@18.3.1)
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
       '@sindresorhus/slugify': 1.1.0
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/generators': 5.52.1(@types/node@24.13.3)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/generators': 5.52.2(@types/node@24.13.3)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       ai: 5.0.210(zod@3.25.76)
       date-fns: 2.30.0
       fs-extra: 11.3.4
@@ -9838,22 +9817,22 @@ snapshots:
       - ts-toolbelt
       - typescript
 
-  '@strapi/core@5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
+  '@strapi/core@5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
     dependencies:
       '@casl/ability': 6.7.5
       '@koa/cors': 5.0.0
       '@koa/router': 12.0.2(supports-color@5.5.0)
       '@modelcontextprotocol/sdk': 1.30.0(supports-color@5.5.0)(zod@3.25.76)
       '@paralleldrive/cuid2': 2.2.2
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.3.4(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/database': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/generators': 5.52.1(@types/node@24.13.3)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/logger': 5.52.1
-      '@strapi/openapi': 5.52.1(supports-color@5.5.0)
-      '@strapi/permissions': 5.52.1(ts-toolbelt@9.6.0)
-      '@strapi/types': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/typescript-utils': 5.52.1
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.3.4(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/database': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/generators': 5.52.2(@types/node@24.13.3)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/logger': 5.52.2
+      '@strapi/openapi': 5.52.2(supports-color@5.5.0)
+      '@strapi/permissions': 5.52.2(ts-toolbelt@9.6.0)
+      '@strapi/types': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/typescript-utils': 5.52.2
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       '@vercel/stega': 0.1.2
       bcryptjs: 2.4.3
       boxen: 5.1.2
@@ -9932,11 +9911,11 @@ snapshots:
       - tedious
       - ts-toolbelt
 
-  '@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)':
+  '@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)':
     dependencies:
-      '@strapi/logger': 5.52.1
-      '@strapi/types': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/logger': 5.52.2
+      '@strapi/types': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       chalk: 4.1.2
       cli-table3: 0.6.5
       commander: 8.3.0
@@ -9968,10 +9947,10 @@ snapshots:
       - typescript
       - utf-8-validate
 
-  '@strapi/database@5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
+  '@strapi/database@5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
     dependencies:
       '@paralleldrive/cuid2': 2.2.2
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       ajv: 8.20.0
       date-fns: 2.30.0
       debug: 4.3.4(supports-color@5.5.0)
@@ -10035,13 +10014,13 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@strapi/email@5.52.1(2cfcaf67f3a624e463c95fc9fa5b740f)':
+  '@strapi/email@5.52.2(a76cb5edc1d8376875a8e7bdcaf5d9f5)':
     dependencies:
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/provider-email-sendmail': 5.52.1
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/provider-email-sendmail': 5.52.2
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       koa: 2.16.4(supports-color@5.5.0)
       koa2-ratelimit: 1.1.3
       lodash: 4.18.1
@@ -10069,11 +10048,11 @@ snapshots:
       - ts-toolbelt
       - typescript
 
-  '@strapi/generators@5.52.1(@types/node@24.13.3)(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
+  '@strapi/generators@5.52.2(@types/node@24.13.3)(supports-color@5.5.0)(ts-toolbelt@9.6.0)':
     dependencies:
       '@sindresorhus/slugify': 1.1.0
-      '@strapi/typescript-utils': 5.52.1
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/typescript-utils': 5.52.2
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       chalk: 4.1.2
       fs-extra: 11.3.4
       handlebars: 4.7.9
@@ -10087,14 +10066,14 @@ snapshots:
       - supports-color
       - ts-toolbelt
 
-  '@strapi/i18n@5.52.1(fc35b2cbb1831c13f9e767e42e2ce6e5)':
+  '@strapi/i18n@5.52.2(91884d5a76ccd77490a2e49022395ccb)':
     dependencies:
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/content-manager': 5.52.1(afd44853dbf2ffe1f1bbe4ed2c61a667)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/content-manager': 5.52.2(026d46ea60b097d9b199ffffba82790a)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       lodash: 4.18.1
       qs: 6.15.3
       react: 18.3.1
@@ -10125,12 +10104,12 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       styled-components: 6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@strapi/logger@5.52.1':
+  '@strapi/logger@5.52.2':
     dependencies:
       lodash: 4.18.1
       winston: 3.10.0
 
-  '@strapi/openapi@5.52.1(supports-color@5.5.0)':
+  '@strapi/openapi@5.52.2(supports-color@5.5.0)':
     dependencies:
       debug: 4.3.4(supports-color@5.5.0)
       openapi-types: 12.1.3
@@ -10138,22 +10117,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@strapi/permissions@5.52.1(ts-toolbelt@9.6.0)':
+  '@strapi/permissions@5.52.2(ts-toolbelt@9.6.0)':
     dependencies:
       '@casl/ability': 6.7.5
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       lodash: 4.18.1
       qs: 6.15.3
       sift: 16.0.1
     transitivePeerDependencies:
       - ts-toolbelt
 
-  '@strapi/plugin-cloud@5.52.1(280a9a116abfd8b1c166cd8530339838)':
+  '@strapi/plugin-cloud@5.52.2(7d7f64eb933e74d4211c4911e1c7cc7e)':
     dependencies:
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/strapi': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@swc/core@1.15.11(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(clean-css@5.3.3)(debug@4.4.3(supports-color@5.5.0))(esbuild@0.28.2)(html-minifier-terser@6.1.0)(jiti@2.7.0)(koa@2.16.4(supports-color@5.5.0))(lightningcss@1.32.0)(pg@8.23.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(terser@5.46.0)(ts-toolbelt@9.6.0)(tsx@4.23.12)(type-fest@4.41.0)(uglify-js@3.19.3)(yaml@2.9.0)
+      '@strapi/strapi': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@swc/core@1.15.11(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(clean-css@5.3.3)(debug@4.4.3(supports-color@5.5.0))(esbuild@0.28.2)(html-minifier-terser@6.1.0)(jiti@2.7.0)(koa@2.16.4(supports-color@5.5.0))(lightningcss@1.32.0)(pg@8.23.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(terser@5.46.0)(ts-toolbelt@9.6.0)(tsx@4.23.12)(type-fest@4.41.0)(uglify-js@3.19.3)(yaml@2.9.0)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       react-intl: 6.6.2(react@18.3.1)(typescript@5.9.3)
@@ -10170,12 +10149,13 @@ snapshots:
       - '@types/react-dom'
       - typescript
 
-  '@strapi/plugin-users-permissions@5.52.1(1a35c6986392e808adcfe1e1199d3166)':
+  '@strapi/plugin-users-permissions@5.52.2(c329d053f1620f341c80324a3cb09393)':
     dependencies:
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/strapi': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@swc/core@1.15.11(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(clean-css@5.3.3)(debug@4.4.3(supports-color@5.5.0))(esbuild@0.28.2)(html-minifier-terser@6.1.0)(jiti@2.7.0)(koa@2.16.4(supports-color@5.5.0))(lightningcss@1.32.0)(pg@8.23.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(terser@5.46.0)(ts-toolbelt@9.6.0)(tsx@4.23.12)(type-fest@4.41.0)(uglify-js@3.19.3)(yaml@2.9.0)
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/strapi': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@swc/core@1.15.11(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(clean-css@5.3.3)(debug@4.4.3(supports-color@5.5.0))(esbuild@0.28.2)(html-minifier-terser@6.1.0)(jiti@2.7.0)(koa@2.16.4(supports-color@5.5.0))(lightningcss@1.32.0)(pg@8.23.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(terser@5.46.0)(ts-toolbelt@9.6.0)(tsx@4.23.12)(type-fest@4.41.0)(uglify-js@3.19.3)(yaml@2.9.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       bcryptjs: 2.4.3
       formik: 2.4.9(@types/react@18.3.31)(react@18.3.1)
       immer: 9.0.21
@@ -10212,26 +10192,26 @@ snapshots:
       - ts-toolbelt
       - typescript
 
-  '@strapi/provider-email-sendmail@5.52.1':
+  '@strapi/provider-email-sendmail@5.52.2':
     dependencies:
       nodemailer: 9.0.1
 
-  '@strapi/provider-upload-local@5.52.1(ts-toolbelt@9.6.0)':
+  '@strapi/provider-upload-local@5.52.2(ts-toolbelt@9.6.0)':
     dependencies:
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       fs-extra: 11.3.4
     transitivePeerDependencies:
       - ts-toolbelt
 
-  '@strapi/review-workflows@5.52.1(504c4c38f55d98dd316d61ddf55a6ef0)':
+  '@strapi/review-workflows@5.52.2(f0b519f9af780dce4dd7b2c5e4b09ea6)':
     dependencies:
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/content-manager': 5.52.1(afd44853dbf2ffe1f1bbe4ed2c61a667)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/content-manager': 5.52.2(026d46ea60b097d9b199ffffba82790a)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/types': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/types': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       date-fns: 2.30.0
       fractional-indexing: 3.2.0
       koa: 2.16.4(supports-color@5.5.0)
@@ -10264,28 +10244,28 @@ snapshots:
       - ts-toolbelt
       - typescript
 
-  '@strapi/strapi@5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@swc/core@1.15.11(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(clean-css@5.3.3)(debug@4.4.3(supports-color@5.5.0))(esbuild@0.28.2)(html-minifier-terser@6.1.0)(jiti@2.7.0)(koa@2.16.4(supports-color@5.5.0))(lightningcss@1.32.0)(pg@8.23.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(terser@5.46.0)(ts-toolbelt@9.6.0)(tsx@4.23.12)(type-fest@4.41.0)(uglify-js@3.19.3)(yaml@2.9.0)':
+  '@strapi/strapi@5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@swc/core@1.15.11(@swc/helpers@0.5.23))(@swc/helpers@0.5.23)(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(clean-css@5.3.3)(debug@4.4.3(supports-color@5.5.0))(esbuild@0.28.2)(html-minifier-terser@6.1.0)(jiti@2.7.0)(koa@2.16.4(supports-color@5.5.0))(lightningcss@1.32.0)(pg@8.23.0)(postcss@8.5.26)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(terser@5.46.0)(ts-toolbelt@9.6.0)(tsx@4.23.12)(type-fest@4.41.0)(uglify-js@3.19.3)(yaml@2.9.0)':
     dependencies:
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.17(react-refresh@0.14.0)(type-fest@4.41.0)(webpack-hot-middleware@2.26.1)(webpack@5.109.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.26)(uglify-js@3.19.3))
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/cloud-cli': 5.52.1(@types/node@24.13.3)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/content-manager': 5.52.1(afd44853dbf2ffe1f1bbe4ed2c61a667)
-      '@strapi/content-releases': 5.52.1(524beedee4e3d98688d47c7e6633c17d)
-      '@strapi/content-type-builder': 5.52.1(93abde7e3858f89b08d8ed82130ac58a)
-      '@strapi/core': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/data-transfer': 5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/database': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/email': 5.52.1(2cfcaf67f3a624e463c95fc9fa5b740f)
-      '@strapi/generators': 5.52.1(@types/node@24.13.3)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/i18n': 5.52.1(fc35b2cbb1831c13f9e767e42e2ce6e5)
-      '@strapi/logger': 5.52.1
-      '@strapi/openapi': 5.52.1(supports-color@5.5.0)
-      '@strapi/permissions': 5.52.1(ts-toolbelt@9.6.0)
-      '@strapi/review-workflows': 5.52.1(504c4c38f55d98dd316d61ddf55a6ef0)
-      '@strapi/types': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
-      '@strapi/typescript-utils': 5.52.1
-      '@strapi/upload': 5.52.1(afd44853dbf2ffe1f1bbe4ed2c61a667)
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/cloud-cli': 5.52.2(@types/node@24.13.3)(debug@4.4.3(supports-color@5.5.0))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/content-manager': 5.52.2(026d46ea60b097d9b199ffffba82790a)
+      '@strapi/content-releases': 5.52.2(aeb372c11bf8aa5a5770505d22d2b188)
+      '@strapi/content-type-builder': 5.52.2(31f6413113ed61d6b0df92ef9aff89e2)
+      '@strapi/core': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/data-transfer': 5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/database': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/email': 5.52.2(a76cb5edc1d8376875a8e7bdcaf5d9f5)
+      '@strapi/generators': 5.52.2(@types/node@24.13.3)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/i18n': 5.52.2(91884d5a76ccd77490a2e49022395ccb)
+      '@strapi/logger': 5.52.2
+      '@strapi/openapi': 5.52.2(supports-color@5.5.0)
+      '@strapi/permissions': 5.52.2(ts-toolbelt@9.6.0)
+      '@strapi/review-workflows': 5.52.2(f0b519f9af780dce4dd7b2c5e4b09ea6)
+      '@strapi/types': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)
+      '@strapi/typescript-utils': 5.52.2
+      '@strapi/upload': 5.52.2(026d46ea60b097d9b199ffffba82790a)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       '@types/nodemon': 1.19.6
       '@vitejs/plugin-react-swc': 3.11.0(@swc/helpers@0.5.23)(vite@6.4.3(@types/node@24.13.3)(jiti@2.7.0)(lightningcss@1.32.0)(terser@5.46.0)(tsx@4.23.12)(yaml@2.9.0))
       boxen: 5.1.2
@@ -10394,16 +10374,16 @@ snapshots:
       - webpack-plugin-serve
       - yaml
 
-  '@strapi/types@5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)':
+  '@strapi/types@5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3)':
     dependencies:
       '@casl/ability': 6.7.5
       '@koa/cors': 5.0.0
       '@koa/router': 12.0.2(supports-color@5.5.0)
       '@modelcontextprotocol/sdk': 1.30.0(supports-color@5.5.0)(zod@3.25.76)
-      '@strapi/database': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/logger': 5.52.1
-      '@strapi/permissions': 5.52.1(ts-toolbelt@9.6.0)
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/database': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/logger': 5.52.2
+      '@strapi/permissions': 5.52.2(ts-toolbelt@9.6.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       commander: 8.3.0
       json-logic-js: 2.0.5
       koa: 2.16.4(supports-color@5.5.0)
@@ -10426,7 +10406,7 @@ snapshots:
       - ts-toolbelt
       - typescript
 
-  '@strapi/typescript-utils@5.52.1':
+  '@strapi/typescript-utils@5.52.2':
     dependencies:
       chalk: 4.1.2
       cli-table3: 0.6.5
@@ -10463,19 +10443,19 @@ snapshots:
       - '@types/react'
       - '@types/react-dom'
 
-  '@strapi/upload@5.52.1(afd44853dbf2ffe1f1bbe4ed2c61a667)':
+  '@strapi/upload@5.52.2(026d46ea60b097d9b199ffffba82790a)':
     dependencies:
       '@dnd-kit/core': 6.3.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@mux/mux-player-react': 3.1.0(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-dialog': 1.0.5(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toggle-group': 1.1.11(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@reduxjs/toolkit': 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(redux@4.2.1))(react@18.3.1)
-      '@strapi/admin': 5.52.1(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.1(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
-      '@strapi/database': 5.52.1(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/admin': 5.52.2(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@emotion/is-prop-valid@1.4.0)(@strapi/data-transfer@5.52.2(@types/node@24.13.3)(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)(typescript@5.9.3))(@types/hoist-non-react-statics@3.3.7(@types/react@18.3.31))(@types/node@24.13.3)(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(better-sqlite3@13.0.3)(debug@4.4.3(supports-color@5.5.0))(pg@8.23.0)(react-dom@18.3.1(react@18.3.1))(react-router-dom@6.30.6(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(react@18.3.1)(redux@4.2.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(supports-color@5.5.0)(ts-toolbelt@9.6.0)
+      '@strapi/database': 5.52.2(better-sqlite3@13.0.3)(pg@8.23.0)(supports-color@5.5.0)(ts-toolbelt@9.6.0)
       '@strapi/design-system': 2.2.4(@babel/runtime@7.28.6)(@codemirror/autocomplete@6.20.0)(@codemirror/language@6.12.1)(@codemirror/lint@6.9.4)(@codemirror/search@6.6.0)(@codemirror/theme-one-dark@6.1.3)(@strapi/icons@2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)))(@types/react-dom@18.3.7(@types/react@18.3.31))(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@strapi/icons': 2.2.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(styled-components@6.5.3(css-to-react-native@3.2.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@strapi/provider-upload-local': 5.52.1(ts-toolbelt@9.6.0)
-      '@strapi/utils': 5.52.1(ts-toolbelt@9.6.0)
+      '@strapi/provider-upload-local': 5.52.2(ts-toolbelt@9.6.0)
+      '@strapi/utils': 5.52.2(ts-toolbelt@9.6.0)
       byte-size: 8.1.1
       cropperjs: 1.6.2
       date-fns: 2.30.0
@@ -10525,7 +10505,7 @@ snapshots:
       - ts-toolbelt
       - typescript
 
-  '@strapi/utils@5.52.1(ts-toolbelt@9.6.0)':
+  '@strapi/utils@5.52.2(ts-toolbelt@9.6.0)':
     dependencies:
       '@sindresorhus/slugify': 1.1.0
       date-fns: 2.30.0
@@ -10588,10 +10568,6 @@ snapshots:
       '@swc/helpers': 0.5.23
 
   '@swc/counter@0.1.3': {}
-
-  '@swc/helpers@0.5.18':
-    dependencies:
-      tslib: 2.8.1
 
   '@swc/helpers@0.5.23':
     dependencies:
@@ -10712,22 +10688,22 @@ snapshots:
 
   '@tokenizer/token@0.3.0': {}
 
-  '@turbo/darwin-64@2.10.11':
+  '@turbo/darwin-64@2.10.12':
     optional: true
 
-  '@turbo/darwin-arm64@2.10.11':
+  '@turbo/darwin-arm64@2.10.12':
     optional: true
 
-  '@turbo/linux-64@2.10.11':
+  '@turbo/linux-64@2.10.12':
     optional: true
 
-  '@turbo/linux-arm64@2.10.11':
+  '@turbo/linux-arm64@2.10.12':
     optional: true
 
-  '@turbo/windows-64@2.10.11':
+  '@turbo/windows-64@2.10.12':
     optional: true
 
-  '@turbo/windows-arm64@2.10.11':
+  '@turbo/windows-arm64@2.10.12':
     optional: true
 
   '@tybys/wasm-util@0.10.1':
@@ -12235,7 +12211,7 @@ snapshots:
       get-tsconfig: 4.13.6
       loader-utils: 2.0.4
       webpack: 5.109.2(@swc/core@1.15.11(@swc/helpers@0.5.23))(clean-css@5.3.3)(esbuild@0.28.2)(html-minifier-terser@6.1.0)(lightningcss@1.32.0)(postcss@8.5.26)(uglify-js@3.19.3)
-      webpack-sources: 3.3.4
+      webpack-sources: 3.5.1
 
   esbuild-register@3.6.0(esbuild@0.28.2)(supports-color@5.5.0):
     dependencies:
@@ -12283,9 +12259,9 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  eslint-config-next@16.3.2(@typescript-eslint/parser@8.56.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
+  eslint-config-next@16.3.3(@typescript-eslint/parser@8.56.0(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)(typescript@5.9.3):
     dependencies:
-      '@next/eslint-plugin-next': 16.3.2(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
+      '@next/eslint-plugin-next': 16.3.3(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))
       eslint: 9.39.5(jiti@2.7.0)(supports-color@8.1.1)
       eslint-import-resolver-node: 0.3.9(supports-color@8.1.1)
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)(supports-color@8.1.1))(supports-color@8.1.1)
@@ -13899,15 +13875,6 @@ snapshots:
 
   markdown-it-sup@1.0.0: {}
 
-  markdown-it@14.2.0:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.2
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
-
   markdown-it@14.3.0:
     dependencies:
       argparse: 2.0.1
@@ -14296,9 +14263,9 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  next@16.3.2(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
+  next@16.3.3(@babel/core@7.29.0(supports-color@8.1.1))(@opentelemetry/api@1.9.0)(@types/node@24.13.3)(babel-plugin-macros@3.1.0)(react-dom@19.2.8(react@19.2.8))(react@19.2.8):
     dependencies:
-      '@next/env': 16.3.2
+      '@next/env': 16.3.3
       '@swc/helpers': 0.5.23
       baseline-browser-mapping: 2.10.0
       caniuse-lite: 1.0.30001770
@@ -14307,14 +14274,14 @@ snapshots:
       react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(@babel/core@7.29.0(supports-color@8.1.1))(babel-plugin-macros@3.1.0)(react@19.2.8)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.3.2
-      '@next/swc-darwin-x64': 16.3.2
-      '@next/swc-linux-arm64-gnu': 16.3.2
-      '@next/swc-linux-arm64-musl': 16.3.2
-      '@next/swc-linux-x64-gnu': 16.3.2
-      '@next/swc-linux-x64-musl': 16.3.2
-      '@next/swc-win32-arm64-msvc': 16.3.2
-      '@next/swc-win32-x64-msvc': 16.3.2
+      '@next/swc-darwin-arm64': 16.3.3
+      '@next/swc-darwin-x64': 16.3.3
+      '@next/swc-linux-arm64-gnu': 16.3.3
+      '@next/swc-linux-arm64-musl': 16.3.3
+      '@next/swc-linux-x64-gnu': 16.3.3
+      '@next/swc-linux-x64-musl': 16.3.3
+      '@next/swc-win32-arm64-msvc': 16.3.3
+      '@next/swc-win32-x64-msvc': 16.3.3
       '@opentelemetry/api': 1.9.0
       sharp: 0.35.3(@types/node@24.13.3)
     transitivePeerDependencies:
@@ -14771,11 +14738,11 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
-  posthog-js@1.418.11:
+  posthog-js@1.420.0(@types/react@19.2.18)(react@19.2.8):
     dependencies:
-      '@posthog/browser-common': 0.5.0
-      '@posthog/core': 1.48.8
-      '@posthog/types': 1.405.1
+      '@posthog/browser-common': 0.6.0
+      '@posthog/core': 1.48.11
+      '@posthog/types': 1.406.2
       core-js: 3.49.0
       dompurify: 3.4.13
       fflate: 0.4.8
@@ -14783,6 +14750,9 @@ snapshots:
       query-selector-shadow-dom: 1.0.1
       web-vitals: 5.3.0
       web-vitals-soft-navs: web-vitals@6.0.0
+    optionalDependencies:
+      '@types/react': 19.2.18
+      react: 19.2.8
     transitivePeerDependencies:
       - preact-render-to-string
 
@@ -15890,14 +15860,14 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo@2.10.11:
+  turbo@2.10.12:
     optionalDependencies:
-      '@turbo/darwin-64': 2.10.11
-      '@turbo/darwin-arm64': 2.10.11
-      '@turbo/linux-64': 2.10.11
-      '@turbo/linux-arm64': 2.10.11
-      '@turbo/windows-64': 2.10.11
-      '@turbo/windows-arm64': 2.10.11
+      '@turbo/darwin-64': 2.10.12
+      '@turbo/darwin-arm64': 2.10.12
+      '@turbo/linux-64': 2.10.12
+      '@turbo/linux-arm64': 2.10.12
+      '@turbo/windows-64': 2.10.12
+      '@turbo/windows-arm64': 2.10.12
 
   type-check@0.4.0:
     dependencies:
@@ -15976,7 +15946,7 @@ snapshots:
     dependencies:
       '@gerrit0/mini-shiki': 3.23.0
       lunr: 2.3.9
-      markdown-it: 14.2.0
+      markdown-it: 14.3.0
       minimatch: 10.2.6
       typescript: 5.9.3
       yaml: 2.9.0
@@ -16207,7 +16177,7 @@ snapshots:
       opener: 1.5.2
       picocolors: 1.1.1
       sirv: 3.0.2
-      ws: 8.21.1
+      ws: 8.21.2
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -16227,8 +16197,6 @@ snapshots:
       ansi-html-community: 0.0.8
       html-entities: 2.6.0
       strip-ansi: 6.0.1
-
-  webpack-sources@3.3.4: {}
 
   webpack-sources@3.5.1: {}
 
@@ -16374,8 +16342,6 @@ snapshots:
     dependencies:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
-
-  ws@8.21.1: {}
 
   ws@8.21.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -64,15 +64,55 @@ allowBuilds:
   unrs-resolver: true
 
 minimumReleaseAgeExclude:
-  - '@posthog/core@1.48.8'
-  - '@posthog/types@1.405.1'
-  - posthog-js@1.418.11
+  - '@posthog/core@1.48.8 || 1.48.11'
+  - '@posthog/types@1.405.1 || 1.406.2'
+  - posthog-js@1.420.0
   - tar@7.5.22
-  - '@posthog/browser-common@0.5.0'
-  - '@strapi/plugin-cloud@5.52.1'
-  - '@strapi/plugin-users-permissions@5.52.1'
-  - '@strapi/strapi@5.52.1'
+  - '@posthog/browser-common@0.5.0 || 0.6.0'
+  - '@strapi/plugin-cloud@5.52.2'
+  - '@strapi/plugin-users-permissions@5.52.2'
+  - '@strapi/strapi@5.52.2'
   - hono@4.13.4
   - '@hono/node-server@1.19.17'
   - yaml@1.10.3
   - '@types/react-dom@19.2.5'
+  - '@next/env@16.3.3'
+  - '@next/eslint-plugin-next@16.3.3'
+  - '@next/swc-darwin-arm64@16.3.3'
+  - '@next/swc-darwin-x64@16.3.3'
+  - '@next/swc-linux-arm64-gnu@16.3.3'
+  - '@next/swc-linux-arm64-musl@16.3.3'
+  - '@next/swc-linux-x64-gnu@16.3.3'
+  - '@next/swc-linux-x64-musl@16.3.3'
+  - '@next/swc-win32-arm64-msvc@16.3.3'
+  - '@next/swc-win32-x64-msvc@16.3.3'
+  - '@strapi/admin@5.52.2'
+  - '@strapi/cloud-cli@5.52.2'
+  - '@strapi/content-manager@5.52.2'
+  - '@strapi/content-releases@5.52.2'
+  - '@strapi/content-type-builder@5.52.2'
+  - '@strapi/core@5.52.2'
+  - '@strapi/data-transfer@5.52.2'
+  - '@strapi/database@5.52.2'
+  - '@strapi/email@5.52.2'
+  - '@strapi/generators@5.52.2'
+  - '@strapi/i18n@5.52.2'
+  - '@strapi/logger@5.52.2'
+  - '@strapi/openapi@5.52.2'
+  - '@strapi/permissions@5.52.2'
+  - '@strapi/provider-email-sendmail@5.52.2'
+  - '@strapi/provider-upload-local@5.52.2'
+  - '@strapi/review-workflows@5.52.2'
+  - '@strapi/types@5.52.2'
+  - '@strapi/typescript-utils@5.52.2'
+  - '@strapi/upload@5.52.2'
+  - '@strapi/utils@5.52.2'
+  - '@turbo/darwin-64@2.10.12'
+  - '@turbo/darwin-arm64@2.10.12'
+  - '@turbo/linux-64@2.10.12'
+  - '@turbo/linux-arm64@2.10.12'
+  - '@turbo/windows-64@2.10.12'
+  - '@turbo/windows-arm64@2.10.12'
+  - eslint-config-next@16.3.3
+  - next@16.3.3
+  - turbo@2.10.12

--- a/scripts/typecheck.test.mjs
+++ b/scripts/typecheck.test.mjs
@@ -1,0 +1,44 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+
+function read(relativePath) {
+  return readFileSync(resolve(root, relativePath), "utf8");
+}
+
+test("root typecheck runs turbo typecheck, not pnpm exec tsc", () => {
+  const pkg = JSON.parse(read("package.json"));
+  assert.equal(pkg.scripts.typecheck, "turbo typecheck");
+  assert.doesNotMatch(pkg.scripts.typecheck, /exec tsc/);
+});
+
+test("workspace packages expose a typecheck script that is tsc --noEmit", () => {
+  for (const relativePath of [
+    "apps/web/package.json",
+    "apps/cms/package.json",
+    "packages/shared/package.json",
+  ]) {
+    const pkg = JSON.parse(read(relativePath));
+    assert.equal(
+      pkg.scripts.typecheck,
+      "tsc --noEmit",
+      `${relativePath} must define typecheck as tsc --noEmit`,
+    );
+  }
+});
+
+test("Taskfile typecheck and pre-push do not use pnpm exec tsc", () => {
+  const taskfile = read("Taskfile.yml");
+  assert.doesNotMatch(taskfile, /exec tsc/);
+  assert.match(taskfile, /^  typecheck:\n(?:.*\n)*?    cmd: pnpm typecheck/m);
+});
+
+test("docs do not tell agents to pnpm exec tsc", () => {
+  assert.doesNotMatch(read("apps/web/README.md"), /exec tsc/);
+  assert.doesNotMatch(read("AGENTS.md"), /exec tsc --noEmit/);
+  assert.match(read("AGENTS.md"), /Never `pnpm --filter=\* exec tsc`/);
+});

--- a/scripts/typecheck.test.mjs
+++ b/scripts/typecheck.test.mjs
@@ -1,19 +1,42 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
+import { readdirSync, readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const SKIP_DIRS = new Set([
+  ".git",
+  ".next",
+  ".turbo",
+  ".cache",
+  "dist",
+  "node_modules",
+]);
 
 function read(relativePath) {
   return readFileSync(resolve(root, relativePath), "utf8");
 }
 
+function* walkFiles(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    if (SKIP_DIRS.has(entry.name)) {
+      continue;
+    }
+
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkFiles(path);
+      continue;
+    }
+
+    yield path;
+  }
+}
+
 test("root typecheck runs turbo typecheck, not pnpm exec tsc", () => {
   const pkg = JSON.parse(read("package.json"));
   assert.equal(pkg.scripts.typecheck, "turbo typecheck");
-  assert.doesNotMatch(pkg.scripts.typecheck, /exec tsc/);
 });
 
 test("workspace packages expose a typecheck script that is tsc --noEmit", () => {
@@ -31,14 +54,49 @@ test("workspace packages expose a typecheck script that is tsc --noEmit", () => 
   }
 });
 
-test("Taskfile typecheck and pre-push do not use pnpm exec tsc", () => {
-  const taskfile = read("Taskfile.yml");
-  assert.doesNotMatch(taskfile, /exec tsc/);
-  assert.match(taskfile, /^  typecheck:\n(?:.*\n)*?    cmd: pnpm typecheck/m);
+test("turbo.json defines a workspace typecheck task", () => {
+  const turbo = JSON.parse(read("turbo.json"));
+  assert.ok(turbo.tasks.typecheck, "turbo.json must define a typecheck task");
+  assert.deepEqual(turbo.tasks.typecheck.dependsOn, ["^typecheck"]);
+});
+
+test("Taskfile typecheck cmd is pnpm typecheck", () => {
+  assert.match(
+    read("Taskfile.yml"),
+    /^  typecheck:\n    desc: .*\n    cmd: pnpm typecheck$/m,
+  );
+});
+
+test("CI and husky invoke pnpm typecheck, not tsc via exec", () => {
+  assert.match(read(".github/workflows/ci.yml"), /^\s+run: pnpm typecheck$/m);
+  assert.match(read(".husky/pre-push"), /^pnpm typecheck && /);
 });
 
 test("docs do not tell agents to pnpm exec tsc", () => {
   assert.doesNotMatch(read("apps/web/README.md"), /exec tsc/);
   assert.doesNotMatch(read("AGENTS.md"), /exec tsc --noEmit/);
   assert.match(read("AGENTS.md"), /Never `pnpm --filter=\* exec tsc`/);
+});
+
+test("no workflow, task, or package script invokes tsc via pnpm exec", () => {
+  const allowed = new Set([
+    resolve(root, "AGENTS.md"),
+    resolve(root, "scripts/typecheck.test.mjs"),
+  ]);
+
+  for (const file of walkFiles(root)) {
+    if (allowed.has(file)) {
+      continue;
+    }
+
+    if (!/\.(md|yml|yaml|json|mjs|ts|tsx|sh)$/.test(file)) {
+      continue;
+    }
+
+    assert.doesNotMatch(
+      readFileSync(file, "utf8"),
+      /exec tsc/,
+      `${file} must not invoke tsc via pnpm exec`,
+    );
+  }
 });

--- a/turbo.json
+++ b/turbo.json
@@ -21,6 +21,9 @@
     "lint": {
       "dependsOn": ["^build"]
     },
+    "typecheck": {
+      "dependsOn": ["^typecheck"]
+    },
     "test": {
       "dependsOn": ["^build"]
     }


### PR DESCRIPTION
Closes #72.

## Why

Root `pnpm typecheck` was `pnpm --filter=web exec tsc --noEmit`. That path can re-run install, prune `packages/shared/*`, and rewrite `pnpm-lock.yaml`. CI stays green on a fresh `--frozen-lockfile` install; local/agent workflows are the footgun.

Checked against current `main` before changing anything: the `exec tsc` command is still there (Taskfile, root script, web README). On a clean tree with pnpm 11.24 the mutation did **not** reproduce, but `exec` is still the wrong API. No other open issues on this repo; adjacent same-bug surfaces (docs, Taskfile, CI's `pnpm typecheck`) are included. Typecheck expanded to all workspace packages via Turbo as agreed.

## Typecheck

- `apps/web`, `apps/cms`, and `packages/shared` each expose `"typecheck": "tsc --noEmit"`.
- Root is `turbo typecheck`. Taskfile `typecheck` / `pre-push` call that.
- `AGENTS.md` and web README: do not invoke `tsc` via `pnpm exec`. Do not add `typescript` at the root.
- Pin in `scripts/typecheck.test.mjs`.

Verified: `pnpm typecheck` exits 0 and leaves `pnpm-lock.yaml` / `packages/shared/*` unchanged.

## Deps

Latest versions this stack can actually run:

| Package | From | To |
|---|---|---|
| next / eslint-config-next | 16.3.2 | 16.3.3 |
| @strapi/strapi + plugins | 5.52.1 | 5.52.2 |
| posthog-js | 1.418.11 | 1.420.0 |
| turbo | 2.10.11 | 2.10.12 |
| pnpm (`packageManager`, hex SHA-512) | 11.23.0 | 11.24.0 |

Left alone, with reason:

- **TypeScript 7.0.2** — different compiler; Next/Strapi still on 5.9.3 (latest 5.x).
- **ESLint 10.9.1** — `eslint-plugin-react@7.37.5` from `eslint-config-next` crashes (`getFilename is not a function`). Stay on 9.39.5 (latest 9; npm marks it deprecated).
- **CMS React 19 / react-router-dom 7 / @types/node 26** — Strapi 5 peers React 18 + RRD 6; Node engines are `>=22.13 <25`, `.nvmrc` is 24. `@types/node@24.13.3` is already latest 24.

`pnpm audit --audit-level high` is clean (3 low / 2 moderate remain; same class as parked #13).

## SEO audit (live `www.mehdi-zare.com`)

DataForSEO Instant Pages homepage **onpage_score 100**. Apex → www redirect, robots, sitemap, llms.txt, JSON-LD all present.

Fixes from the crawl:

1. **Inner-page `og:title` / `twitter:title` dropped the site name.** Document title used the layout template (`About | Mehdi Zare`); Open Graph stayed `About`. `composeDocumentTitle` + `title.absolute` keep document, OG, and Twitter in sync. Homepage titles that already lead with the name are left alone.
2. **`/blog` description was the site-wide blurb.** Now a writing-specific description, shared with archive pages.
3. **`/contact` title was `Contact` while H1 / ContactPage JSON-LD said `Get in Touch`.** Metadata title now matches the visible H1.

## Verification

- `pnpm typecheck` — 3/3 packages, lockfile unchanged
- `pnpm lint` — clean
- `pnpm test` — 164 web + 16 script tests
- `DISABLE_STRAPI_CMS=true pnpm --filter=web build` — Next.js 16.3.3, exit 0
- `pnpm audit --audit-level high` — no high/critical