### PR TITLE
test(web): close the defeatable source-text contract guards

### DIFF
--- a/apps/web/tests/ai-engineer-landing.test.ts
+++ b/apps/web/tests/ai-engineer-landing.test.ts
@@ -3,6 +3,11 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import {
+  assertCallsHelper,
+  assertRendersComponent,
+} from "./contract-assertions.ts";
+
 const forbiddenTerms = [
   /\bCISA\b/i,
   /\bgovernment\b/i,
@@ -22,14 +27,19 @@ test("AI engineer landing is a dedicated non-blog route titled to the query", ()
 
   assert.match(page, /pathname = "\/ai-engineer"/);
   assert.match(page, /title: aiEngineerMetadataTitle/);
-  assert.match(page, /getSiteProfile/);
+  assertCallsHelper(page, "getSiteProfile", "#94");
   assert.match(fallback, /export const aiEngineerMetadataTitle = "AI Engineer"/);
   assert.match(fallback, /`AI engineer \$\{siteProfile\.siteName\}/);
   assert.doesNotMatch(fallback, /AI engineer Mehdi Zare/);
   assert.doesNotMatch(page, /\/blog\//);
   assert.match(readSource("src/components/layout/Footer.tsx"), /href: "\/ai-engineer"/);
   assert.match(readSource("src/components/home/ServicesGrid.tsx"), /href: "\/ai-engineer"/);
-  assert.match(readSource("src/app/about/page.tsx"), /AiEngineerProfileLink/);
+  assertRendersComponent(
+    readSource("src/app/about/page.tsx"),
+    "AiEngineerProfileLink",
+    "#94",
+    "about page"
+  );
   assert.match(readSource("src/app/about/page.tsx"), /section="about_hero"/);
   const blogPage = readSource("src/app/blog/[slug]/page.tsx");
   assert.match(blogPage, /how-ai-works-from-data-to-decisions/);
@@ -37,12 +47,12 @@ test("AI engineer landing is a dedicated non-blog route titled to the query", ()
     blogPage,
     /why-most-ai-projects-die-before-production-and-it-s-not-a-tech-problem/
   );
-  assert.match(blogPage, /AiEngineerProfileLink/);
+  assertRendersComponent(blogPage, "AiEngineerProfileLink", "#94", "blog article page");
   assert.match(blogPage, /AI_ENGINEER_IN_CONTENT_BLOG_SLUGS\.has\(article\.slug\)/);
   assert.match(blogPage, /section="blog_body"/);
   const profileLink = readSource("src/components/seo/AiEngineerProfileLink.tsx");
   assert.match(profileLink, /href="\/ai-engineer"/);
-  assert.match(profileLink, /TrackedLink/);
+  assertRendersComponent(profileLink, "TrackedLink", "#94", "AiEngineerProfileLink");
   assert.match(profileLink, /eventName="funnel_cta_click"/);
   assert.match(profileLink, /cta_label: "AI engineer landing"/);
   assert.match(profileLink, /destination: "\/ai-engineer"/);

--- a/apps/web/tests/contract-assertions.ts
+++ b/apps/web/tests/contract-assertions.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+
+// Shared assertions for the source-text contract tests.
+//
+// Those tests read a file as a string and assert regexes against it, to pin
+// *placement* -- that a page routes through a shared helper instead of
+// re-implementing it inline. Behavior is tested separately against the helper
+// itself. Two mistakes have already been made writing these regexes by hand,
+// so the shapes live here rather than at each call site:
+//
+//   /helperName/     is satisfied by the import statement alone, so a file can
+//                    import a helper, re-inline its logic, and still pass (#94)
+//   /helperName\(/   is satisfied by a local named `_helperName`, because `\(`
+//                    without `\b` anchors nothing on the left (#95)
+//
+// Passing a helper name through one of these functions applies `\b` and the
+// whitespace tolerance uniformly, so the next guard cannot omit them.
+
+const IDENTIFIER = /^[A-Za-z_$][A-Za-z0-9_$]*$/;
+
+function assertIdentifier(name: string): void {
+  assert.match(
+    name,
+    IDENTIFIER,
+    `expected a bare identifier, got ${JSON.stringify(name)} -- these helpers interpolate the name into a RegExp, so a pattern would be silently mis-anchored`
+  );
+}
+
+/**
+ * Asserts that `source` calls `helper`, rather than merely importing it.
+ *
+ * `subject` names what is being checked and leads the failure message; pass a
+ * file path when the assertion runs in a loop, so the message says which one
+ * broke. `contract` cites the issues that established the rule.
+ */
+export function assertCallsHelper(
+  source: string,
+  helper: string,
+  contract: string,
+  subject = "page"
+): void {
+  assertIdentifier(helper);
+  assert.match(
+    source,
+    new RegExp(`\\b${helper}\\s*\\(`),
+    `${subject} must call ${helper}(), not merely import it (${contract})`
+  );
+}
+
+/**
+ * Asserts that `source` renders `component` as JSX, rather than merely
+ * importing it. The component equivalent of `assertCallsHelper` -- a component
+ * that is imported but swapped for a plain element loses whatever the wrapper
+ * provided (analytics, canonical hrefs) while the import keeps a bare-name
+ * match green.
+ */
+export function assertRendersComponent(
+  source: string,
+  component: string,
+  contract: string,
+  subject = "page"
+): void {
+  assertIdentifier(component);
+  assert.match(
+    source,
+    new RegExp(`<${component}[\\s/>]`),
+    `${subject} must render <${component}>, not merely import it (${contract})`
+  );
+}

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { assertCallsHelper } from "./contract-assertions.ts";
+
 const source = readFileSync(resolve(process.cwd(), "src/lib/seo.ts"), "utf8");
 
 function readSource(relativePath: string): string {
@@ -74,11 +76,7 @@ test("bina-print metadata does not fall back to the homepage site description", 
 
 test("tag listing metadata shares the listing copy helper and never uses the site blurb", () => {
   const pageSource = readSource("src/app/blog/tag/[slug]/page.tsx");
-  assert.match(
-    pageSource,
-    /resolveTagListingCopy\(/,
-    "page must call resolveTagListingCopy, not merely import it (#79, #81, #94)"
-  );
+  assertCallsHelper(pageSource, "resolveTagListingCopy", "#75, #94");
   assert.match(pageSource, /description:\s*pageDescription/);
   assert.doesNotMatch(pageSource, /siteDescription/);
   assert.doesNotMatch(pageSource, /getSiteProfile/);
@@ -94,11 +92,7 @@ test("tag listing title comes from the shared copy helper, not a raw headline ch
 
 test("category listing metadata shares the listing copy helper for intro and description", () => {
   const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
-  assert.match(
-    pageSource,
-    /resolveCategoryListingCopy\(/,
-    "page must call resolveCategoryListingCopy, not merely import it (#77, #94)"
-  );
+  assertCallsHelper(pageSource, "resolveCategoryListingCopy", "#77, #94");
   assert.match(pageSource, /description:\s*pageDescription/);
   assert.doesNotMatch(
     pageSource,
@@ -116,14 +110,13 @@ test("category listing title comes from the shared copy helper, not a raw headli
 
 test("category listing parent names route through the display-name helper", () => {
   const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
-  assert.match(
-    pageSource,
-    /resolveTaxonomyDisplayName\(/,
-    "page must call resolveTaxonomyDisplayName, not merely import it (#94)"
-  );
+  assertCallsHelper(pageSource, "resolveTaxonomyDisplayName", "#77, #94");
   assert.match(pageSource, /category\.parent\.name,\s*category\.parent\.headline/);
   // No trailing comma: `name: category.parent.name ?? resolveTaxonomyDisplayName(...)`
-  // reinstates the raw-CMS-name-wins bug while leaving the assertion above green.
+  // reinstates the raw-CMS-name-wins bug while leaving the assertion above
+  // green. Reading the page as text means this also fires on a comment or a
+  // string that merely quotes the shape -- describe it in prose rather than
+  // loosening the guard.
   assert.doesNotMatch(
     pageSource,
     /name:\s*category\.parent\.name/,
@@ -145,11 +138,7 @@ test("category subcategory cards route names and descriptions through the shared
   const inlined =
     "child-card mapping belongs in resolveSubcategoryCards, not the page (#78, #88)";
 
-  assert.match(
-    pageSource,
-    /resolveSubcategoryCards\(/,
-    "page must call resolveSubcategoryCards, not merely import it (#88)"
-  );
+  assertCallsHelper(pageSource, "resolveSubcategoryCards", "#78, #88");
   assert.doesNotMatch(pageSource, /name:\s*child\.name/, inlined);
   assert.doesNotMatch(pageSource, /child\.name\s*\?\?\s*child\.headline/, inlined);
   assert.doesNotMatch(pageSource, /description:\s*child\.description/, inlined);
@@ -162,11 +151,7 @@ test("category subcategory cards route names and descriptions through the shared
 test("paginated blog 404s use the noindex helper for invalid and out-of-range pages", () => {
   const pageSource = readSource("src/app/blog/page/[page]/page.tsx");
   assert.match(pageSource, /buildNoIndexMetadata\("Blog Page Not Found"\)/);
-  assert.match(
-    pageSource,
-    /parsePositivePageNumber\(/,
-    "page must call parsePositivePageNumber, not merely import it (#94)"
-  );
+  assertCallsHelper(pageSource, "parsePositivePageNumber", "#74, #94");
   assert.match(pageSource, /currentPage > pagination\.pageCount/);
 });
 

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -74,7 +74,11 @@ test("bina-print metadata does not fall back to the homepage site description", 
 
 test("tag listing metadata shares the listing copy helper and never uses the site blurb", () => {
   const pageSource = readSource("src/app/blog/tag/[slug]/page.tsx");
-  assert.match(pageSource, /resolveTagListingCopy/);
+  assert.match(
+    pageSource,
+    /resolveTagListingCopy\(/,
+    "page must call resolveTagListingCopy, not merely import it (#79, #81, #94)"
+  );
   assert.match(pageSource, /description:\s*pageDescription/);
   assert.doesNotMatch(pageSource, /siteDescription/);
   assert.doesNotMatch(pageSource, /getSiteProfile/);
@@ -90,7 +94,11 @@ test("tag listing title comes from the shared copy helper, not a raw headline ch
 
 test("category listing metadata shares the listing copy helper for intro and description", () => {
   const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
-  assert.match(pageSource, /resolveCategoryListingCopy/);
+  assert.match(
+    pageSource,
+    /resolveCategoryListingCopy\(/,
+    "page must call resolveCategoryListingCopy, not merely import it (#77, #94)"
+  );
   assert.match(pageSource, /description:\s*pageDescription/);
   assert.doesNotMatch(
     pageSource,
@@ -108,9 +116,19 @@ test("category listing title comes from the shared copy helper, not a raw headli
 
 test("category listing parent names route through the display-name helper", () => {
   const pageSource = readSource("src/app/blog/category/[slug]/page.tsx");
-  assert.match(pageSource, /resolveTaxonomyDisplayName/);
+  assert.match(
+    pageSource,
+    /resolveTaxonomyDisplayName\(/,
+    "page must call resolveTaxonomyDisplayName, not merely import it (#94)"
+  );
   assert.match(pageSource, /category\.parent\.name,\s*category\.parent\.headline/);
-  assert.doesNotMatch(pageSource, /name:\s*category\.parent\.name,/);
+  // No trailing comma: `name: category.parent.name ?? resolveTaxonomyDisplayName(...)`
+  // reinstates the raw-CMS-name-wins bug while leaving the assertion above green.
+  assert.doesNotMatch(
+    pageSource,
+    /name:\s*category\.parent\.name/,
+    "parent name must resolve through resolveTaxonomyDisplayName, not the raw CMS value (#77, #94)"
+  );
   assert.doesNotMatch(pageSource, /formatCategoryName/);
 });
 
@@ -144,7 +162,11 @@ test("category subcategory cards route names and descriptions through the shared
 test("paginated blog 404s use the noindex helper for invalid and out-of-range pages", () => {
   const pageSource = readSource("src/app/blog/page/[page]/page.tsx");
   assert.match(pageSource, /buildNoIndexMetadata\("Blog Page Not Found"\)/);
-  assert.match(pageSource, /parsePositivePageNumber/);
+  assert.match(
+    pageSource,
+    /parsePositivePageNumber\(/,
+    "page must call parsePositivePageNumber, not merely import it (#94)"
+  );
   assert.match(pageSource, /currentPage > pagination\.pageCount/);
 });
 

--- a/apps/web/tests/site-profile-usage.test.ts
+++ b/apps/web/tests/site-profile-usage.test.ts
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
+import { assertCallsHelper } from "./contract-assertions.ts";
+
 const pageFiles = [
   "src/app/layout.tsx",
   "src/app/page.tsx",
@@ -21,11 +23,7 @@ function readSource(relativePath: string): string {
 test("key pages consume Site Profile as canonical source", () => {
   for (const file of pageFiles) {
     const source = readSource(file);
-    assert.match(
-      source,
-      /getSiteProfile\(/,
-      `${file} must call getSiteProfile, not merely import it (#94)`
-    );
+    assertCallsHelper(source, "getSiteProfile", "#94", file);
   }
 });
 

--- a/apps/web/tests/site-profile-usage.test.ts
+++ b/apps/web/tests/site-profile-usage.test.ts
@@ -21,7 +21,11 @@ function readSource(relativePath: string): string {
 test("key pages consume Site Profile as canonical source", () => {
   for (const file of pageFiles) {
     const source = readSource(file);
-    assert.match(source, /getSiteProfile/);
+    assert.match(
+      source,
+      /getSiteProfile\(/,
+      `${file} must call getSiteProfile, not merely import it (#94)`
+    );
   }
 });
 


### PR DESCRIPTION
Closes #94. Test-only. The direct continuation of #88 — that PR fixed one instance of two weaknesses; this closes every remaining one, and a third weakness found reviewing the fix.

## The three shapes

**A. `assert.match(source, /bareIdentifier/)` is satisfied by the import statement alone.** A file can import a helper, never call it, re-implement the chain inline with `||`, and pass — reintroducing the blank-CMS-value bug of #75/#77. #88 fixed this for `resolveSubcategoryCards` by pinning a call shape.

**B. `assert.doesNotMatch(..., /…,/)` pinned by a trailing comma.** Any variant not ending in a comma at that exact position slips through.

**C. `assert.match(source, /helper\(/)` has no left anchor.** A local named `_helper` satisfies it — so the fix for A was itself defeatable. Found reviewing this PR.

## Changes

Every call-shape guard now goes through `apps/web/tests/contract-assertions.ts`:

```ts
assertCallsHelper(pageSource, "resolveTagListingCopy", "#75, #94");
assertRendersComponent(profileLink, "TrackedLink", "#94", "AiEngineerProfileLink");
```

`assertCallsHelper` applies `\b` and tolerates whitespace before the paren, so the next guard cannot omit either. `assertRendersComponent` is the JSX equivalent — a component that is imported but swapped for a plain element keeps a bare-name match green while silently dropping whatever the wrapper provided. Both reject anything that is not a bare identifier, since the name is interpolated into a `RegExp` and a pattern would be mis-anchored in silence.

| File | Guard | Shape |
|---|---|---|
| `seo-contract.test.ts` | `resolveTagListingCopy` | A, C |
| | `resolveCategoryListingCopy` | A, C |
| | `resolveTaxonomyDisplayName` | A, C |
| | `name: category.parent.name,` | B |
| | `parsePositivePageNumber` | A, C |
| | `resolveSubcategoryCards` (from #88) | C |
| `site-profile-usage.test.ts` | `getSiteProfile` × 8 pages | A, C |
| `ai-engineer-landing.test.ts` | `getSiteProfile` | A, C |
| | `AiEngineerProfileLink` × 2 pages | A (JSX) |
| | `TrackedLink` | A (JSX) |

## Demonstrated, not assumed

Every guard was checked against the mutant it claims to catch, on this branch and on `main`. The realistic ones keep the import and re-implement the chain, rather than merely renaming:

| Mutant | This branch | `main` |
|---|---|---|
| tag page re-implements the copy chain with `\|\|`, dropping trimming and title-casing | **red** | green |
| same for the category page | **red** | green |
| local `pickName(...)` preserving the argument pin verbatim | **red** | green |
| `name: category.parent.name ?? resolveTaxonomyDisplayName(...)` | **red** | green |
| inline `Number()` parse accepting `" 2"`, `"+2"`, `"1e3"` | **red** | green |
| the same tag-page mutant, renamed `_resolveTagListingCopy` | **red** | green (**and green on the first version of this PR**) |
| `about/page.tsx` imports `getSiteProfile`, calls a local | **red** | green |
| `<TrackedLink>` swapped for `<a>`, import kept | **red** | green |
| `<AiEngineerProfileLink>` swapped for `<span>`, import kept | **red** | green |
| a space before the paren — a legitimate formatting | green | green |

Green on `main` in every case, so every gap was genuinely open rather than incidentally covered elsewhere.

Two of these deserve naming. The `_resolveTagListingCopy` mutant is shape C — it was green against the first version of this PR, which is why the anchoring exists. And `<TrackedLink>` → `<a>` silently drops a `funnel_cta_click` analytics event while the import keeps a bare-name match satisfied.

## Not tightened, and why

- `seo-contract.test.ts` `resolveCanonicalUrl` / `composeDocumentTitle`, and `site-profile.test.ts` — match against the files where those symbols are **defined**, so the import-only concern does not apply.
- `seo-contract.test.ts` `buildNoIndexMetadata` — already backed by a call-shape assertion on the next line.
- `site-profile-usage.test.ts` `ctaLabel` / `siteName` / `credentialLine` — each paired with a `doesNotMatch` on the hardcoded string, which carries the real guarantee.
- `homepage-visibility.test.ts` `mediumPublications` — declared in the file under test, not imported.

After this change no comma-pinned `doesNotMatch` remains anywhere in `apps/web/tests/`, and every bare-identifier `assert.match` that remains falls into one of those four categories.

## Verification

- 210/210 `apps/web` tests, 21/21 `scripts` tests
- `tsc --noEmit` clean in `apps/web`, `apps/cms`, `packages/shared`; `eslint` clean
- Ten mutants run; nine red on this branch and green on `main`, one (space before paren) green on both to confirm no false positive

🤖 Generated with [Claude Code](https://claude.com/claude-code)