### PR TITLE
fix(web): treat empty CMS category fields as absent in listing copy

### DIFF
--- a/apps/web/src/app/blog/category/[slug]/page.tsx
+++ b/apps/web/src/app/blog/category/[slug]/page.tsx
@@ -3,6 +3,10 @@ import Link from "next/link";
 import { notFound } from "next/navigation";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { PostCard } from "@/components/blog/PostCard";
+import {
+  resolveCategoryListingCopy,
+  resolveTaxonomyDisplayName,
+} from "@/lib/blog-listing";
 import { getCategorySeedBySlug } from "@/lib/taxonomy-seed";
 import { getCategories, getCategoryBySlug, getArticles } from "@/lib/strapi";
 import {
@@ -23,14 +27,6 @@ interface SubcategoryCard {
   name: string;
   slug: string;
   description?: string;
-}
-
-function formatCategoryName(slug: string): string {
-  return slug
-    .split("-")
-    .filter(Boolean)
-    .map((part) => part[0].toUpperCase() + part.slice(1))
-    .join(" ");
 }
 
 function buildWhatYouWillFindPoints(
@@ -90,22 +86,23 @@ export async function generateMetadata({
       return buildNoIndexMetadata("Category Not Found");
     }
 
-    const fallbackName = seed?.headline ?? seed?.name ?? formatCategoryName(slug);
-    const fallbackDescription =
-      seed?.intro ?? seed?.description ?? `Articles in ${fallbackName}`;
+    const { categoryTitle, pageDescription } = resolveCategoryListingCopy({
+      slug,
+      name: category?.name,
+      seedName: seed?.name,
+      headline: category?.headline,
+      seedHeadline: seed?.headline,
+      intro: category?.intro,
+      seedIntro: seed?.intro,
+      categoryDescription: category?.description,
+      seedDescription: seed?.description,
+    });
 
+    // buildPageMetadata already prefers a filled seo.metaTitle over this title.
     return buildPageMetadata({
       pathname: `/blog/category/${slug}`,
-      title:
-        category?.seo?.metaTitle ??
-        category?.headline ??
-        category?.name ??
-        fallbackName,
-      description:
-        category?.seo?.metaDescription ??
-        category?.intro ??
-        category?.description ??
-        fallbackDescription,
+      title: categoryTitle,
+      description: pageDescription,
       seo: category?.seo,
       type: "website",
     });
@@ -114,12 +111,18 @@ export async function generateMetadata({
       return buildNoIndexMetadata("Category Not Found");
     }
 
-    const fallbackName = seed.headline ?? seed.name ?? formatCategoryName(slug);
+    const { categoryTitle, pageDescription } = resolveCategoryListingCopy({
+      slug,
+      seedName: seed.name,
+      seedHeadline: seed.headline,
+      seedIntro: seed.intro,
+      seedDescription: seed.description,
+    });
 
     return buildPageMetadata({
       pathname: `/blog/category/${slug}`,
-      title: fallbackName,
-      description: seed.intro ?? seed.description ?? `Articles in ${fallbackName}`,
+      title: categoryTitle,
+      description: pageDescription,
       type: "website",
     });
   }
@@ -141,27 +144,38 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
     notFound();
   }
 
-  const categoryName = category?.name ?? seed?.name ?? formatCategoryName(slug);
-  const categoryTitle = category?.headline ?? seed?.headline ?? categoryName;
-  const categoryDescription =
-    category?.intro ??
-    seed?.intro ??
-    category?.description ??
-    seed?.description ??
-    `Articles in ${categoryName}`;
+  const {
+    categoryName,
+    categoryTitle,
+    pageDescription: categoryDescription,
+  } = resolveCategoryListingCopy({
+    slug,
+    name: category?.name,
+    seedName: seed?.name,
+    headline: category?.headline,
+    seedHeadline: seed?.headline,
+    intro: category?.intro,
+    seedIntro: seed?.intro,
+    categoryDescription: category?.description,
+    seedDescription: seed?.description,
+  });
 
   const parentSeed = seed?.parentSlug ? getCategorySeedBySlug(seed.parentSlug) : undefined;
   const parentInfo = category?.parent
     ? {
-        name: category.parent.name,
+        name: resolveTaxonomyDisplayName(
+          category.parent.slug,
+          category.parent.name
+        ),
         slug: category.parent.slug,
       }
     : parentSeed
       ? {
-          name:
-            parentSeed.name ??
-            parentSeed.headline ??
-            formatCategoryName(parentSeed.slug),
+          name: resolveTaxonomyDisplayName(
+            parentSeed.slug,
+            parentSeed.name,
+            parentSeed.headline
+          ),
           slug: parentSeed.slug,
         }
       : null;
@@ -170,13 +184,17 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
     category?.children && category.children.length > 0
       ? category.children.map((child) => ({
           id: child.id,
-          name: child.name,
+          name: resolveTaxonomyDisplayName(child.slug, child.name),
           slug: child.slug,
           description: child.description,
         }))
       : (seed?.children ?? []).map((child) => ({
           id: child.slug,
-          name: child.name ?? child.headline ?? formatCategoryName(child.slug),
+          name: resolveTaxonomyDisplayName(
+            child.slug,
+            child.name,
+            child.headline
+          ),
           slug: child.slug,
           description: child.description,
         }));

--- a/apps/web/src/app/blog/category/[slug]/page.tsx
+++ b/apps/web/src/app/blog/category/[slug]/page.tsx
@@ -165,7 +165,8 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
     ? {
         name: resolveTaxonomyDisplayName(
           category.parent.slug,
-          category.parent.name
+          category.parent.name,
+          category.parent.headline
         ),
         slug: category.parent.slug,
       }
@@ -184,7 +185,11 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
     category?.children && category.children.length > 0
       ? category.children.map((child) => ({
           id: child.id,
-          name: resolveTaxonomyDisplayName(child.slug, child.name),
+          name: resolveTaxonomyDisplayName(
+            child.slug,
+            child.name,
+            child.headline
+          ),
           slug: child.slug,
           description: child.description,
         }))

--- a/apps/web/src/app/blog/tag/[slug]/page.tsx
+++ b/apps/web/src/app/blog/tag/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { PostCard } from "@/components/blog/PostCard";
-import { formatTagName, resolveTagListingCopy } from "@/lib/blog-listing";
+import { formatSlugName, resolveTagListingCopy } from "@/lib/blog-listing";
 import { getTagSeedBySlug } from "@/lib/taxonomy-seed";
 import { getTags, getTagBySlug, getArticles } from "@/lib/strapi";
 import { buildBreadcrumbJsonLd, buildNoIndexMetadata, buildPageMetadata, buildWebPageJsonLd } from "@/lib/seo";
@@ -49,7 +49,7 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
       tagDescription: tag?.description,
       seedDescription: seed?.description,
     });
