### PR TITLE
fix(scripts): skip nested checkouts by property, not by directory name

### DIFF
--- a/scripts/typecheck.test.mjs
+++ b/scripts/typecheck.test.mjs
@@ -1,10 +1,20 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+// Build and dependency output only. Second checkouts of this repo are skipped
+// by isNestedCheckout instead, so this set does not have to enumerate every
+// path some tool might create a worktree in.
 const SKIP_DIRS = new Set([
   ".git",
   ".next",
@@ -19,6 +29,19 @@ function read(relativePath) {
   return readFileSync(resolve(root, relativePath), "utf8");
 }
 
+/**
+ * A directory holding a `.git` entry is a separate checkout of this repo, so
+ * it carries its own copy of every file the allowlist exempts by root absolute
+ * path -- including the AGENTS.md that documents the banned command by name.
+ * Scanning one trips this guard on the repo's own prose and blocks every push.
+ *
+ * `.git` is a directory in a clone and a pointer file in a worktree, so this
+ * tests for existence rather than type.
+ */
+function isNestedCheckout(dir) {
+  return existsSync(resolve(dir, ".git"));
+}
+
 function* walkFiles(dir) {
   for (const entry of readdirSync(dir, { withFileTypes: true })) {
     if (SKIP_DIRS.has(entry.name)) {
@@ -27,6 +50,10 @@ function* walkFiles(dir) {
 
     const path = resolve(dir, entry.name);
     if (entry.isDirectory()) {
+      if (isNestedCheckout(path)) {
+        continue;
+      }
+
       yield* walkFiles(path);
       continue;
     }
@@ -99,6 +126,35 @@ test("no workflow, task, or package script invokes tsc via pnpm exec", () => {
       /exec tsc/,
       `${file} must not invoke tsc via pnpm exec`,
     );
+  }
+});
+
+test("the scanner does not descend into a nested checkout outside .worktrees", () => {
+  // The allowlist exempts AGENTS.md by root absolute path, so every second
+  // checkout of this repo carries an AGENTS.md that is not exempt -- and
+  // AGENTS.md documents the banned command by name. Skipping by directory
+  // name only covers the paths we thought to enumerate: #78 added
+  // `.worktrees`, and the guard then tripped on Claude Code's own worktrees
+  // under `.claude/worktrees`. Skip on the property instead -- a directory
+  // holding a `.git` entry is a separate checkout, whatever it is called.
+  const fixtureDir = resolve(root, "__nested_checkout_fixture__");
+  mkdirSync(fixtureDir, { recursive: true });
+  // A worktree's .git is a pointer file, not a directory.
+  writeFileSync(resolve(fixtureDir, ".git"), "gitdir: /tmp/nowhere\n");
+  writeFileSync(resolve(fixtureDir, "AGENTS.md"), "pnpm --filter=* exec tsc\n");
+
+  try {
+    const scanned = [...walkFiles(root)].filter((file) =>
+      file.startsWith(`${fixtureDir}/`),
+    );
+
+    assert.deepEqual(
+      scanned,
+      [],
+      "walkFiles must skip any directory containing a .git entry",
+    );
+  } finally {
+    rmSync(fixtureDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Closes #85.

## Problem

`pnpm test` fails on a clean `main`. `.husky/pre-push` is `pnpm typecheck && pnpm test`, so **every push from the primary checkout is blocked** — I hit this on a plain `git push origin --delete` of an already-merged branch:

```
✖ no workflow, task, or package script invokes tsc via pnpm exec
  AssertionError: …/.claude/worktrees/code-review-worktree-eedca7/AGENTS.md
  must not invoke tsc via pnpm exec
```

## Root cause — #78's fix was name-based

The guard walks the repo asserting no file invokes the banned command. `AGENTS.md` documents that command by name, so it is allowlisted — but **by root absolute path only**:

```js
const allowed = new Set([
  resolve(root, "AGENTS.md"),
  resolve(root, "scripts/typecheck.test.mjs"),
]);
```

Every second checkout of this repo carries its own `AGENTS.md` at a *different* absolute path, so that copy is not exempt and trips the guard on the repo's own prose.

#78 fixed this by adding `.worktrees` to `SKIP_DIRS`. That only covers the one path we thought to enumerate. Claude Code creates its worktrees under `.claude/worktrees/`, so the guard walked straight back in — and it caught **both** allowlisted files' copies:

```
.claude/worktrees/code-review-worktree-eedca7/AGENTS.md
.claude/worktrees/code-review-worktree-eedca7/scripts/typecheck.test.mjs
```

Confirmed a genuine worktree, not a stray copy — `git worktree list` lists it, and its `.git` is an 84-byte `gitdir:` pointer file.

## Fix

Skip on the **property**, not the name. A directory holding a `.git` entry is a separate checkout by definition, whatever it is called:

```js
function isNestedCheckout(dir) {
  return existsSync(resolve(dir, ".git"));
}
```

`existsSync` rather than a type check, because `.git` is a *directory* in a clone and a *pointer file* in a worktree.

`SKIP_DIRS` keeps its build and dependency entries (`node_modules`, `.next`, `.turbo`, `dist`) — matching on the name is the right tool there. It no longer has to predict where tooling will put checkouts.

## Why not just add `.claude/worktrees` to the set

That is the same fix that already failed once. The set would have to enumerate every location any tool might create a checkout in, and it has now missed one twice. The `/code-review` skill also creates worktrees under `/tmp`; the next tool will pick somewhere else.

## Verification

Verified against the real primary checkout with a live worktree present, running both walks over the actual directory tree:

| | Guard violations found |
|---|---|
| Pre-fix walk | **2** (both inside `.claude/worktrees/`) |
| Post-fix walk | **0** |

Plus:

- `pnpm test` — 206/206 web, **21/21** scripts (1 new)
- `pnpm typecheck` — 3/3 packages
- `pnpm lint` — clean

Red-green watched: the new test plants a fixture checkout at a directory **not** named `.worktrees` (a `.git` pointer file plus an `AGENTS.md` containing the banned string) and failed before `isNestedCheckout` existed. The existing `.worktrees` fixture test from #78 still passes, so the old coverage is intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)