### PR TITLE
fix(web): route tag listing titles through the shared taxonomy helper

### DIFF
--- a/apps/web/src/app/blog/tag/[slug]/page.tsx
+++ b/apps/web/src/app/blog/tag/[slug]/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { PostCard } from "@/components/blog/PostCard";
-import { formatSlugName, resolveTagListingCopy } from "@/lib/blog-listing";
+import { resolveTagListingCopy } from "@/lib/blog-listing";
 import { getTagSeedBySlug } from "@/lib/taxonomy-seed";
 import { getTags, getTagBySlug, getArticles } from "@/lib/strapi";
 import { buildBreadcrumbJsonLd, buildNoIndexMetadata, buildPageMetadata, buildWebPageJsonLd } from "@/lib/seo";
@@ -40,20 +40,22 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
       return buildNoIndexMetadata("Tag Not Found");
     }
 
-    const { pageDescription } = resolveTagListingCopy({
+    const { tagTitle, pageDescription } = resolveTagListingCopy({
       slug,
       name: tag?.name,
       seedName: seed?.name,
+      headline: tag?.headline,
+      seedHeadline: seed?.headline,
       intro: tag?.intro,
       seedIntro: seed?.intro,
       tagDescription: tag?.description,
       seedDescription: seed?.description,
     });
-    const fallbackTitle = seed?.headline ?? seed?.name ?? formatSlugName(slug);
 
+    // buildPageMetadata already prefers a filled seo.metaTitle over this title.
     return buildPageMetadata({
       pathname: `/blog/tag/${slug}`,
-      title: tag?.seo?.metaTitle ?? tag?.headline ?? tag?.name ?? fallbackTitle,
+      title: tagTitle,
       description: pageDescription,
       seo: tag?.seo,
     });
@@ -62,16 +64,17 @@ export async function generateMetadata({ params }: TagPageProps): Promise<Metada
       return buildNoIndexMetadata("Tag Not Found");
     }
 
-    const { pageDescription } = resolveTagListingCopy({
+    const { tagTitle, pageDescription } = resolveTagListingCopy({
       slug,
       seedName: seed.name,
+      seedHeadline: seed.headline,
       seedIntro: seed.intro,
       seedDescription: seed.description,
     });
 
     return buildPageMetadata({
       pathname: `/blog/tag/${slug}`,
-      title: seed.headline ?? seed.name ?? formatSlugName(slug),
+      title: tagTitle,
       description: pageDescription,
     });
   }
@@ -114,17 +117,18 @@ export default async function TagPage({ params }: TagPageProps) {
   }
 
   const canonicalPath = `/blog/tag/${slug}`;
-  const { tagName, pageDescription } = resolveTagListingCopy({
+  const { tagName, tagTitle, pageDescription } = resolveTagListingCopy({
     slug,
     name: tag?.name,
     seedName: seed?.name,
+    headline: tag?.headline,
+    seedHeadline: seed?.headline,
     intro: tag?.intro,
     seedIntro: seed?.intro,
     tagDescription: tag?.description,
     seedDescription: seed?.description,
   });
-  const pageTitle = tag?.headline ?? seed?.headline ?? tagName;
-  const highlights = buildTagHighlights(pageTitle);
+  const highlights = buildTagHighlights(tagTitle);
 
   return (
     <>
@@ -132,7 +136,7 @@ export default async function TagPage({ params }: TagPageProps) {
         id="tag-webpage-jsonld"
         data={buildWebPageJsonLd({
           pathname: canonicalPath,
-          title: pageTitle,
+          title: tagTitle,
           description: pageDescription,
           type: "CollectionPage",
         })}
@@ -150,7 +154,7 @@ export default async function TagPage({ params }: TagPageProps) {
           <div className="mb-12">
             <p className="font-mono text-xs uppercase tracking-[0.25em] text-mid-gray">Tag</p>
             <h1 className="mt-4 font-serif text-4xl text-ink sm:text-5xl">
-              {pageTitle}
+              {tagTitle}
             </h1>
             <p className="mt-4 text-lg text-mid-gray">{pageDescription}</p>
           </div>

--- a/apps/web/src/lib/blog-listing.ts
+++ b/apps/web/src/lib/blog-listing.ts
@@ -44,25 +44,74 @@ export function buildTagListingDescription(tagName: string): string {
   return `Articles tagged ${tagName}.`;
 }
 
-export function resolveTagListingCopy(input: {
+/**
+ * Shared resolution for every taxonomy listing: the display name used for
+ * breadcrumbs, the title used for metadata / h1 / JSON-LD, and the page
+ * description. Every candidate goes through `firstFilled`, so a CMS empty
+ * string or whitespace-only value is treated as absent instead of winning
+ * the chain and rendering blank. Tags and categories share this so the two
+ * routes cannot drift apart again.
+ */
+function resolveTaxonomyListingCopy(input: {
   slug: string;
   name?: string | null;
   seedName?: string | null;
+  headline?: string | null;
+  seedHeadline?: string | null;
   intro?: string | null;
   seedIntro?: string | null;
-  tagDescription?: string | null;
+  description?: string | null;
   seedDescription?: string | null;
-}): { tagName: string; pageDescription: string } {
-  const tagName = resolveTaxonomyDisplayName(input.slug, input.name, input.seedName);
+  buildFallbackDescription: (displayName: string) => string;
+}): { displayName: string; title: string; pageDescription: string } {
+  const displayName = resolveTaxonomyDisplayName(
+    input.slug,
+    input.name,
+    input.seedName
+  );
+  const title = firstFilled(input.headline, input.seedHeadline) ?? displayName;
   const pageDescription =
     firstFilled(
       input.intro,
       input.seedIntro,
-      input.tagDescription,
+      input.description,
       input.seedDescription
-    ) ?? buildTagListingDescription(tagName);
+    ) ?? input.buildFallbackDescription(displayName);
 
-  return { tagName, pageDescription };
+  return { displayName, title, pageDescription };
+}
+
+/**
+ * Resolves the three strings a tag listing renders -- breadcrumb name,
+ * display title, and description -- from CMS values with seed fallbacks.
+ * Headline wins over name across both sources so the metadata title, the h1,
+ * and the JSON-LD name always agree.
+ */
+export function resolveTagListingCopy(input: {
+  slug: string;
+  name?: string | null;
+  seedName?: string | null;
+  headline?: string | null;
+  seedHeadline?: string | null;
+  intro?: string | null;
+  seedIntro?: string | null;
+  tagDescription?: string | null;
+  seedDescription?: string | null;
+}): { tagName: string; tagTitle: string; pageDescription: string } {
+  const { displayName, title, pageDescription } = resolveTaxonomyListingCopy({
+    slug: input.slug,
+    name: input.name,
+    seedName: input.seedName,
+    headline: input.headline,
+    seedHeadline: input.seedHeadline,
+    intro: input.intro,
+    seedIntro: input.seedIntro,
+    description: input.tagDescription,
+    seedDescription: input.seedDescription,
+    buildFallbackDescription: buildTagListingDescription,
+  });
+
+  return { tagName: displayName, tagTitle: title, pageDescription };
 }
 
 export function buildCategoryListingDescription(categoryName: string): string {
@@ -86,22 +135,20 @@ export function resolveCategoryListingCopy(input: {
   categoryDescription?: string | null;
   seedDescription?: string | null;
 }): { categoryName: string; categoryTitle: string; pageDescription: string } {
-  const categoryName = resolveTaxonomyDisplayName(
-    input.slug,
-    input.name,
-    input.seedName
-  );
-  const categoryTitle =
-    firstFilled(input.headline, input.seedHeadline) ?? categoryName;
-  const pageDescription =
-    firstFilled(
-      input.intro,
-      input.seedIntro,
-      input.categoryDescription,
-      input.seedDescription
-    ) ?? buildCategoryListingDescription(categoryName);
+  const { displayName, title, pageDescription } = resolveTaxonomyListingCopy({
+    slug: input.slug,
+    name: input.name,
+    seedName: input.seedName,
+    headline: input.headline,
+    seedHeadline: input.seedHeadline,
+    intro: input.intro,
+    seedIntro: input.seedIntro,
+    description: input.categoryDescription,
+    seedDescription: input.seedDescription,
+    buildFallbackDescription: buildCategoryListingDescription,
+  });
 
-  return { categoryName, categoryTitle, pageDescription };
+  return { categoryName: displayName, categoryTitle: title, pageDescription };
 }
 
 export function buildBlogPageUrl(page: number): string {

--- a/apps/web/tests/blog-listing.test.ts
+++ b/apps/web/tests/blog-listing.test.ts
@@ -88,6 +88,57 @@ test("tag listing copy falls back to a slug-derived name when CMS and seed names
   assert.equal(copy.pageDescription, "Articles tagged Production Ai.");
 });
 
+test("tag listing copy prefers a filled headline over the tag name", () => {
+  const copy = resolveTagListingCopy({
+    slug: "llm-systems",
+    name: "LLM Systems",
+    headline: "Shipping LLM Systems",
+    intro: "Real intro copy.",
+  });
+
+  assert.equal(copy.tagTitle, "Shipping LLM Systems");
+  assert.equal(copy.tagName, "LLM Systems");
+});
+
+test("tag listing copy prefers a seed headline over the CMS name", () => {
+  const copy = resolveTagListingCopy({
+    slug: "llm-systems",
+    name: "LLM Systems",
+    headline: "",
+    seedHeadline: "Seed Headline",
+    intro: "Real intro copy.",
+  });
+
+  assert.equal(copy.tagTitle, "Seed Headline");
+});
+
+test("tag listing copy falls back to the resolved name when every headline is empty", () => {
+  const copy = resolveTagListingCopy({
+    slug: "llm-systems",
+    name: "LLM Systems",
+    headline: "",
+    seedHeadline: "   ",
+    intro: "Real intro copy.",
+  });
+
+  assert.equal(copy.tagTitle, "LLM Systems");
+  assert.notEqual(copy.tagTitle, "");
+});
+
+test("tag listing copy title falls back to the slug label when name and headline are blank", () => {
+  const copy = resolveTagListingCopy({
+    slug: "production-ai",
+    name: "",
+    headline: "",
+    seedName: "  ",
+    seedHeadline: null,
+  });
+
+  assert.equal(copy.tagTitle, "Production Ai");
+  assert.equal(copy.tagName, "Production Ai");
+  assert.equal(copy.pageDescription, "Articles tagged Production Ai.");
+});
+
 test("buildCategoryListingDescription uses the shared in-category sentence", () => {
   assert.equal(buildCategoryListingDescription("AI Engineering"), "Articles in AI Engineering.");
 });

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -80,6 +80,14 @@ test("tag listing metadata shares the listing copy helper and never uses the sit
   assert.doesNotMatch(pageSource, /getSiteProfile/);
 });
 
+test("tag listing title comes from the shared copy helper, not a raw headline chain", () => {
+  const pageSource = readSource("src/app/blog/tag/[slug]/page.tsx");
+  assert.match(pageSource, /title:\s*tagTitle/);
+  assert.doesNotMatch(pageSource, /tag\?\.headline\s*\?\?/);
+  assert.doesNotMatch(pageSource, /seed\??\.headline\s*\?\?/);
+  assert.doesNotMatch(pageSource, /tag\?\.seo\?\.metaTitle\s*\?\?/);
+});
+
 test("category listing metadata shares the listing copy helper for intro and description", () => {
   const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
   assert.match(pageSource, /resolveCategoryListingCopy/);


### PR DESCRIPTION
Closes #79. Closes #81 (duplicate of #79, opened while triaging the PR #78 review).

## Problem

#76 moved tag listing **intro/description** onto `firstFilled`. The tag **title** chain was left on `??`, so a CMS `headline: ""` (or whitespace) won the chain and blanked the document title, the `<h1>`, and the WebPage JSON-LD `name`:

| Site | Leak |
|---|---|
| `page.tsx:52` | `seed?.headline ?? seed?.name ?? formatSlugName(slug)` |
| `page.tsx:56` | `tag?.seo?.metaTitle ?? tag?.headline ?? tag?.name ?? fallbackTitle` |
| `page.tsx:74` | `seed.headline ?? seed.name ?? formatSlugName(slug)` |
| `page.tsx:126` | `tag?.headline ?? seed?.headline ?? tagName` |

Same defect class as #75 and #77, on the sibling route.

## Fix

`resolveTagListingCopy` gains `headline`/`seedHeadline` inputs and returns `tagTitle`. Metadata, the `<h1>`, the JSON-LD `name`, and the highlight bullets all read that one string. No `??` chain on a display string remains in the tag page.

### Root-cause fix, not just the symptom

The tag and category resolvers were byte-identical apart from their fallback sentence — and that duplication is *why* the routes drifted (tags fixed in #76, categories not until #78, titles never). Both now delegate to one private `resolveTaxonomyListingCopy`; a future field is added once and both routes get it.

## Deliberate behavior changes

Both mirror what #78 settled for categories:

1. **Metadata title and `<h1>` no longer disagree.** Metadata resolved `cmsHeadline → cmsName → seedHeadline → seedName`; the body resolved `cmsHeadline → seedHeadline → tagName`. A tag with a CMS name, no CMS headline, and a seed headline rendered one string in `<title>` and a different one in `<h1>`. Both now use headline-across-sources, then name-across-sources.
2. **`tag?.seo?.metaTitle` dropped from the page's own chain.** `buildPageMetadata` (`src/lib/seo.ts:330`) already does `seo?.metaTitle?.trim() || title`, so the page chain was redundant — and it let an empty `metaTitle` win where `buildPageMetadata` would correctly have ignored it. Net behavior for a filled `metaTitle` is unchanged.

## Verification

- `pnpm test` — 200/200 web (5 new), 20/20 scripts
- `pnpm typecheck` — 3/3 packages
- `pnpm lint` — clean

Red-green watched on every test: the 4 new `tagTitle` unit tests failed with `undefined` before the helper changed, and all 4 assertions in the new seo-contract test were verified to fail against the pre-fix page source.

## Follow-up still open

- **P2** #80 — whitespace-only subcategory descriptions on category cards (separate file, separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)