-    const fallbackTitle = seed?.headline ?? seed?.name ?? formatTagName(slug);
+    const fallbackTitle = seed?.headline ?? seed?.name ?? formatSlugName(slug);
 
     return buildPageMetadata({
       pathname: `/blog/tag/${slug}`,
@@ -71,7 +71,7 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
 
     return buildPageMetadata({
       pathname: `/blog/tag/${slug}`,
-      title: seed.headline ?? seed.name ?? formatTagName(slug),
+      title: seed.headline ?? seed.name ?? formatSlugName(slug),
       description: pageDescription,
     });
   }

--- a/apps/web/src/lib/blog-listing.ts
+++ b/apps/web/src/lib/blog-listing.ts
@@ -20,7 +20,8 @@ function firstFilled(
   return undefined;
 }
 
-export function formatTagName(slug: string): string {
+/** Title-cases a taxonomy slug for use as a last-resort display label. */
+export function formatSlugName(slug: string): string {
   return slug
     .split("-")
     .filter(Boolean)
@@ -28,11 +29,15 @@ export function formatTagName(slug: string): string {
     .join(" ");
 }
 
-export function resolveTagName(
+/**
+ * Picks the first non-blank candidate, treating CMS empty strings and
+ * whitespace as absent, and falls back to the slug-derived label.
+ */
+export function resolveTaxonomyDisplayName(
   slug: string,
   ...candidates: Array<string | null | undefined>
 ): string {
-  return firstFilled(...candidates) ?? formatTagName(slug);
+  return firstFilled(...candidates) ?? formatSlugName(slug);
 }
 
 export function buildTagListingDescription(tagName: string): string {
@@ -48,7 +53,7 @@ export function resolveTagListingCopy(input: {
   tagDescription?: string | null;
   seedDescription?: string | null;
 }): { tagName: string; pageDescription: string } {
-  const tagName = resolveTagName(input.slug, input.name, input.seedName);
+  const tagName = resolveTaxonomyDisplayName(input.slug, input.name, input.seedName);
   const pageDescription =
     firstFilled(
       input.intro,
@@ -58,6 +63,45 @@ export function resolveTagListingCopy(input: {
     ) ?? buildTagListingDescription(tagName);
 
   return { tagName, pageDescription };
+}
+
+export function buildCategoryListingDescription(categoryName: string): string {
+  return `Articles in ${categoryName}.`;
+}
+
+/**
+ * Resolves the three strings a category listing renders -- breadcrumb name,
+ * display title, and description -- from CMS values with seed fallbacks.
+ * Headline wins over name across both sources so the metadata title, the h1,
+ * and the JSON-LD name always agree.
+ */
+export function resolveCategoryListingCopy(input: {
+  slug: string;
+  name?: string | null;
+  seedName?: string | null;
+  headline?: string | null;
+  seedHeadline?: string | null;
+  intro?: string | null;
+  seedIntro?: string | null;
+  categoryDescription?: string | null;
+  seedDescription?: string | null;
+}): { categoryName: string; categoryTitle: string; pageDescription: string } {
+  const categoryName = resolveTaxonomyDisplayName(
+    input.slug,
+    input.name,
+    input.seedName
+  );
+  const categoryTitle =
+    firstFilled(input.headline, input.seedHeadline) ?? categoryName;
+  const pageDescription =
+    firstFilled(
+      input.intro,
+      input.seedIntro,
+      input.categoryDescription,
+      input.seedDescription
+    ) ?? buildCategoryListingDescription(categoryName);
+
+  return { categoryName, categoryTitle, pageDescription };
 }
 
 export function buildBlogPageUrl(page: number): string {

--- a/apps/web/tests/blog-listing.test.ts
+++ b/apps/web/tests/blog-listing.test.ts
@@ -5,8 +5,11 @@ import { DEFAULT_SITE_PROFILE } from "../src/lib/site-profile-defaults.ts";
 const { buildPageMetadata } = await import("../src/lib/seo.ts");
 const {
   buildTagListingDescription,
-  formatTagName,
+  buildCategoryListingDescription,
+  formatSlugName,
+  resolveTaxonomyDisplayName,
   resolveTagListingCopy,
+  resolveCategoryListingCopy,
 } = await import("../src/lib/blog-listing.ts");
 
 test("buildTagListingDescription uses the shared tagged-articles sentence", () => {
@@ -67,7 +70,7 @@ test("tag listing copy prefers CMS or seed name over a slug-only catch-path labe
 
   assert.equal(copy.tagName, "LLM Systems");
   assert.equal(copy.pageDescription, "Articles tagged LLM Systems.");
-  assert.notEqual(copy.pageDescription, `Articles tagged ${formatTagName("llm-systems")}.`);
+  assert.notEqual(copy.pageDescription, `Articles tagged ${formatSlugName("llm-systems")}.`);
 });
 
 test("tag listing copy falls back to a slug-derived name when CMS and seed names are empty", () => {
@@ -83,4 +86,132 @@ test("tag listing copy falls back to a slug-derived name when CMS and seed names
 
   assert.equal(copy.tagName, "Production Ai");
   assert.equal(copy.pageDescription, "Articles tagged Production Ai.");
+});
+
+test("buildCategoryListingDescription uses the shared in-category sentence", () => {
+  assert.equal(buildCategoryListingDescription("AI Engineering"), "Articles in AI Engineering.");
+});
+
+test("category listing copy with empty intro and description does not emit blank copy", () => {
+  const metadataCopy = resolveCategoryListingCopy({
+    slug: "empty-intro-category",
+    name: "Empty Intro Category",
+    seedName: "Seed Name That Should Lose",
+    intro: "",
+    seedIntro: "   ",
+    categoryDescription: undefined,
+    seedDescription: null,
+  });
+
+  assert.equal(metadataCopy.categoryName, "Empty Intro Category");
+  assert.equal(metadataCopy.pageDescription, "Articles in Empty Intro Category.");
+
+  const metadata = buildPageMetadata({
+    pathname: "/blog/category/empty-intro-category",
+    title: metadataCopy.categoryName,
+    description: metadataCopy.pageDescription,
+    seo: {
+      id: 1,
+      metaDescription: "",
+    },
+  });
+  assert.equal(metadata.description, metadataCopy.pageDescription);
+  assert.notEqual(metadata.description, "");
+});
+
+test("category listing copy prefers CMS or seed name over a slug-only catch-path label", () => {
+  const copy = resolveCategoryListingCopy({
+    slug: "llm-systems",
+    seedName: "LLM Systems",
+    seedIntro: "",
+    seedDescription: "",
+  });
+
+  assert.equal(copy.categoryName, "LLM Systems");
+  assert.equal(copy.pageDescription, "Articles in LLM Systems.");
+  assert.notEqual(copy.pageDescription, `Articles in ${formatSlugName("llm-systems")}.`);
+});
+
+test("category listing copy falls back to a slug-derived name when CMS and seed names are empty", () => {
+  const copy = resolveCategoryListingCopy({
+    slug: "production-ai",
+    name: "",
+    seedName: undefined,
+    intro: "",
+    seedIntro: "",
+    categoryDescription: "",
+    seedDescription: "",
+  });
+
+  assert.equal(copy.categoryName, "Production Ai");
+  assert.equal(copy.pageDescription, "Articles in Production Ai.");
+});
+
+test("resolveTaxonomyDisplayName skips empty and whitespace candidates", () => {
+  assert.equal(
+    resolveTaxonomyDisplayName("agent-frameworks", "", "   ", "Agent Frameworks"),
+    "Agent Frameworks"
+  );
+});
+
+test("resolveTaxonomyDisplayName falls back to the slug label when every candidate is blank", () => {
+  assert.equal(
+    resolveTaxonomyDisplayName("agent-frameworks", "", null, undefined, "  "),
+    "Agent Frameworks"
+  );
+});
+
+test("resolveTaxonomyDisplayName trims the candidate it returns", () => {
+  assert.equal(resolveTaxonomyDisplayName("llm-systems", "  LLM Systems  "), "LLM Systems");
+});
+
+test("category listing copy falls back to the resolved name when every headline is empty", () => {
+  const copy = resolveCategoryListingCopy({
+    slug: "ai-engineering",
+    name: "AI Engineering",
+    headline: "",
+    seedHeadline: "   ",
+    intro: "Real intro copy.",
+  });
+
+  assert.equal(copy.categoryTitle, "AI Engineering");
+  assert.notEqual(copy.categoryTitle, "");
+});
+
+test("category listing copy prefers a filled headline over the category name", () => {
+  const copy = resolveCategoryListingCopy({
+    slug: "ai-engineering",
+    name: "AI Engineering",
+    headline: "Building AI That Ships",
+    intro: "Real intro copy.",
+  });
+
+  assert.equal(copy.categoryTitle, "Building AI That Ships");
+  assert.equal(copy.categoryName, "AI Engineering");
+});
+
+test("category listing copy prefers a seed headline over the CMS name", () => {
+  const copy = resolveCategoryListingCopy({
+    slug: "ai-engineering",
+    name: "AI Engineering",
+    headline: "",
+    seedHeadline: "Seed Headline",
+    intro: "Real intro copy.",
+  });
+
+  assert.equal(copy.categoryTitle, "Seed Headline");
+});
+
+test("category listing copy title falls back to the slug label when name and headline are blank", () => {
+  const copy = resolveCategoryListingCopy({
+    slug: "production-ai",
+    name: "",
+    headline: "",
+    seedName: "  ",
+    seedHeadline: null,
+  });
+
+  assert.equal(copy.categoryTitle, "Production Ai");
+  assert.equal(copy.categoryName, "Production Ai");
+  assert.equal(copy.pageDescription, "Articles in Production Ai.");
 });

--- a/apps/web/tests/blog-listing.test.ts
+++ b/apps/web/tests/blog-listing.test.ts
@@ -108,7 +108,7 @@ test("category listing copy with empty intro and description does not emit blank
 
   const metadata = buildPageMetadata({
     pathname: "/blog/category/empty-intro-category",
-    title: metadataCopy.categoryName,
+    title: metadataCopy.categoryTitle,
     description: metadataCopy.pageDescription,
     seo: {
       id: 1,
@@ -163,6 +163,13 @@ test("resolveTaxonomyDisplayName falls back to the slug label when every candida
 
 test("resolveTaxonomyDisplayName trims the candidate it returns", () => {
   assert.equal(resolveTaxonomyDisplayName("llm-systems", "  LLM Systems  "), "LLM Systems");
+});
+
+test("resolveTaxonomyDisplayName prefers a filled headline when name is empty", () => {
+  assert.equal(
+    resolveTaxonomyDisplayName("agent-frameworks", "", "Agent Frameworks Headline"),
+    "Agent Frameworks Headline"
+  );
 });
 
 test("category listing copy falls back to the resolved name when every headline is empty", () => {

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -101,6 +101,8 @@ test("category listing title comes from the shared copy helper, not a raw headli
 test("category listing parent and subcategory names route through the display-name helper", () => {
   const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
   assert.match(pageSource, /resolveTaxonomyDisplayName/);
+  assert.match(pageSource, /category\.parent\.name,\s*category\.parent\.headline/);
+  assert.match(pageSource, /child\.name,\s*child\.headline/);
   assert.doesNotMatch(pageSource, /name:\s*category\.parent\.name,/);
   assert.doesNotMatch(pageSource, /name:\s*child\.name,/);
   assert.doesNotMatch(pageSource, /child\.name\s*\?\?\s*child\.headline/);

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -80,6 +80,33 @@ test("tag listing metadata shares the listing copy helper and never uses the sit
   assert.doesNotMatch(pageSource, /getSiteProfile/);
 });
 
+test("category listing metadata shares the listing copy helper for intro and description", () => {
+  const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
+  assert.match(pageSource, /resolveCategoryListingCopy/);
+  assert.match(pageSource, /description:\s*pageDescription/);
+  assert.doesNotMatch(
+    pageSource,
+    /category\?\.intro\s*\?\?\s*category\?\.description/
+  );
+});
+
+test("category listing title comes from the shared copy helper, not a raw headline chain", () => {
+  const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
+  assert.match(pageSource, /title:\s*categoryTitle/);
+  assert.doesNotMatch(pageSource, /category\?\.headline\s*\?\?/);
+  assert.doesNotMatch(pageSource, /seed\??\.headline\s*\?\?/);
+  assert.doesNotMatch(pageSource, /category\?\.seo\?\.metaTitle\s*\?\?/);
+});
+
+test("category listing parent and subcategory names route through the display-name helper", () => {
+  const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
+  assert.match(pageSource, /resolveTaxonomyDisplayName/);
+  assert.doesNotMatch(pageSource, /name:\s*category\.parent\.name,/);
+  assert.doesNotMatch(pageSource, /name:\s*child\.name,/);
+  assert.doesNotMatch(pageSource, /child\.name\s*\?\?\s*child\.headline/);
+  assert.doesNotMatch(pageSource, /formatCategoryName/);
+});
+
 test("paginated blog 404s use the noindex helper for invalid and out-of-range pages", () => {
   const pageSource = readSource("src/app/blog/page/[page]/page.tsx");
   assert.match(pageSource, /buildNoIndexMetadata\("Blog Page Not Found"\)/);

--- a/scripts/typecheck.test.mjs
+++ b/scripts/typecheck.test.mjs
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync } from "node:fs";
+import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -10,6 +10,7 @@ const SKIP_DIRS = new Set([
   ".next",
   ".turbo",
   ".cache",
+  ".worktrees",
   "dist",
   "node_modules",
 ]);
@@ -98,5 +99,30 @@ test("no workflow, task, or package script invokes tsc via pnpm exec", () => {
       /exec tsc/,
       `${file} must not invoke tsc via pnpm exec`,
     );
+  }
+});
+
+test("the scanner does not descend into nested worktree checkouts", () => {
+  // A git worktree under .worktrees/ is a second checkout of this repo, so it
+  // carries its own AGENTS.md. That copy is not the allowlisted root path, and
+  // AGENTS.md documents the banned command by name -- scanning it trips the
+  // guard on its own prose and blocks every push.
+  const fixtureDir = resolve(root, ".worktrees/__scanner_fixture__");
+  mkdirSync(fixtureDir, { recursive: true });
+  writeFileSync(resolve(fixtureDir, "AGENTS.md"), "pnpm --filter=* exec tsc\n");
+
+  try {
+    const worktreesRoot = resolve(root, ".worktrees");
+    const scanned = [...walkFiles(root)].filter((file) =>
+      file.startsWith(`${worktreesRoot}/`),
+    );
+
+    assert.deepEqual(
+      scanned,
+      [],
+      "walkFiles must skip .worktrees so sibling checkouts are not scanned",
+    );
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Closes #77.

## Problem

Category listings resolved every display string with `??`, so a CMS empty string or whitespace won the chain and rendered as blank. #76 fixed this for tag listings via `firstFilled`; category listings kept the `??` chains.

The blast radius was wider than intro/description alone — #77 names metadata, visible copy, **and** JSON-LD as in scope:

| Location | Leak |
|---|---|
| `generateMetadata` | empty `intro`/`description` → blank meta description |
| page body | empty `headline` → blank `<h1>`, blank JSON-LD `name`, and a `Production-focused implementation patterns for .` bullet |
| `parentInfo` | empty CMS `parent.name` → blank breadcrumb crumb in the nav **and** in BreadcrumbList JSON-LD |
| `subcategories` | empty CMS `child.name` → blank subcategory link text and a blank `Focused tracks:` entry |

## Fix

Route every category display string through the same filled-string rule tags use.

- `formatTagName` + `formatCategoryName` (byte-identical) collapse into one `formatSlugName`; `resolveTagName` + `resolveCategoryName` collapse into one exported `resolveTaxonomyDisplayName`.
- `resolveCategoryListingCopy` gains `headline`/`seedHeadline` inputs and returns `categoryTitle`, so the metadata title, the `<h1>`, and the JSON-LD `name` all read one string.
- Breadcrumb parent and subcategory names resolve through the shared helper instead of raw CMS fields.

The only `??` left in the category page are on an array default and two date fields.

## Deliberate behavior changes

1. **Metadata title and `<h1>` no longer disagree.** Metadata resolved `cmsHeadline → cmsName → seedHeadline → seedName`; the body resolved `cmsHeadline → seedHeadline → cmsName → seedName`. A category with a CMS name, no CMS headline, and a seed headline rendered one string in `<title>` and a different one in `<h1>`. Both now use the body's order.
2. **Fallback sentence gains a period** — `Articles in X.`, matching the tag helper's `Articles tagged X.`. Affects only categories with neither intro nor description.

`buildPageMetadata` already prefers a filled `seo.metaTitle`/`seo.metaDescription`, so those redundant fields are dropped from the page's own chains.

## Unrelated blocker fixed in the second commit

`scripts/typecheck.test.mjs` failed the pre-push hook on a clean tree. `SKIP_DIRS` omitted `.worktrees`, so the pnpm-exec-tsc guard walked into every git worktree — each a full second checkout of this repo — and read its copy of `AGENTS.md`. The `allowed` set exempts `AGENTS.md` by root absolute path only, so the worktree copy was not exempt, and `AGENTS.md` documents the banned command by name. The guard tripped on its own prose and blocked pushes for anyone with a worktree checked out.

Fixed by skipping `.worktrees`, pinned by a test that plants a violating fixture there and asserts the scan never reaches it — so the fix doesn't depend on which worktrees happen to exist. Happy to split this into its own PR if you'd rather.

## Verification

- `pnpm test` — 194/194 web, 20/20 scripts, 0 failures
- `pnpm typecheck --force` — 3/3 packages, 0 cached
- `npx eslint src tests` — exit 0

Red-green was watched for every test: the 7 new helper tests failed on missing `formatSlugName`/`resolveTaxonomyDisplayName`/`categoryTitle`, the 2 new contract tests failed before the page was rewired, and the worktree-scanner test failed with `walkFiles must skip .worktrees` before `SKIP_DIRS` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)