### PR TITLE
fix(web): treat blank subcategory descriptions as absent on category cards

### DIFF
--- a/apps/web/src/app/blog/category/[slug]/page.tsx
+++ b/apps/web/src/app/blog/category/[slug]/page.tsx
@@ -5,7 +5,9 @@ import { JsonLd } from "@/components/seo/JsonLd";
 import { PostCard } from "@/components/blog/PostCard";
 import {
   resolveCategoryListingCopy,
+  resolveSubcategoryCards,
   resolveTaxonomyDisplayName,
+  type SubcategoryCard,
 } from "@/lib/blog-listing";
 import { getCategorySeedBySlug } from "@/lib/taxonomy-seed";
 import { getCategories, getCategoryBySlug, getArticles } from "@/lib/strapi";
@@ -20,13 +22,6 @@ type ArticleList = Awaited<ReturnType<typeof getArticles>>["data"];
 
 interface CategoryPageProps {
   params: Promise<{ slug: string }>;
-}
-
-interface SubcategoryCard {
-  id: number | string;
-  name: string;
-  slug: string;
-  description?: string;
 }
 
 function buildWhatYouWillFindPoints(
@@ -181,28 +176,11 @@ export default async function CategoryPage({ params }: CategoryPageProps) {
         }
       : null;
 
-  const subcategories: SubcategoryCard[] =
+  const subcategories: SubcategoryCard[] = resolveSubcategoryCards(
     category?.children && category.children.length > 0
-      ? category.children.map((child) => ({
-          id: child.id,
-          name: resolveTaxonomyDisplayName(
-            child.slug,
-            child.name,
-            child.headline
-          ),
-          slug: child.slug,
-          description: child.description,
-        }))
-      : (seed?.children ?? []).map((child) => ({
-          id: child.slug,
-          name: resolveTaxonomyDisplayName(
-            child.slug,
-            child.name,
-            child.headline
-          ),
-          slug: child.slug,
-          description: child.description,
-        }));
+      ? category.children
+      : (seed?.children ?? [])
+  );
 
   const childSlugs = subcategories.map((subcategory) => subcategory.slug);
   const isParent = subcategories.length > 0;

--- a/apps/web/src/lib/blog-listing.ts
+++ b/apps/web/src/lib/blog-listing.ts
@@ -40,6 +40,38 @@ export function resolveTaxonomyDisplayName(
   return firstFilled(...candidates) ?? formatSlugName(slug);
 }
 
+/** A subcategory link card rendered on a parent category listing. */
+export interface SubcategoryCard {
+  id: number | string;
+  name: string;
+  slug: string;
+  description?: string;
+}
+
+/**
+ * Maps CMS or seed child categories onto subcategory cards, resolving the
+ * label through the shared display-name rule and treating a blank CMS
+ * description as absent so a whitespace-only value cannot render an empty
+ * paragraph under the card title. CMS children carry a numeric `id`; seed
+ * children have none and are keyed by slug.
+ */
+export function resolveSubcategoryCards(
+  children: Array<{
+    id?: number | string;
+    name?: string | null;
+    slug: string;
+    headline?: string | null;
+    description?: string | null;
+  }>
+): SubcategoryCard[] {
+  return children.map((child) => ({
+    id: child.id ?? child.slug,
+    name: resolveTaxonomyDisplayName(child.slug, child.name, child.headline),
+    slug: child.slug,
+    description: firstFilled(child.description),
+  }));
+}
+
 export function buildTagListingDescription(tagName: string): string {
   return `Articles tagged ${tagName}.`;
 }

--- a/apps/web/tests/blog-listing.test.ts
+++ b/apps/web/tests/blog-listing.test.ts
@@ -10,6 +10,7 @@ const {
   resolveTaxonomyDisplayName,
   resolveTagListingCopy,
   resolveCategoryListingCopy,
+  resolveSubcategoryCards,
 } = await import("../src/lib/blog-listing.ts");
 
 test("buildTagListingDescription uses the shared tagged-articles sentence", () => {
@@ -272,4 +273,47 @@ test("category listing copy title falls back to the slug label when name and hea
   assert.equal(copy.categoryTitle, "Production Ai");
   assert.equal(copy.categoryName, "Production Ai");
   assert.equal(copy.pageDescription, "Articles in Production Ai.");
+});
+
+test("subcategory cards drop whitespace-only descriptions", () => {
+  const [card] = resolveSubcategoryCards([
+    { id: 7, name: "Agents", slug: "agents", description: "   " },
+  ]);
+
+  assert.equal(card.description, undefined);
+});
+
+test("subcategory cards trim the descriptions they keep", () => {
+  const [card] = resolveSubcategoryCards([
+    { id: 7, name: "Agents", slug: "agents", description: "  Focused track.  " },
+  ]);
+
+  assert.equal(card.description, "Focused track.");
+});
+
+test("subcategory cards resolve names through the shared display-name helper", () => {
+  const [card] = resolveSubcategoryCards([
+    { id: 7, name: "   ", headline: "Agent Frameworks", slug: "agent-frameworks" },
+  ]);
+
+  assert.equal(card.name, "Agent Frameworks");
+});
+
+test("subcategory cards fall back to the slug label when name and headline are blank", () => {
+  const [card] = resolveSubcategoryCards([
+    { name: "", headline: "  ", slug: "agent-frameworks", description: null },
+  ]);
+
+  assert.equal(card.name, "Agent Frameworks");
+  assert.equal(card.description, undefined);
+});
+
+test("subcategory cards key seed children by slug when the CMS id is absent", () => {
+  const [cms, seedChild] = resolveSubcategoryCards([
+    { id: 12, name: "Agents", slug: "agents" },
+    { name: "Evals", slug: "evals" },
+  ]);
+
+  assert.equal(cms.id, 12);
+  assert.equal(seedChild.id, "evals");
 });

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -106,15 +106,26 @@ test("category listing title comes from the shared copy helper, not a raw headli
   assert.doesNotMatch(pageSource, /category\?\.seo\?\.metaTitle\s*\?\?/);
 });
 
-test("category listing parent and subcategory names route through the display-name helper", () => {
+test("category listing parent names route through the display-name helper", () => {
   const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
   assert.match(pageSource, /resolveTaxonomyDisplayName/);
   assert.match(pageSource, /category\.parent\.name,\s*category\.parent\.headline/);
-  assert.match(pageSource, /child\.name,\s*child\.headline/);
   assert.doesNotMatch(pageSource, /name:\s*category\.parent\.name,/);
-  assert.doesNotMatch(pageSource, /name:\s*child\.name,/);
-  assert.doesNotMatch(pageSource, /child\.name\s*\?\?\s*child\.headline/);
   assert.doesNotMatch(pageSource, /formatCategoryName/);
+});
+
+test("category subcategory cards route names and descriptions through the shared helpers", () => {
+  const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
+  const listingSource = readSource("src/lib/blog-listing.ts");
+
+  // The child mapping moved out of the page into resolveSubcategoryCards, so
+  // the name-resolution contract is asserted where the mapping now lives.
+  assert.match(pageSource, /resolveSubcategoryCards/);
+  assert.doesNotMatch(pageSource, /name:\s*child\.name,/);
+  assert.doesNotMatch(pageSource, /description:\s*child\.description,/);
+  assert.match(listingSource, /child\.name,\s*child\.headline/);
+  assert.match(listingSource, /description:\s*firstFilled\(child\.description\)/);
+  assert.doesNotMatch(listingSource, /child\.name\s*\?\?\s*child\.headline/);
 });
 
 test("paginated blog 404s use the noindex helper for invalid and out-of-range pages", () => {


### PR DESCRIPTION
Closes #80.

## Problem

Subcategory card descriptions were the last category display string still passed through raw from the CMS, missed by #78 because the render guard *looks* like it handles the case:

```tsx
{child.description && <p className="mt-2 text-sm text-mid-gray">{child.description}</p>}
```

That suppresses `""` — but a whitespace-only value is truthy, so `"   "` rendered an empty `<p>` under the card title, leaving a stray gap in the subcategory grid.

## Fix

Route the child mapping through a new `resolveSubcategoryCards` in `blog-listing.ts`, applying the same filled-string rule the rest of the category page has used since #78, and trimming what it keeps.

### Why the mapping moved out of the page

Two reasons beyond the one-line fix:

1. **The CMS and seed branches were near-identical** — 20 lines that differed only in whether the card key came from `child.id` or `child.slug`. That is now `child.id ?? child.slug` in one place. The same duplication-causes-drift pattern that #82 addressed for the copy resolvers.
2. **Inline mapping in a server component cannot be unit tested.** The whitespace bug could only ever have been pinned by a source-text assertion. Extracted, it gets five real behavioral tests.

`SubcategoryCard` moves alongside the function it describes.

## Test bookkeeping

The #78 contract test `category listing parent and subcategory names route through the display-name helper` asserted `/child\.name,\s*child\.headline/` **against the page source** — that mapping no longer lives there, so it correctly went red.

Rather than delete the assertion, its intent is preserved and split:

- Parent-name assertions stay on the page (that mapping did not move).
- The child-name contract is now asserted against `blog-listing.ts`, where the mapping lives, alongside a new assertion that the description goes through `firstFilled`.
- Five unit tests cover the helper's real behavior — blank drop, trim-on-keep, headline fallback, slug fallback, and CMS-id vs. seed-slug keying.

Net coverage goes up, not down.

## Behavior notes

- `child.id ?? child.slug` is nullish-coalescing, so a CMS child with `id: 0` keeps `0`. Only a genuinely absent id (seed children) falls back to the slug — matching the previous branch-per-source behavior exactly.
- Kept descriptions are now trimmed. Harmless in rendered HTML, consistent with every other resolved string on the page.

## Verification

- `pnpm test` — 206/206 web (6 new), 20/20 scripts
- `pnpm typecheck` — 3/3 packages
- `pnpm lint` — clean

Red-green watched: all six new tests failed before the helper existed, and 4 of the 5 assertions in the reworked contract test were verified to fail against the pre-fix sources (the 5th is a carried-over defensive guard from #78 that was already satisfied).

## Related

- #83 (P1) — author identity fields leak empty CMS values into titles and Person JSON-LD on the author and article routes. Same defect class, different route family, filed from the #78 review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)