### PR TITLE
fix(web): composed noindex 404s and listing copy without homepage blurbs

### DIFF
--- a/apps/web/src/app/author/[slug]/page.tsx
+++ b/apps/web/src/app/author/[slug]/page.tsx
@@ -25,6 +25,11 @@ interface AuthorPageProps {
 
 type AuthorList = Awaited<ReturnType<typeof getAuthors>>["data"];
 
+function authorListingDescription(name: string, bioShort?: string | null): string {
+  const bio = bioShort?.trim();
+  return bio ? bio : `Articles by ${name}.`;
+}
+
 function getAllAuthors(): Promise<AuthorList> {
   // Shared STRAPI_MAX_PAGES cap. Extra slugs still render on demand
   // (dynamicParams defaults to true).
@@ -55,7 +60,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
 
     const role = author.jobTitle ?? author.headline ?? siteProfile.authorRole;
     const title = `${author.name} | ${role}`;
-    const description = author.bioShort ?? `Articles by ${author.name}.`;
+    const description = authorListingDescription(author.name, author.bioShort);
 
     return buildPageMetadata({
       pathname: `/author/${author.slug}`,
@@ -144,7 +149,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
   const authorPath = `/author/${author.slug}`;
   const personId = toPersonId(authorPath);
   const role = author.jobTitle ?? author.headline ?? siteProfile.authorRole;
-  const description = author.bioShort ?? `Articles by ${author.name}.`;
+  const description = authorListingDescription(author.name, author.bioShort);
   const websiteUrl =
     normalizeIdentityUrl(author.websiteUrl, CANONICAL_IDENTITY_ORIGIN) ??
     siteProfile.author.websiteUrl;

--- a/apps/web/src/app/author/[slug]/page.tsx
+++ b/apps/web/src/app/author/[slug]/page.tsx
@@ -9,6 +9,7 @@ import { getSiteProfile } from "@/lib/site-profile";
 import { fetchAllPages, getArticles, getAuthorBySlug, getAuthors } from "@/lib/strapi";
 import {
   buildBreadcrumbJsonLd,
+  buildNoIndexMetadata,
   buildPageMetadata,
   buildPersonJsonLd,
   buildProfilePageJsonLd,
@@ -49,18 +50,12 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
     const author = response.data[0];
 
     if (!author) {
-      return {
-        title: "Author Not Found",
-        robots: {
-          index: false,
-          follow: false,
-        },
-      };
+      return buildNoIndexMetadata("Author Not Found");
     }
 
     const role = author.jobTitle ?? author.headline ?? siteProfile.authorRole;
     const title = `${author.name} | ${role}`;
-    const description = author.bioShort ?? siteProfile.siteDescription;
+    const description = author.bioShort ?? `Articles by ${author.name}.`;
 
     return buildPageMetadata({
       pathname: `/author/${author.slug}`,
@@ -77,13 +72,7 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
       ],
     });
   } catch {
-    return {
-      title: "Author Not Found",
-      robots: {
-        index: false,
-        follow: false,
-      },
-    };
+    return buildNoIndexMetadata("Author Not Found");
   }
 }
 
@@ -155,7 +144,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
   const authorPath = `/author/${author.slug}`;
   const personId = toPersonId(authorPath);
   const role = author.jobTitle ?? author.headline ?? siteProfile.authorRole;
-  const description = author.bioShort ?? siteProfile.siteDescription;
+  const description = author.bioShort ?? `Articles by ${author.name}.`;
   const websiteUrl =
     normalizeIdentityUrl(author.websiteUrl, CANONICAL_IDENTITY_ORIGIN) ??
     siteProfile.author.websiteUrl;

--- a/apps/web/src/app/bina-print/page.tsx
+++ b/apps/web/src/app/bina-print/page.tsx
@@ -8,6 +8,7 @@ import { fallbackBinaPrintData } from "@/content/fallbacks";
 import { isBinaPrintEnabled } from "@/lib/feature-flags";
 import {
   buildBreadcrumbJsonLd,
+  buildNoIndexMetadata,
   buildPageMetadata,
   buildWebPageJsonLd,
 } from "@/lib/seo";
@@ -17,7 +18,9 @@ import { getBinaPrintPage } from "@/lib/strapi";
 const binaPrintMetadataTitle = "Bina Print";
 
 export async function generateMetadata(): Promise<Metadata> {
-  const siteProfile = await getSiteProfile();
+  if (!isBinaPrintEnabled()) {
+    return buildNoIndexMetadata("Bina Print Not Found");
+  }
 
   try {
     const response = await getBinaPrintPage();
@@ -26,7 +29,7 @@ export async function generateMetadata(): Promise<Metadata> {
     return buildPageMetadata({
       pathname: "/bina-print",
       title: binaPrintMetadataTitle,
-      description: cmsData?.heroSubheadline || siteProfile.siteDescription,
+      description: cmsData?.heroSubheadline || fallbackBinaPrintData.heroSubheadline,
       seo: cmsData?.seo,
       type: "website",
       keywords: [
@@ -40,7 +43,7 @@ export async function generateMetadata(): Promise<Metadata> {
     return buildPageMetadata({
       pathname: "/bina-print",
       title: binaPrintMetadataTitle,
-      description: siteProfile.siteDescription,
+      description: fallbackBinaPrintData.heroSubheadline,
       type: "website",
       keywords: [
         "AI scoring system",

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -14,6 +14,7 @@ import { getSiteProfile } from "@/lib/site-profile";
 import {
   buildBlogPostingJsonLd,
   buildBreadcrumbJsonLd,
+  buildNoIndexMetadata,
   buildPageMetadata,
   buildWebPageJsonLd,
   splitKeywords,
@@ -53,28 +54,19 @@ export async function generateStaticParams() {
 export async function generateMetadata({
   params,
 }: BlogPostPageProps): Promise<Metadata> {
-  const siteProfile = await getSiteProfile();
-
   try {
     const { slug } = await params;
     const res = await getArticleBySlug(slug);
     const article = res.data[0];
 
     if (!article) {
-      return {
-        title: "Post Not Found",
-        robots: {
-          index: false,
-          follow: false,
-        },
-      };
+      return buildNoIndexMetadata("Post Not Found");
     }
 
     const metadata = buildPageMetadata({
       pathname: `/blog/${slug}`,
       title: article.title,
-      description:
-        article.excerpt || siteProfile.siteDescription,
+      description: article.excerpt || article.title,
       seo: article.seo,
       image: article.featuredImage,
       type: "article",
@@ -92,13 +84,7 @@ export async function generateMetadata({
 
     return metadata;
   } catch {
-    return {
-      title: "Post Not Found",
-      robots: {
-        index: false,
-        follow: false,
-      },
-    };
+    return buildNoIndexMetadata("Post Not Found");
   }
 }
 
@@ -179,7 +165,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const authorLinkedIn = articleAuthor?.linkedinUrl ?? siteProfile.author.linkedinUrl;
   const authorInitials = buildInitials(authorName);
   const articleDescription =
-    article.excerpt || siteProfile.siteDescription;
+    article.excerpt || article.title;
   const primaryImage =
     toAbsoluteMediaUrl(article.seo?.metaImage?.url) ??
     toAbsoluteMediaUrl(article.featuredImage?.url);

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -66,7 +66,7 @@ export async function generateMetadata({
     const metadata = buildPageMetadata({
       pathname: `/blog/${slug}`,
       title: article.title,
-      description: article.excerpt || article.title,
+      description: article.excerpt?.trim() || article.title,
       seo: article.seo,
       image: article.featuredImage,
       type: "article",
@@ -165,7 +165,7 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const authorLinkedIn = articleAuthor?.linkedinUrl ?? siteProfile.author.linkedinUrl;
   const authorInitials = buildInitials(authorName);
   const articleDescription =
-    article.excerpt || article.title;
+    article.excerpt?.trim() || article.title;
   const primaryImage =
     toAbsoluteMediaUrl(article.seo?.metaImage?.url) ??
     toAbsoluteMediaUrl(article.featuredImage?.url);

--- a/apps/web/src/app/blog/category/[slug]/page.tsx
+++ b/apps/web/src/app/blog/category/[slug]/page.tsx
@@ -6,9 +6,10 @@ import { PostCard } from "@/components/blog/PostCard";
 import { getCategorySeedBySlug } from "@/lib/taxonomy-seed";
 import { getCategories, getCategoryBySlug, getArticles } from "@/lib/strapi";
 import {
+  buildBreadcrumbJsonLd,
+  buildNoIndexMetadata,
   buildPageMetadata,
   buildWebPageJsonLd,
-  buildBreadcrumbJsonLd,
 } from "@/lib/seo";
 
 type ArticleList = Awaited<ReturnType<typeof getArticles>>["data"];
@@ -86,13 +87,7 @@ export async function generateMetadata({
     const category = res.data[0];
 
     if (!category && !seed) {
-      return {
-        title: "Category Not Found",
-        robots: {
-          index: false,
-          follow: false,
-        },
-      };
+      return buildNoIndexMetadata("Category Not Found");
     }
 
     const fallbackName = seed?.headline ?? seed?.name ?? formatCategoryName(slug);
@@ -116,13 +111,7 @@ export async function generateMetadata({
     });
   } catch {
     if (!seed) {
-      return {
-        title: "Category Not Found",
-        robots: {
-          index: false,
-          follow: false,
-        },
-      };
+      return buildNoIndexMetadata("Category Not Found");
     }
 
     const fallbackName = seed.headline ?? seed.name ?? formatCategoryName(slug);

--- a/apps/web/src/app/blog/page/[page]/page.tsx
+++ b/apps/web/src/app/blog/page/[page]/page.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/blog-listing";
 import { getSiteProfile } from "@/lib/site-profile";
 import { getArticles } from "@/lib/strapi";
-import { buildPageMetadata, toPersonId } from "@/lib/seo";
+import { buildNoIndexMetadata, buildPageMetadata, toPersonId } from "@/lib/seo";
 
 interface BlogArchivePageProps {
   params: Promise<{ page: string }>;
@@ -39,7 +39,18 @@ export async function generateMetadata({ params }: BlogArchivePageProps): Promis
   const { page: rawPage } = await params;
   const currentPage = parsePositivePageNumber(rawPage);
 
-  const pageNumberLabel = currentPage && currentPage > 1 ? ` - Page ${currentPage}` : "";
+  if (!currentPage) {
+    return buildNoIndexMetadata("Blog Page Not Found");
+  }
+
+  if (currentPage > 1) {
+    const { pagination } = await getBlogListingData(currentPage);
+    if (pagination && currentPage > pagination.pageCount) {
+      return buildNoIndexMetadata("Blog Page Not Found");
+    }
+  }
+
+  const pageNumberLabel = currentPage > 1 ? ` - Page ${currentPage}` : "";
   const metadata = buildPageMetadata({
     pathname: "/blog",
     title: `Blog${pageNumberLabel}`,

--- a/apps/web/src/app/blog/tag/[slug]/page.tsx
+++ b/apps/web/src/app/blog/tag/[slug]/page.tsx
@@ -54,7 +54,7 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
     return buildPageMetadata({
       pathname: `/blog/tag/${slug}`,
       title: tag?.seo?.metaTitle ?? tag?.headline ?? tag?.name ?? fallbackTitle,
-      description: tag?.seo?.metaDescription ?? pageDescription,
+      description: pageDescription,
       seo: tag?.seo,
     });
   } catch {

--- a/apps/web/src/app/blog/tag/[slug]/page.tsx
+++ b/apps/web/src/app/blog/tag/[slug]/page.tsx
@@ -2,21 +2,13 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { PostCard } from "@/components/blog/PostCard";
+import { formatTagName, resolveTagListingCopy } from "@/lib/blog-listing";
 import { getTagSeedBySlug } from "@/lib/taxonomy-seed";
 import { getTags, getTagBySlug, getArticles } from "@/lib/strapi";
-import { getSiteProfile } from "@/lib/site-profile";
-import { buildPageMetadata, buildWebPageJsonLd, buildBreadcrumbJsonLd } from "@/lib/seo";
+import { buildBreadcrumbJsonLd, buildNoIndexMetadata, buildPageMetadata, buildWebPageJsonLd } from "@/lib/seo";
 
 interface TagPageProps {
   params: Promise<{ slug: string }>;
-}
-
-function formatTagName(slug: string): string {
-  return slug
-    .split("-")
-    .filter(Boolean)
-    .map((part) => part[0].toUpperCase() + part.slice(1))
-    .join(" ");
 }
 
 function buildTagHighlights(tagTitle: string): string[] {
@@ -45,39 +37,42 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
     const tag = tagRes.data[0];
 
     if (!tag && !seed) {
-      return {
-        title: "Tag Not Found",
-        robots: { index: false, follow: false },
-      };
+      return buildNoIndexMetadata("Tag Not Found");
     }
 
-    const siteProfile = await getSiteProfile();
+    const { pageDescription } = resolveTagListingCopy({
+      slug,
+      name: tag?.name,
+      seedName: seed?.name,
+      intro: tag?.intro,
+      seedIntro: seed?.intro,
+      tagDescription: tag?.description,
+      seedDescription: seed?.description,
+    });
     const fallbackTitle = seed?.headline ?? seed?.name ?? formatTagName(slug);
-    const fallbackDescription =
-      seed?.intro ?? seed?.description ?? siteProfile.siteDescription;
 
     return buildPageMetadata({
       pathname: `/blog/tag/${slug}`,
       title: tag?.seo?.metaTitle ?? tag?.headline ?? tag?.name ?? fallbackTitle,
-      description:
-        tag?.seo?.metaDescription ??
-        tag?.intro ??
-        tag?.description ??
-        fallbackDescription,
+      description: tag?.seo?.metaDescription ?? pageDescription,
       seo: tag?.seo,
     });
   } catch {
     if (!seed) {
-      return {
-        title: "Tag Not Found",
-        robots: { index: false, follow: false },
-      };
+      return buildNoIndexMetadata("Tag Not Found");
     }
+
+    const { pageDescription } = resolveTagListingCopy({
+      slug,
+      seedName: seed.name,
+      seedIntro: seed.intro,
+      seedDescription: seed.description,
+    });
 
     return buildPageMetadata({
       pathname: `/blog/tag/${slug}`,
       title: seed.headline ?? seed.name ?? formatTagName(slug),
-      description: seed.intro ?? seed.description ?? `Articles tagged ${formatTagName(slug)}.`,
+      description: pageDescription,
     });
   }
 }
@@ -119,14 +114,16 @@ export default async function TagPage({ params }: TagPageProps) {
   }
 
   const canonicalPath = `/blog/tag/${slug}`;
-  const tagName = tag?.name ?? seed?.name ?? formatTagName(slug);
+  const { tagName, pageDescription } = resolveTagListingCopy({
+    slug,
+    name: tag?.name,
+    seedName: seed?.name,
+    intro: tag?.intro,
+    seedIntro: seed?.intro,
+    tagDescription: tag?.description,
+    seedDescription: seed?.description,
+  });
   const pageTitle = tag?.headline ?? seed?.headline ?? tagName;
-  const pageDescription =
-    tag?.intro ??
-    seed?.intro ??
-    tag?.description ??
-    seed?.description ??
-    `Articles tagged ${tagName}.`;
   const highlights = buildTagHighlights(pageTitle);
 
   return (

--- a/apps/web/src/app/not-found.tsx
+++ b/apps/web/src/app/not-found.tsx
@@ -1,13 +1,8 @@
 import type { Metadata } from "next";
 import Link from "next/link";
+import { buildNoIndexMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "Page Not Found",
-  robots: {
-    index: false,
-    follow: false,
-  },
-};
+export const metadata: Metadata = buildNoIndexMetadata("Page Not Found");
 
 export default function NotFound() {
   return (

--- a/apps/web/src/lib/blog-listing.ts
+++ b/apps/web/src/lib/blog-listing.ts
@@ -5,6 +5,61 @@ export const BLOG_PAGE_SIZE = 9;
 export const BLOG_PAGE_DESCRIPTION =
   "Writing on production AI systems, LLM architecture, and shipping AI in finance, defense, healthcare, and enterprise.";
 
+function firstFilled(
+  ...values: Array<string | null | undefined>
+): string | undefined {
+  for (const value of values) {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      if (trimmed) {
+        return trimmed;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+export function formatTagName(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function resolveTagName(
+  slug: string,
+  ...candidates: Array<string | null | undefined>
+): string {
+  return firstFilled(...candidates) ?? formatTagName(slug);
+}
+
+export function buildTagListingDescription(tagName: string): string {
+  return `Articles tagged ${tagName}.`;
+}
+
+export function resolveTagListingCopy(input: {
+  slug: string;
+  name?: string | null;
+  seedName?: string | null;
+  intro?: string | null;
+  seedIntro?: string | null;
+  tagDescription?: string | null;
+  seedDescription?: string | null;
+}): { tagName: string; pageDescription: string } {
+  const tagName = resolveTagName(input.slug, input.name, input.seedName);
+  const pageDescription =
+    firstFilled(
+      input.intro,
+      input.seedIntro,
+      input.tagDescription,
+      input.seedDescription
+    ) ?? buildTagListingDescription(tagName);
+
+  return { tagName, pageDescription };
+}
+
 export function buildBlogPageUrl(page: number): string {
   return page > 1 ? `/blog/page/${page}` : "/blog";
 }

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -329,7 +329,7 @@ export function buildPageMetadata({
 }: BuildPageMetadataOptions): Metadata {
   const resolvedTitle = seo?.metaTitle?.trim() || title;
   const documentTitle = composeDocumentTitle(resolvedTitle);
-  const resolvedDescription = seo?.metaDescription ?? description;
+  const resolvedDescription = seo?.metaDescription?.trim() || description;
   const canonical = resolveCanonicalUrl(pathname, seo?.canonicalURL);
   const robots = normalizeRobotsValue(seo?.metaRobots);
   const resolvedImage = seo?.metaImage ?? image;
@@ -380,7 +380,8 @@ export function buildPageMetadata({
  * Titles + robots for not-found metadata. Absolute composed titles keep
  * document / Open Graph / Twitter in sync. A short page-specific description
  * (the route title) prevents the root layout homepage blurb from inheriting
- * onto 404s.
+ * onto 404s. Canonical and og:url are explicitly unset so Next does not
+ * merge the layout homepage `/` values onto noindex routes.
  */
 export function buildNoIndexMetadata(title: string): Metadata {
   const documentTitle = composeDocumentTitle(title);
@@ -392,9 +393,13 @@ export function buildNoIndexMetadata(title: string): Metadata {
       index: false,
       follow: false,
     },
+    alternates: {
+      canonical: null,
+    },
     openGraph: {
       title: documentTitle,
       description: title,
+      url: null,
     },
     twitter: {
       title: documentTitle,

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -376,6 +376,33 @@ export function buildPageMetadata({
   return metadata;
 }
 
+/**
+ * Titles + robots for not-found metadata. Absolute composed titles keep
+ * document / Open Graph / Twitter in sync. A short page-specific description
+ * (the route title) prevents the root layout homepage blurb from inheriting
+ * onto 404s.
+ */
+export function buildNoIndexMetadata(title: string): Metadata {
+  const documentTitle = composeDocumentTitle(title);
+
+  return {
+    title: { absolute: documentTitle },
+    description: title,
+    robots: {
+      index: false,
+      follow: false,
+    },
+    openGraph: {
+      title: documentTitle,
+      description: title,
+    },
+    twitter: {
+      title: documentTitle,
+      description: title,
+    },
+  };
+}
+
 export function buildWebsiteJsonLd(options: WebsiteJsonLdOptions = {}): Record<string, unknown> {
   const siteUrl = getSiteUrl();
   const name = options.name ?? SITE_NAME;

--- a/apps/web/tests/blog-listing.test.ts
+++ b/apps/web/tests/blog-listing.test.ts
@@ -45,6 +45,10 @@ test("tag listing copy with empty intro and description does not use the homepag
     pathname: "/blog/tag/empty-intro-tag",
     title: metadataCopy.tagName,
     description: metadataCopy.pageDescription,
+    seo: {
+      id: 1,
+      metaDescription: "",
+    },
   });
   assert.equal(metadata.description, visibleCopy.pageDescription);
   assert.equal(

--- a/apps/web/tests/blog-listing.test.ts
+++ b/apps/web/tests/blog-listing.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { DEFAULT_SITE_PROFILE } from "../src/lib/site-profile-defaults.ts";
+
+const { buildPageMetadata } = await import("../src/lib/seo.ts");
+const {
+  buildTagListingDescription,
+  formatTagName,
+  resolveTagListingCopy,
+} = await import("../src/lib/blog-listing.ts");
+
+test("buildTagListingDescription uses the shared tagged-articles sentence", () => {
+  assert.equal(buildTagListingDescription("LangGraph"), "Articles tagged LangGraph.");
+});
+
+test("tag listing copy with empty intro and description does not use the homepage blurb", () => {
+  const metadataCopy = resolveTagListingCopy({
+    slug: "empty-intro-tag",
+    name: "Empty Intro Tag",
+    seedName: "Seed Name That Should Lose",
+    intro: "",
+    seedIntro: "   ",
+    tagDescription: undefined,
+    seedDescription: null,
+  });
+  const visibleCopy = resolveTagListingCopy({
+    slug: "empty-intro-tag",
+    name: "Empty Intro Tag",
+    seedName: "Seed Name That Should Lose",
+    intro: "",
+    seedIntro: "   ",
+    tagDescription: undefined,
+    seedDescription: null,
+  });
+
+  assert.equal(metadataCopy.tagName, "Empty Intro Tag");
+  assert.equal(metadataCopy.pageDescription, "Articles tagged Empty Intro Tag.");
+  assert.equal(visibleCopy.pageDescription, metadataCopy.pageDescription);
+  assert.equal(
+    metadataCopy.pageDescription.includes(DEFAULT_SITE_PROFILE.siteDescription),
+    false
+  );
+
+  const metadata = buildPageMetadata({
+    pathname: "/blog/tag/empty-intro-tag",
+    title: metadataCopy.tagName,
+    description: metadataCopy.pageDescription,
+  });
+  assert.equal(metadata.description, visibleCopy.pageDescription);
+  assert.equal(
+    String(metadata.description).includes(DEFAULT_SITE_PROFILE.siteDescription),
+    false
+  );
+});
+
+test("tag listing copy prefers CMS or seed name over a slug-only catch-path label", () => {
+  const copy = resolveTagListingCopy({
+    slug: "llm-systems",
+    seedName: "LLM Systems",
+    seedIntro: "",
+    seedDescription: "",
+  });
+
+  assert.equal(copy.tagName, "LLM Systems");
+  assert.equal(copy.pageDescription, "Articles tagged LLM Systems.");
+  assert.notEqual(copy.pageDescription, `Articles tagged ${formatTagName("llm-systems")}.`);
+});
+
+test("tag listing copy falls back to a slug-derived name when CMS and seed names are empty", () => {
+  const copy = resolveTagListingCopy({
+    slug: "production-ai",
+    name: "",
+    seedName: undefined,
+    intro: "",
+    seedIntro: "",
+    tagDescription: "",
+    seedDescription: "",
+  });
+
+  assert.equal(copy.tagName, "Production Ai");
+  assert.equal(copy.pageDescription, "Articles tagged Production Ai.");
+});

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -5,12 +5,81 @@ import { resolve } from "node:path";
 
 const source = readFileSync(resolve(process.cwd(), "src/lib/seo.ts"), "utf8");
 
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8");
+}
+
+const noIndexCallSites = [
+  { file: "src/app/not-found.tsx", title: "Page Not Found" },
+  { file: "src/app/blog/[slug]/page.tsx", title: "Post Not Found" },
+  { file: "src/app/author/[slug]/page.tsx", title: "Author Not Found" },
+  { file: "src/app/blog/category/[slug]/page.tsx", title: "Category Not Found" },
+  { file: "src/app/blog/tag/[slug]/page.tsx", title: "Tag Not Found" },
+  { file: "src/app/blog/page/[page]/page.tsx", title: "Blog Page Not Found" },
+  { file: "src/app/bina-print/page.tsx", title: "Bina Print Not Found" },
+] as const;
+
 test("metadata builder keeps canonical URL + social metadata defaults", () => {
   assert.match(source, /resolveCanonicalUrl/);
   assert.match(source, /card: "summary_large_image"/);
   assert.match(source, /alternates:\s*{\s*canonical/);
   assert.match(source, /composeDocumentTitle/);
   assert.match(source, /title:\s*\{\s*absolute:\s*documentTitle/);
+});
+
+test("noindex metadata helper composes titles and disables indexing", () => {
+  assert.match(source, /export function buildNoIndexMetadata\(title: string\)/);
+  assert.match(source, /const documentTitle = composeDocumentTitle\(title\)/);
+  assert.match(source, /index:\s*false/);
+  assert.match(source, /follow:\s*false/);
+});
+
+test("not-found generateMetadata call sites use buildNoIndexMetadata", () => {
+  for (const { file, title } of noIndexCallSites) {
+    const pageSource = readSource(file);
+    assert.match(pageSource, /buildNoIndexMetadata/, file);
+    assert.match(pageSource, new RegExp(`buildNoIndexMetadata\\("${title}"\\)`), file);
+    assert.doesNotMatch(
+      pageSource,
+      /title:\s*"(Page|Post|Author|Category|Tag) Not Found"/,
+      file
+    );
+  }
+});
+
+test("author metadata does not fall back to the homepage site description", () => {
+  const pageSource = readSource("src/app/author/[slug]/page.tsx");
+  assert.doesNotMatch(pageSource, /siteDescription/);
+  assert.match(pageSource, /author\.bioShort \?\? `Articles by \$\{author\.name\}\.`/);
+});
+
+test("article metadata does not fall back to the homepage site description", () => {
+  const pageSource = readSource("src/app/blog/[slug]/page.tsx");
+  assert.doesNotMatch(pageSource, /siteDescription/);
+  assert.match(pageSource, /article\.excerpt \|\| article\.title/);
+});
+
+test("bina-print metadata does not fall back to the homepage site description", () => {
+  const pageSource = readSource("src/app/bina-print/page.tsx");
+  assert.doesNotMatch(pageSource, /siteDescription/);
+  assert.match(pageSource, /fallbackBinaPrintData\.heroSubheadline/);
+  assert.match(pageSource, /!isBinaPrintEnabled\(\)/);
+  assert.match(pageSource, /buildNoIndexMetadata\("Bina Print Not Found"\)/);
+});
+
+test("tag listing metadata shares the listing copy helper and never uses the site blurb", () => {
+  const pageSource = readSource("src/app/blog/tag/[slug]/page.tsx");
+  assert.match(pageSource, /resolveTagListingCopy/);
+  assert.match(pageSource, /tag\?\.seo\?\.metaDescription \?\? pageDescription/);
+  assert.doesNotMatch(pageSource, /siteDescription/);
+  assert.doesNotMatch(pageSource, /getSiteProfile/);
+});
+
+test("paginated blog 404s use the noindex helper for invalid and out-of-range pages", () => {
+  const pageSource = readSource("src/app/blog/page/[page]/page.tsx");
+  assert.match(pageSource, /buildNoIndexMetadata\("Blog Page Not Found"\)/);
+  assert.match(pageSource, /parsePositivePageNumber/);
+  assert.match(pageSource, /currentPage > pagination\.pageCount/);
 });
 
 test("website JSON-LD supports canonical overrides", () => {

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -25,6 +25,7 @@ test("metadata builder keeps canonical URL + social metadata defaults", () => {
   assert.match(source, /alternates:\s*{\s*canonical/);
   assert.match(source, /composeDocumentTitle/);
   assert.match(source, /title:\s*\{\s*absolute:\s*documentTitle/);
+  assert.match(source, /seo\?\.metaDescription\?\.trim\(\) \|\| description/);
 });
 
 test("noindex metadata helper composes titles and disables indexing", () => {
@@ -32,6 +33,8 @@ test("noindex metadata helper composes titles and disables indexing", () => {
   assert.match(source, /const documentTitle = composeDocumentTitle\(title\)/);
   assert.match(source, /index:\s*false/);
   assert.match(source, /follow:\s*false/);
+  assert.match(source, /canonical:\s*null/);
+  assert.match(source, /url:\s*null/);
 });
 
 test("not-found generateMetadata call sites use buildNoIndexMetadata", () => {
@@ -50,13 +53,15 @@ test("not-found generateMetadata call sites use buildNoIndexMetadata", () => {
 test("author metadata does not fall back to the homepage site description", () => {
   const pageSource = readSource("src/app/author/[slug]/page.tsx");
   assert.doesNotMatch(pageSource, /siteDescription/);
-  assert.match(pageSource, /author\.bioShort \?\? `Articles by \$\{author\.name\}\.`/);
+  assert.match(pageSource, /authorListingDescription\(author\.name, author\.bioShort\)/);
+  assert.match(pageSource, /bioShort\?\.trim\(\)/);
+  assert.match(pageSource, /Articles by \$\{name\}\./);
 });
 
 test("article metadata does not fall back to the homepage site description", () => {
   const pageSource = readSource("src/app/blog/[slug]/page.tsx");
   assert.doesNotMatch(pageSource, /siteDescription/);
-  assert.match(pageSource, /article\.excerpt \|\| article\.title/);
+  assert.match(pageSource, /article\.excerpt\?\.trim\(\) \|\| article\.title/);
 });
 
 test("bina-print metadata does not fall back to the homepage site description", () => {
@@ -70,7 +75,7 @@ test("bina-print metadata does not fall back to the homepage site description", 
 test("tag listing metadata shares the listing copy helper and never uses the site blurb", () => {
   const pageSource = readSource("src/app/blog/tag/[slug]/page.tsx");
   assert.match(pageSource, /resolveTagListingCopy/);
-  assert.match(pageSource, /tag\?\.seo\?\.metaDescription \?\? pageDescription/);
+  assert.match(pageSource, /description:\s*pageDescription/);
   assert.doesNotMatch(pageSource, /siteDescription/);
   assert.doesNotMatch(pageSource, /getSiteProfile/);
 });

--- a/apps/web/tests/seo-jsonld.test.ts
+++ b/apps/web/tests/seo-jsonld.test.ts
@@ -10,10 +10,12 @@ const {
   buildBlogPostingJsonLd,
   buildBlogJsonLd,
   buildFAQJsonLd,
+  buildNoIndexMetadata,
   buildPageMetadata,
   composeDocumentTitle,
   resolveCanonicalUrl,
 } = await import("../src/lib/seo.ts");
+import { DEFAULT_SITE_PROFILE } from "../src/lib/site-profile-defaults.ts";
 
 // ── WebSite JSON-LD ────────────────────────────────────────────────────
 
@@ -107,6 +109,18 @@ test("buildPageMetadata ignores blank CMS metaTitle and composes the page title"
   });
   assert.deepEqual(metadata.title, { absolute: "About | Mehdi Zare" });
   assert.equal(metadata.openGraph?.title, "About | Mehdi Zare");
+});
+
+test("buildNoIndexMetadata sets noindex and composed titles on document, Open Graph, and Twitter", () => {
+  const metadata = buildNoIndexMetadata("Post Not Found");
+  assert.deepEqual(metadata.title, { absolute: "Post Not Found | Mehdi Zare" });
+  assert.equal(metadata.openGraph?.title, "Post Not Found | Mehdi Zare");
+  assert.equal(metadata.twitter?.title, "Post Not Found | Mehdi Zare");
+  assert.deepEqual(metadata.robots, { index: false, follow: false });
+  assert.equal(metadata.description, "Post Not Found");
+  assert.equal(metadata.openGraph?.description, "Post Not Found");
+  assert.equal(metadata.twitter?.description, "Post Not Found");
+  assert.notEqual(metadata.description, DEFAULT_SITE_PROFILE.siteDescription);
 });
 
 // ── Person JSON-LD ─────────────────────────────────────────────────────

--- a/apps/web/tests/seo-jsonld.test.ts
+++ b/apps/web/tests/seo-jsonld.test.ts
@@ -111,6 +111,21 @@ test("buildPageMetadata ignores blank CMS metaTitle and composes the page title"
   assert.equal(metadata.openGraph?.title, "About | Mehdi Zare");
 });
 
+test("buildPageMetadata ignores blank CMS metaDescription", () => {
+  const metadata = buildPageMetadata({
+    pathname: "/blog/tag/empty-intro-tag",
+    title: "Empty Intro Tag",
+    description: "Articles tagged Empty Intro Tag.",
+    seo: {
+      id: 1,
+      metaDescription: "   ",
+    },
+  });
+  assert.equal(metadata.description, "Articles tagged Empty Intro Tag.");
+  assert.equal(metadata.openGraph?.description, "Articles tagged Empty Intro Tag.");
+  assert.equal(metadata.twitter?.description, "Articles tagged Empty Intro Tag.");
+});
+
 test("buildNoIndexMetadata sets noindex and composed titles on document, Open Graph, and Twitter", () => {
   const metadata = buildNoIndexMetadata("Post Not Found");
   assert.deepEqual(metadata.title, { absolute: "Post Not Found | Mehdi Zare" });
@@ -120,6 +135,8 @@ test("buildNoIndexMetadata sets noindex and composed titles on document, Open Gr
   assert.equal(metadata.description, "Post Not Found");
   assert.equal(metadata.openGraph?.description, "Post Not Found");
   assert.equal(metadata.twitter?.description, "Post Not Found");
+  assert.equal(metadata.alternates?.canonical, null);
+  assert.equal(metadata.openGraph?.url, null);
   assert.notEqual(metadata.description, DEFAULT_SITE_PROFILE.siteDescription);
 });
 


### PR DESCRIPTION
## Summary
- #74: `buildNoIndexMetadata` composes document/OG/Twitter titles and sets noindex on every 404 `generateMetadata` path, including paginated blog and the bina-print flag-off route. Canonical and `og:url` are unset so 404s do not inherit the homepage `/` values from the root layout.
- #75: Tag listings no longer fall back to `siteDescription`. Metadata, body copy, and JSON-LD share `Articles tagged ${tagName}.` when CMS/seed intro and description are empty.
- Package D leftovers: author profiles without a short bio use `Articles by {name}.` (empty/whitespace `bioShort` included); missing articles/categories use the same noindex helper; bina-print falls back to its own hero subheadline instead of the homepage blurb.
- Blank CMS `metaDescription` now falls through the same way blank `metaTitle` already did.

Closes #74
Closes #75
Follow-up: #77 (P3 category empty intro/description)

## Test plan
- [x] `pnpm --filter=web test` (180 passed locally on the review-fix commit)
- [x] `pnpm --filter=web typecheck` (Turbo / local `tsc --noEmit`)
- [ ] Author with no short bio, or a blank `bioShort`, shows `Articles by {name}.` in metadata and JSON-LD, not the homepage description
- [ ] Tag page description is the CMS/seed intro or `Articles tagged {Name}.` even when CMS `metaDescription` is blank
- [ ] 404 titles are composed (`Page Not Found | Mehdi Zare` / `Post Not Found | Mehdi Zare`, etc.) and robots are noindex; canonical/`og:url` are not the homepage
- [ ] Invalid or out-of-range `/blog/page/{n}` and bina-print with the flag off return noindex metadata
