### PR TITLE
fix(web): treat blank CMS strings as absent on author, article and about routes

### DIFF
--- a/apps/web/src/app/about/page.tsx
+++ b/apps/web/src/app/about/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { CareerTimeline } from "@/components/about/CareerTimeline";
 import { CredentialBadges } from "@/components/about/CredentialBadges";
+import { EducationList } from "@/components/about/EducationList";
 import { BlocksRenderer } from "@/components/blog/BlocksRenderer";
 import { AiEngineerProfileLink } from "@/components/seo/AiEngineerProfileLink";
 import { CmsStructuredData } from "@/components/seo/CmsStructuredData";
@@ -199,20 +200,7 @@ export default async function AboutPage() {
           </AnimatedSection>
 
           <AnimatedSection delay={0.2} className="mt-10">
-            <div className="grid gap-4 sm:grid-cols-2">
-              {data.education.map((edu) => (
-                <article key={edu.id} className="border border-warm-gray bg-paper p-6">
-                  <h3 className="font-medium text-ink">
-                    {edu.degree}
-                    {edu.field ? `, ${edu.field}` : ""}
-                  </h3>
-                  <p className="mt-1 text-sm text-accent-warm">{edu.institution}</p>
-                  {edu.description ? (
-                    <p className="mt-3 text-sm text-mid-gray">{edu.description}</p>
-                  ) : null}
-                </article>
-              ))}
-            </div>
+            <EducationList education={data.education} />
           </AnimatedSection>
         </div>
       </section>

--- a/apps/web/src/app/author/[slug]/page.tsx
+++ b/apps/web/src/app/author/[slug]/page.tsx
@@ -13,22 +13,21 @@ import {
   buildPageMetadata,
   buildPersonJsonLd,
   buildProfilePageJsonLd,
-  getSiteUrl,
   toAbsoluteMediaUrl,
   toPersonId,
 } from "@/lib/seo";
 import { identityUrlKey, normalizeIdentityUrl } from "@/lib/url-normalization";
+import {
+  CANONICAL_IDENTITY_ORIGIN,
+  authorIdentityFallbacks,
+  resolveAuthorPageIdentity,
+} from "@/lib/author-identity";
 
 interface AuthorPageProps {
   params: Promise<{ slug: string }>;
 }
 
 type AuthorList = Awaited<ReturnType<typeof getAuthors>>["data"];
-
-function authorListingDescription(name: string, bioShort?: string | null): string {
-  const bio = bioShort?.trim();
-  return bio ? bio : `Articles by ${name}.`;
-}
 
 function getAllAuthors(): Promise<AuthorList> {
   // Shared STRAPI_MAX_PAGES cap. Extra slugs still render on demand
@@ -58,14 +57,16 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
       return buildNoIndexMetadata("Author Not Found");
     }
 
-    const role = author.jobTitle ?? author.headline ?? siteProfile.authorRole;
-    const title = `${author.name} | ${role}`;
-    const description = authorListingDescription(author.name, author.bioShort);
+    const identity = resolveAuthorPageIdentity(
+      author,
+      authorIdentityFallbacks(siteProfile),
+      CANONICAL_IDENTITY_ORIGIN
+    );
 
     return buildPageMetadata({
       pathname: `/author/${author.slug}`,
-      title,
-      description,
+      title: identity.title,
+      description: identity.description,
       image: author.profileImage,
       type: "website",
       keywords: [
@@ -80,8 +81,6 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
     return buildNoIndexMetadata("Author Not Found");
   }
 }
-
-const CANONICAL_IDENTITY_ORIGIN = getSiteUrl();
 
 function dedupeUrls(urls: Array<string | null | undefined>): string[] {
   const seen = new Set<string>();
@@ -148,14 +147,12 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
 
   const authorPath = `/author/${author.slug}`;
   const personId = toPersonId(authorPath);
-  const role = author.jobTitle ?? author.headline ?? siteProfile.authorRole;
-  const description = authorListingDescription(author.name, author.bioShort);
-  const websiteUrl =
-    normalizeIdentityUrl(author.websiteUrl, CANONICAL_IDENTITY_ORIGIN) ??
-    siteProfile.author.websiteUrl;
-  const linkedinUrl =
-    normalizeIdentityUrl(author.linkedinUrl, CANONICAL_IDENTITY_ORIGIN) ??
-    siteProfile.author.linkedinUrl;
+  const identity = resolveAuthorPageIdentity(
+    author,
+    authorIdentityFallbacks(siteProfile),
+    CANONICAL_IDENTITY_ORIGIN
+  );
+  const { name: authorName, role, description, websiteUrl, linkedinUrl } = identity;
   const sameAs = dedupeUrls([
     websiteUrl,
     linkedinUrl,
@@ -168,7 +165,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         id="author-profilepage-jsonld"
         data={buildProfilePageJsonLd({
           pathname: authorPath,
-          title: author.name,
+          title: authorName,
           description,
           personId,
         })}
@@ -178,7 +175,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         data={buildPersonJsonLd({
           id: personId,
           path: authorPath,
-          name: author.name,
+          name: authorName,
           title: role,
           description,
           url: websiteUrl,
@@ -225,7 +222,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
                 />
               ) : (
                 <div className="flex h-full items-center justify-center font-serif text-4xl text-ink">
-                  {author.name
+                  {authorName
                     .split(" ")
                     .map((part) => part[0])
                     .filter(Boolean)
@@ -238,7 +235,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
 
             <div>
               <p className="font-mono text-xs uppercase tracking-[0.25em] text-mid-gray">Author</p>
-              <h1 className="mt-3 font-serif text-4xl leading-tight text-ink sm:text-5xl">{author.name}</h1>
+              <h1 className="mt-3 font-serif text-4xl leading-tight text-ink sm:text-5xl">{authorName}</h1>
               <p className="mt-3 font-mono text-xs uppercase tracking-[0.2em] text-accent-warm">{role}</p>
               <p className="mt-5 max-w-3xl text-lg leading-relaxed text-mid-gray">{description}</p>
 
@@ -284,7 +281,7 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
         ) : null}
 
         <div className="mt-10">
-          <h2 className="font-serif text-2xl text-ink">Articles by {author.name}</h2>
+          <h2 className="font-serif text-2xl text-ink">Articles by {authorName}</h2>
           {authoredArticles.length > 0 ? (
             <div className="mt-6 grid gap-4 sm:grid-cols-2">
               {authoredArticles.map((article) => {

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -12,6 +12,12 @@ import { TableOfContents } from "@/components/blog/TableOfContents";
 import { TagBadge } from "@/components/blog/TagBadge";
 import { getSiteProfile } from "@/lib/site-profile";
 import {
+  CANONICAL_IDENTITY_ORIGIN,
+  authorIdentityFallbacks,
+  resolveArticleAuthorIdentity,
+} from "@/lib/author-identity";
+import { blankToUndefined } from "@/lib/strings";
+import {
   buildBlogPostingJsonLd,
   buildBreadcrumbJsonLd,
   buildNoIndexMetadata,
@@ -152,17 +158,25 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
     article.publishedDate ?? article.publishedAt;
   const articlePath = `/blog/${article.slug}`;
   const articleAuthor = article.author;
-  const authorName = articleAuthor?.name ?? siteProfile.authorName;
-  const authorRole =
-    articleAuthor?.jobTitle ?? articleAuthor?.headline ?? siteProfile.authorRole;
-  const authorBio =
-    articleAuthor?.bioShort ?? siteProfile.authorBioShort;
-  const authorPath = articleAuthor?.slug
-    ? `/author/${articleAuthor.slug}`
+  // Shared with /author/[slug] (#83). A cleared CMS field is `""`, which `??`
+  // treats as present -- it used to reach the byline, the avatar initials and,
+  // for the two URLs, Person `url` / `sameAs` as invalid structured data.
+  const authorIdentity = resolveArticleAuthorIdentity(
+    articleAuthor,
+    authorIdentityFallbacks(siteProfile),
+    CANONICAL_IDENTITY_ORIGIN
+  );
+  const {
+    name: authorName,
+    role: authorRole,
+    bioShort: authorBio,
+    websiteUrl: authorWebsite,
+    linkedinUrl: authorLinkedIn,
+  } = authorIdentity;
+  const authorPath = blankToUndefined(articleAuthor?.slug)
+    ? `/author/${blankToUndefined(articleAuthor?.slug)}`
     : siteProfile.author.profilePath;
   const authorPersonId = toPersonId(authorPath);
-  const authorWebsite = articleAuthor?.websiteUrl ?? siteProfile.author.websiteUrl;
-  const authorLinkedIn = articleAuthor?.linkedinUrl ?? siteProfile.author.linkedinUrl;
   const authorInitials = buildInitials(authorName);
   const articleDescription =
     article.excerpt?.trim() || article.title;

--- a/apps/web/src/components/about/CareerTimeline.tsx
+++ b/apps/web/src/components/about/CareerTimeline.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { motion } from "framer-motion";
+import { blankToUndefined } from "@/lib/strings";
 import { cn } from "@/lib/utils";
 import type { Experience } from "@/types/strapi";
 
@@ -31,6 +32,10 @@ export function CareerTimeline({ experiences }: CareerTimelineProps) {
       <div className="space-y-12">
         {experiences.map((experience, index) => {
           const isEven = index % 2 === 0;
+          // A cleared CMS field arrives as `""` and a field left with a space
+          // as `"   "`. The latter is truthy, so guarding on the raw value
+          // renders an empty paragraph and a stray gap (#89).
+          const description = blankToUndefined(experience.description);
 
           return (
             <motion.div
@@ -72,9 +77,9 @@ export function CareerTimeline({ experiences }: CareerTimelineProps) {
                   <p className="mt-1 font-mono text-xs text-mid-gray">
                     {formatPeriod(experience.startDate, experience.endDate, experience.current)}
                   </p>
-                  {experience.description && (
+                  {description && (
                     <p className="mt-3 text-sm text-mid-gray">
-                      {experience.description}
+                      {description}
                     </p>
                   )}
                 </div>

--- a/apps/web/src/components/about/EducationList.tsx
+++ b/apps/web/src/components/about/EducationList.tsx
@@ -1,0 +1,38 @@
+import { blankToUndefined } from "@/lib/strings";
+import type { Education } from "@/types/strapi";
+
+interface EducationListProps {
+  education: Education[];
+}
+
+/**
+ * The education grid on /about. Extracted from the page so its rendered output
+ * can be asserted directly (#89) rather than grepped for a guard shape.
+ *
+ * Every CMS string goes through `blankToUndefined`: a field a content editor
+ * left with a space is truthy, so guarding on the raw value renders an empty
+ * paragraph, and a whitespace-only `field` renders a dangling `MBA, ` heading.
+ */
+export function EducationList({ education }: EducationListProps) {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2">
+      {education.map((edu) => {
+        const field = blankToUndefined(edu.field);
+        const description = blankToUndefined(edu.description);
+
+        return (
+          <article key={edu.id} className="border border-warm-gray bg-paper p-6">
+            <h3 className="font-medium text-ink">
+              {edu.degree}
+              {field ? `, ${field}` : ""}
+            </h3>
+            <p className="mt-1 text-sm text-accent-warm">{edu.institution}</p>
+            {description ? (
+              <p className="mt-3 text-sm text-mid-gray">{description}</p>
+            ) : null}
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/about/EducationList.tsx
+++ b/apps/web/src/components/about/EducationList.tsx
@@ -12,21 +12,31 @@ interface EducationListProps {
  * Every CMS string goes through `blankToUndefined`: a field a content editor
  * left with a space is truthy, so guarding on the raw value renders an empty
  * paragraph, and a whitespace-only `field` renders a dangling `MBA, ` heading.
+ *
+ * That applies to `degree` and `institution` too, even though both are
+ * `required` in the Strapi component: `required` rejects `""` but accepts
+ * `"   "`, which is the same reachability argument #89 makes for `description`.
+ * The heading is joined from the parts that survive, so a blank `degree` cannot
+ * leave a leading separator either.
  */
 export function EducationList({ education }: EducationListProps) {
   return (
     <div className="grid gap-4 sm:grid-cols-2">
       {education.map((edu) => {
+        const degree = blankToUndefined(edu.degree);
         const field = blankToUndefined(edu.field);
+        const institution = blankToUndefined(edu.institution);
         const description = blankToUndefined(edu.description);
+        const heading = [degree, field].filter(Boolean).join(", ");
 
         return (
           <article key={edu.id} className="border border-warm-gray bg-paper p-6">
-            <h3 className="font-medium text-ink">
-              {edu.degree}
-              {field ? `, ${field}` : ""}
-            </h3>
-            <p className="mt-1 text-sm text-accent-warm">{edu.institution}</p>
+            {heading ? (
+              <h3 className="font-medium text-ink">{heading}</h3>
+            ) : null}
+            {institution ? (
+              <p className="mt-1 text-sm text-accent-warm">{institution}</p>
+            ) : null}
             {description ? (
               <p className="mt-3 text-sm text-mid-gray">{description}</p>
             ) : null}

--- a/apps/web/src/lib/author-identity.ts
+++ b/apps/web/src/lib/author-identity.ts
@@ -1,0 +1,206 @@
+import { getSiteUrl } from "@/lib/seo";
+import { blankToUndefined, firstFilled, formatSlugName } from "@/lib/strings";
+import { normalizeIdentityUrl } from "@/lib/url-normalization";
+
+/**
+ * Author identity resolution shared by `/author/[slug]` and `/blog/[slug]`.
+ *
+ * Both routes render the same person's name, role, bio and identity URLs into
+ * a title, a visible byline and `Person` JSON-LD, and both used to do it with
+ * `??`. A CMS field a content editor cleared is `""`, which is not nullish, so
+ * it won the chain: the title came out `"Jane Doe | "`, the description came
+ * out `"Articles by ."`, and on the article route `""` reached Person `url`
+ * and `sameAs` as invalid structured data (#83).
+ *
+ * The two routes had also drifted -- the author route ran identity URLs through
+ * `normalizeIdentityUrl` and the article route did not, so the same Person
+ * could carry different `url` values on different pages. Resolving both here
+ * means they cannot drift again.
+ */
+
+/**
+ * The origin identity URLs are canonicalized against. Exported so
+ * `/author/[slug]` and `/blog/[slug]` cannot pick different ones -- the two
+ * routes emitting different `url` values for the same Person is the drift #83
+ * calls out.
+ */
+export const CANONICAL_IDENTITY_ORIGIN = getSiteUrl();
+
+const TITLE_SEPARATOR = " | ";
+
+/** The subset of a CMS author these helpers read. */
+export interface AuthorIdentitySource {
+  slug?: string | null;
+  name?: string | null;
+  jobTitle?: string | null;
+  headline?: string | null;
+  bioShort?: string | null;
+  websiteUrl?: string | null;
+  linkedinUrl?: string | null;
+}
+
+/** Site Profile values used when the CMS author has nothing usable. */
+export interface AuthorIdentityFallbacks {
+  authorName: string;
+  authorRole: string;
+  authorBioShort: string;
+  websiteUrl: string;
+  linkedinUrl: string;
+}
+
+/**
+ * Projects the Site Profile onto the fallbacks both routes need.
+ *
+ * Deriving these inline is how the two routes drifted: the article route read
+ * `siteProfile.author.websiteUrl` without the normalization the author route
+ * applied. One projection means one answer.
+ */
+export function authorIdentityFallbacks(siteProfile: {
+  authorName: string;
+  authorRole: string;
+  authorBioShort: string;
+  author: { websiteUrl: string; linkedinUrl: string };
+}): AuthorIdentityFallbacks {
+  return {
+    authorName: siteProfile.authorName,
+    authorRole: siteProfile.authorRole,
+    authorBioShort: siteProfile.authorBioShort,
+    websiteUrl: siteProfile.author.websiteUrl,
+    linkedinUrl: siteProfile.author.linkedinUrl,
+  };
+}
+
+export interface AuthorIdentity {
+  name: string;
+  role: string;
+  bioShort: string;
+  websiteUrl: string;
+  linkedinUrl: string;
+  /** `name | role`, with the separator omitted when either half is absent. */
+  title: string;
+  /** The bio when filled, otherwise the articles-by sentence. */
+  description: string;
+}
+
+/**
+ * Joins a name and role for a page title, omitting the separator when either
+ * half is blank so a missing CMS field cannot leave `"Jane Doe | "` in a
+ * `<title>` or an OpenGraph tag.
+ */
+export function composeAuthorTitle(
+  name: string | null | undefined,
+  role: string | null | undefined
+): string {
+  return [blankToUndefined(name), blankToUndefined(role)]
+    .filter((part): part is string => part !== undefined)
+    .join(TITLE_SEPARATOR);
+}
+
+/**
+ * The description for an author surface: their short bio when they have one,
+ * otherwise an articles-by sentence. A blank name yields the bare "Articles."
+ * rather than the literal `"Articles by ."` the raw template produced.
+ */
+export function buildAuthorListingDescription(
+  name: string | null | undefined,
+  bioShort: string | null | undefined
+): string {
+  const bio = blankToUndefined(bioShort);
+  if (bio) {
+    return bio;
+  }
+
+  const filledName = blankToUndefined(name);
+  return filledName ? `Articles by ${filledName}.` : "Articles.";
+}
+
+function resolveIdentityUrl(
+  value: string | null | undefined,
+  fallback: string,
+  canonicalOrigin: string
+): string {
+  return normalizeIdentityUrl(value, canonicalOrigin) ?? fallback;
+}
+
+function resolveRole(
+  source: AuthorIdentitySource | null | undefined,
+  fallbacks: AuthorIdentityFallbacks
+): string {
+  return (
+    firstFilled(source?.jobTitle, source?.headline, fallbacks.authorRole) ?? ""
+  );
+}
+
+/**
+ * Identity for `/author/[slug]`, which describes *that* author.
+ *
+ * The name falls back to the slug label rather than to `authorName`: borrowing
+ * the site owner's name for a record whose name is blank would attribute a
+ * different person's articles to them.
+ */
+export function resolveAuthorPageIdentity(
+  source: AuthorIdentitySource,
+  fallbacks: AuthorIdentityFallbacks,
+  canonicalOrigin: string
+): AuthorIdentity {
+  const slug = blankToUndefined(source.slug);
+  const name =
+    firstFilled(source.name) ?? (slug ? formatSlugName(slug) : "");
+  const role = resolveRole(source, fallbacks);
+  const bioShort =
+    firstFilled(source.bioShort, fallbacks.authorBioShort) ?? "";
+
+  return {
+    name,
+    role,
+    bioShort,
+    websiteUrl: resolveIdentityUrl(
+      source.websiteUrl,
+      fallbacks.websiteUrl,
+      canonicalOrigin
+    ),
+    linkedinUrl: resolveIdentityUrl(
+      source.linkedinUrl,
+      fallbacks.linkedinUrl,
+      canonicalOrigin
+    ),
+    title: composeAuthorTitle(name, role),
+    description: buildAuthorListingDescription(name, source.bioShort),
+  };
+}
+
+/**
+ * Identity for the byline and `Person` JSON-LD on `/blog/[slug]`.
+ *
+ * Here the Site Profile owner *is* the right fallback: an article with no
+ * author relation is the site owner's, which is what the route already assumed
+ * before this change.
+ */
+export function resolveArticleAuthorIdentity(
+  source: AuthorIdentitySource | null | undefined,
+  fallbacks: AuthorIdentityFallbacks,
+  canonicalOrigin: string
+): AuthorIdentity {
+  const name = firstFilled(source?.name, fallbacks.authorName) ?? "";
+  const role = resolveRole(source, fallbacks);
+  const bioShort =
+    firstFilled(source?.bioShort, fallbacks.authorBioShort) ?? "";
+
+  return {
+    name,
+    role,
+    bioShort,
+    websiteUrl: resolveIdentityUrl(
+      source?.websiteUrl,
+      fallbacks.websiteUrl,
+      canonicalOrigin
+    ),
+    linkedinUrl: resolveIdentityUrl(
+      source?.linkedinUrl,
+      fallbacks.linkedinUrl,
+      canonicalOrigin
+    ),
+    title: composeAuthorTitle(name, role),
+    description: buildAuthorListingDescription(name, source?.bioShort),
+  };
+}

--- a/apps/web/src/lib/author-identity.ts
+++ b/apps/web/src/lib/author-identity.ts
@@ -172,35 +172,26 @@ export function resolveAuthorPageIdentity(
 /**
  * Identity for the byline and `Person` JSON-LD on `/blog/[slug]`.
  *
- * Here the Site Profile owner *is* the right fallback: an article with no
- * author relation is the site owner's, which is what the route already assumed
- * before this change.
+ * The Site Profile owner is the right fallback for an article with *no* author
+ * relation -- that is the site owner's article, which is what the route already
+ * assumed before this change. It is the wrong fallback for an article that
+ * *has* a relation whose name is blank: the route still derives `authorPath`
+ * from the relation's own slug, so borrowing the owner's name puts one person's
+ * name above a profile link to another, and points `BlogPosting.author.@id` at
+ * a `Person` node the visible byline contradicts.
+ *
+ * So a present relation is resolved by exactly the rule `/author/[slug]` uses.
+ * Delegating rather than repeating it is the point: this module exists because
+ * the two routes drifted while each spelled the same rule for itself.
  */
 export function resolveArticleAuthorIdentity(
   source: AuthorIdentitySource | null | undefined,
   fallbacks: AuthorIdentityFallbacks,
   canonicalOrigin: string
 ): AuthorIdentity {
-  const name = firstFilled(source?.name, fallbacks.authorName) ?? "";
-  const role = resolveRole(source, fallbacks);
-  const bioShort =
-    firstFilled(source?.bioShort, fallbacks.authorBioShort) ?? "";
-
-  return {
-    name,
-    role,
-    bioShort,
-    websiteUrl: resolveIdentityUrl(
-      source?.websiteUrl,
-      fallbacks.websiteUrl,
-      canonicalOrigin
-    ),
-    linkedinUrl: resolveIdentityUrl(
-      source?.linkedinUrl,
-      fallbacks.linkedinUrl,
-      canonicalOrigin
-    ),
-    title: composeAuthorTitle(name, role),
-    description: buildAuthorListingDescription(name, source?.bioShort),
-  };
+  return resolveAuthorPageIdentity(
+    source ?? { name: fallbacks.authorName },
+    fallbacks,
+    canonicalOrigin
+  );
 }

--- a/apps/web/src/lib/blog-listing.ts
+++ b/apps/web/src/lib/blog-listing.ts
@@ -1,33 +1,14 @@
 import { getArticles, getCategories } from "@/lib/strapi";
+import { firstFilled, formatSlugName } from "@/lib/strings";
+
+// Re-exported: this module is where taxonomy callers already look for it.
+export { formatSlugName };
 
 export const BLOG_PAGE_SIZE = 9;
 
 export const BLOG_PAGE_DESCRIPTION =
   "Writing on production AI systems, LLM architecture, and shipping AI in finance, defense, healthcare, and enterprise.";
 
-function firstFilled(
-  ...values: Array<string | null | undefined>
-): string | undefined {
-  for (const value of values) {
-    if (typeof value === "string") {
-      const trimmed = value.trim();
-      if (trimmed) {
-        return trimmed;
-      }
-    }
-  }
-
-  return undefined;
-}
-
-/** Title-cases a taxonomy slug for use as a last-resort display label. */
-export function formatSlugName(slug: string): string {
-  return slug
-    .split("-")
-    .filter(Boolean)
-    .map((part) => part[0].toUpperCase() + part.slice(1))
-    .join(" ");
-}
 
 /**
  * Picks the first non-blank candidate, treating CMS empty strings and
@@ -56,6 +37,14 @@ export interface SubcategoryCard {
  * CMS children carry a numeric `id`; seed children have none and are keyed
  * by slug — the fallback is nullish-coalescing, so a present-but-falsy `id`
  * keeps its own key rather than silently falling back to the slug.
+ *
+ * A child with a blank slug is dropped rather than rendered (#90). The category
+ * `slug` attribute is a Strapi `uid` that is not `required`, so an empty value
+ * is reachable; keeping it would render a card linking to `/blog/category/`
+ * under an empty title and add a slug to `childSlugs`, costing a `getArticles`
+ * call that can never match. The seed path already drops these in
+ * `toCategorySeed` — this puts the same guarantee on the CMS path, so the
+ * caller does not have to re-check.
  */
 export function resolveSubcategoryCards(
   children: Array<{
@@ -66,12 +55,21 @@ export function resolveSubcategoryCards(
     description?: string | null;
   }>
 ): SubcategoryCard[] {
-  return children.map((child) => ({
-    id: child.id ?? child.slug,
-    name: resolveTaxonomyDisplayName(child.slug, child.name, child.headline),
-    slug: child.slug,
-    description: firstFilled(child.description),
-  }));
+  return children.flatMap((child) => {
+    const slug = firstFilled(child.slug);
+    if (!slug) {
+      return [];
+    }
+
+    return [
+      {
+        id: child.id ?? slug,
+        name: resolveTaxonomyDisplayName(slug, child.name, child.headline),
+        slug,
+        description: firstFilled(child.description),
+      },
+    ];
+  });
 }
 
 export function buildTagListingDescription(tagName: string): string {

--- a/apps/web/src/lib/blog-listing.ts
+++ b/apps/web/src/lib/blog-listing.ts
@@ -1,8 +1,10 @@
 import { getArticles, getCategories } from "@/lib/strapi";
 import { firstFilled, formatSlugName } from "@/lib/strings";
 
-// Re-exported: this module is where taxonomy callers already look for it.
-export { formatSlugName };
+// Deliberately not re-exported. This module imports `@/lib/strapi`, which
+// reaches `server-only`, so a client component that reached `formatSlugName`
+// through here would fail the build for a pure string function. Escaping that
+// chain is why the helper moved to `@/lib/strings` -- import it from there.
 
 export const BLOG_PAGE_SIZE = 9;
 

--- a/apps/web/src/lib/site-profile.ts
+++ b/apps/web/src/lib/site-profile.ts
@@ -6,6 +6,7 @@ import {
 import { identityUrlKey, normalizeIdentityUrl } from "./url-normalization";
 import { isBinaPrintEnabled } from "./feature-flags";
 import { serverEnv } from "./server-env";
+import { blankToUndefined } from "./strings";
 import type {
   Author,
   Credential,
@@ -106,22 +107,13 @@ export class SiteProfileValidationError extends Error {
   }
 }
 
-function normalizeString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
-}
-
 function normalizeStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
     return [];
   }
 
   return value
-    .map((item) => normalizeString(item))
+    .map((item) => blankToUndefined(item))
     .filter((item): item is string => Boolean(item));
 }
 
@@ -132,8 +124,8 @@ function normalizeNavItems(items: SiteSettings["navItems"]): NavItem[] {
 
   const normalized: NavItem[] = [];
   items.forEach((item, index) => {
-    const label = normalizeString(item?.label);
-    const href = normalizeString(item?.href);
+    const label = blankToUndefined(item?.label);
+    const href = blankToUndefined(item?.href);
     if (!label || !href) {
       return;
     }
@@ -172,8 +164,8 @@ function normalizeSocialLinks(items: SiteSettings["socialLinks"]): SocialLink[] 
 
   const normalized = items
     .map((item, index) => {
-      const platform = normalizeString(item?.platform);
-      const url = normalizeString(item?.url);
+      const platform = blankToUndefined(item?.platform);
+      const url = blankToUndefined(item?.url);
       const normalizedUrl = normalizeIdentityUrl(url, CANONICAL_IDENTITY_ORIGIN);
       if (!platform || !normalizedUrl) {
         return null;
@@ -222,9 +214,9 @@ function buildCanonicalSocialLinks(
   const normalizedAuthorLinks = Array.isArray(author?.sameAs)
     ? author.sameAs
         .map((item, index) => {
-          const platform = normalizeString(item?.platform);
+          const platform = blankToUndefined(item?.platform);
           const normalizedUrl = normalizeIdentityUrl(
-            normalizeString(item?.url),
+            blankToUndefined(item?.url),
             CANONICAL_IDENTITY_ORIGIN
           );
 
@@ -242,10 +234,10 @@ function buildCanonicalSocialLinks(
     : [];
 
   const websiteUrl =
-    normalizeIdentityUrl(normalizeString(author?.websiteUrl), CANONICAL_IDENTITY_ORIGIN) ??
+    normalizeIdentityUrl(blankToUndefined(author?.websiteUrl), CANONICAL_IDENTITY_ORIGIN) ??
     DEFAULT_SITE_PROFILE.authorWebsiteUrl;
   const linkedinUrl =
-    normalizeIdentityUrl(normalizeString(author?.linkedinUrl), CANONICAL_IDENTITY_ORIGIN) ??
+    normalizeIdentityUrl(blankToUndefined(author?.linkedinUrl), CANONICAL_IDENTITY_ORIGIN) ??
     DEFAULT_SITE_PROFILE.authorLinkedinUrl;
 
   const canonical = dedupeSocialLinks([
@@ -265,7 +257,7 @@ function normalizeCredentials(credentials: Author["credentials"]): Credential[] 
 
   return credentials
     .map((credential, index): Credential | null => {
-      const title = normalizeString(credential?.title);
+      const title = blankToUndefined(credential?.title);
       if (!title) {
         return null;
       }
@@ -273,9 +265,9 @@ function normalizeCredentials(credentials: Author["credentials"]): Credential[] 
       return {
         id: credential.id ?? index + 1,
         title,
-        issuer: normalizeString(credential.issuer),
-        description: normalizeString(credential.description),
-        url: normalizeString(credential.url),
+        issuer: blankToUndefined(credential.issuer),
+        description: blankToUndefined(credential.description),
+        url: blankToUndefined(credential.url),
       };
     })
     .filter((credential): credential is Credential => credential !== null);
@@ -283,9 +275,9 @@ function normalizeCredentials(credentials: Author["credentials"]): Credential[] 
 
 function deriveRole(author: Author | null | undefined, settings: SiteSettings | null | undefined): string {
   return (
-    normalizeString(author?.jobTitle) ??
-    normalizeString(author?.headline) ??
-    normalizeString(settings?.authorRole) ??
+    blankToUndefined(author?.jobTitle) ??
+    blankToUndefined(author?.headline) ??
+    blankToUndefined(settings?.authorRole) ??
     DEFAULT_SITE_PROFILE.authorRole
   );
 }
@@ -295,14 +287,14 @@ function buildAuthorProfile(
   settings: SiteSettings | null | undefined
 ): AuthorProfile {
   const fallbackSlug = DEFAULT_SITE_PROFILE.authorSlug;
-  const slug = normalizeString(author?.slug) ?? fallbackSlug;
+  const slug = blankToUndefined(author?.slug) ?? fallbackSlug;
   const canonicalSocialLinks = buildCanonicalSocialLinks(author, settings?.socialLinks);
   const websiteUrl =
-    normalizeIdentityUrl(normalizeString(author?.websiteUrl), CANONICAL_IDENTITY_ORIGIN) ??
+    normalizeIdentityUrl(blankToUndefined(author?.websiteUrl), CANONICAL_IDENTITY_ORIGIN) ??
     canonicalSocialLinks.find((link) => link.platform.toLowerCase() === "website")?.url ??
     DEFAULT_SITE_PROFILE.authorWebsiteUrl;
   const linkedinUrl =
-    normalizeIdentityUrl(normalizeString(author?.linkedinUrl), CANONICAL_IDENTITY_ORIGIN) ??
+    normalizeIdentityUrl(blankToUndefined(author?.linkedinUrl), CANONICAL_IDENTITY_ORIGIN) ??
     canonicalSocialLinks.find((link) => link.platform.toLowerCase() === "linkedin")?.url ??
     DEFAULT_SITE_PROFILE.authorLinkedinUrl;
 
@@ -312,13 +304,13 @@ function buildAuthorProfile(
   return {
     id: author?.id,
     documentId: author?.documentId,
-    name: normalizeString(author?.name) ?? normalizeString(settings?.authorName) ?? DEFAULT_SITE_PROFILE.authorName,
+    name: blankToUndefined(author?.name) ?? blankToUndefined(settings?.authorName) ?? DEFAULT_SITE_PROFILE.authorName,
     slug,
     profilePath: `/author/${slug}`,
-    headline: normalizeString(author?.headline),
+    headline: blankToUndefined(author?.headline),
     bioShort:
-      normalizeString(author?.bioShort) ??
-      normalizeString(settings?.authorBioShort) ??
+      blankToUndefined(author?.bioShort) ??
+      blankToUndefined(settings?.authorBioShort) ??
       DEFAULT_SITE_PROFILE.authorBioShort,
     bioLong: author?.bioLong,
     websiteUrl,
@@ -327,18 +319,18 @@ function buildAuthorProfile(
     profileImage: author?.profileImage,
     jobTitle: deriveRole(author, settings),
     worksForName:
-      normalizeString(author?.worksForName) ?? DEFAULT_SITE_PROFILE.authorWorksForName,
+      blankToUndefined(author?.worksForName) ?? DEFAULT_SITE_PROFILE.authorWorksForName,
     worksForUrl:
-      normalizeString(author?.worksForUrl) ?? DEFAULT_SITE_PROFILE.authorWorksForUrl,
+      blankToUndefined(author?.worksForUrl) ?? DEFAULT_SITE_PROFILE.authorWorksForUrl,
     alumniOf: alumniOf.length > 0 ? alumniOf : [...DEFAULT_SITE_PROFILE.authorAlumniOf],
     knowsAbout: knowsAbout.length > 0 ? knowsAbout : [...DEFAULT_SITE_PROFILE.knowsAbout],
     credentials: normalizeCredentials(author?.credentials),
     addressLocality:
-      normalizeString(author?.addressLocality) ?? DEFAULT_SITE_PROFILE.authorAddressLocality,
+      blankToUndefined(author?.addressLocality) ?? DEFAULT_SITE_PROFILE.authorAddressLocality,
     addressRegion:
-      normalizeString(author?.addressRegion) ?? DEFAULT_SITE_PROFILE.authorAddressRegion,
+      blankToUndefined(author?.addressRegion) ?? DEFAULT_SITE_PROFILE.authorAddressRegion,
     addressCountry:
-      normalizeString(author?.addressCountry) ?? DEFAULT_SITE_PROFILE.authorAddressCountry,
+      blankToUndefined(author?.addressCountry) ?? DEFAULT_SITE_PROFILE.authorAddressCountry,
   };
 }
 
@@ -348,7 +340,7 @@ function hasValidNavItems(items: SiteSettings["navItems"]): boolean {
   }
 
   return items.some(
-    (item) => Boolean(normalizeString(item?.label)) && Boolean(normalizeString(item?.href))
+    (item) => Boolean(blankToUndefined(item?.label)) && Boolean(blankToUndefined(item?.href))
   );
 }
 
@@ -359,25 +351,25 @@ function hasValidSocialLinks(items: SiteSettings["socialLinks"]): boolean {
 
   return items.some(
     (item) =>
-      Boolean(normalizeString(item?.platform)) &&
-      Boolean(normalizeIdentityUrl(normalizeString(item?.url), CANONICAL_IDENTITY_ORIGIN))
+      Boolean(blankToUndefined(item?.platform)) &&
+      Boolean(normalizeIdentityUrl(blankToUndefined(item?.url), CANONICAL_IDENTITY_ORIGIN))
   );
 }
 
 function hasCanonicalAuthorData(author: Author | null | undefined): boolean {
   return Boolean(
-    normalizeString(author?.name) &&
+    blankToUndefined(author?.name) &&
       deriveRole(author, undefined) &&
-      normalizeString(author?.bioShort)
+      blankToUndefined(author?.bioShort)
   );
 }
 
 function hasCanonicalSocialData(author: Author | null | undefined): boolean {
   const hasWebsite = Boolean(
-    normalizeIdentityUrl(normalizeString(author?.websiteUrl), CANONICAL_IDENTITY_ORIGIN)
+    normalizeIdentityUrl(blankToUndefined(author?.websiteUrl), CANONICAL_IDENTITY_ORIGIN)
   );
   const hasLinkedIn = Boolean(
-    normalizeIdentityUrl(normalizeString(author?.linkedinUrl), CANONICAL_IDENTITY_ORIGIN)
+    normalizeIdentityUrl(blankToUndefined(author?.linkedinUrl), CANONICAL_IDENTITY_ORIGIN)
   );
 
   if (hasWebsite && hasLinkedIn) {
@@ -390,8 +382,8 @@ function hasCanonicalSocialData(author: Author | null | undefined): boolean {
 
   return author.sameAs.some(
     (item) =>
-      Boolean(normalizeString(item?.platform)) &&
-      Boolean(normalizeIdentityUrl(normalizeString(item?.url), CANONICAL_IDENTITY_ORIGIN))
+      Boolean(blankToUndefined(item?.platform)) &&
+      Boolean(normalizeIdentityUrl(blankToUndefined(item?.url), CANONICAL_IDENTITY_ORIGIN))
   );
 }
 
@@ -417,18 +409,18 @@ function collectMissingRequiredFields(
 
   const missing: string[] = REQUIRED_SITE_PROFILE_FIELDS.filter((field) => {
     if (field === "authorName") {
-      return !normalizeString(settings.authorName) && !normalizeString(author?.name);
+      return !blankToUndefined(settings.authorName) && !blankToUndefined(author?.name);
     }
 
     if (field === "authorRole") {
-      return !normalizeString(settings.authorRole) && !normalizeString(author?.jobTitle) && !normalizeString(author?.headline);
+      return !blankToUndefined(settings.authorRole) && !blankToUndefined(author?.jobTitle) && !blankToUndefined(author?.headline);
     }
 
     if (field === "authorBioShort") {
-      return !normalizeString(settings.authorBioShort) && !normalizeString(author?.bioShort);
+      return !blankToUndefined(settings.authorBioShort) && !blankToUndefined(author?.bioShort);
     }
 
-    return !normalizeString(settings[field as RequiredSiteProfileField]);
+    return !blankToUndefined(settings[field as RequiredSiteProfileField]);
   });
 
   if (!hasValidNavItems(settings.navItems)) {
@@ -458,40 +450,40 @@ function mergeProfile(settings: SiteSettings | null | undefined, author?: Author
   const canonicalAuthor = buildAuthorProfile(author, settings);
 
   return {
-    siteName: normalizeString(settings?.siteName) ?? DEFAULT_SITE_PROFILE.siteName,
+    siteName: blankToUndefined(settings?.siteName) ?? DEFAULT_SITE_PROFILE.siteName,
     siteDescription:
-      normalizeString(settings?.siteDescription) ?? DEFAULT_SITE_PROFILE.siteDescription,
+      blankToUndefined(settings?.siteDescription) ?? DEFAULT_SITE_PROFILE.siteDescription,
     positioningHeadline:
-      normalizeString(settings?.positioningHeadline) ??
+      blankToUndefined(settings?.positioningHeadline) ??
       DEFAULT_SITE_PROFILE.positioningHeadline,
     positioningSubheadline:
-      normalizeString(settings?.positioningSubheadline) ??
+      blankToUndefined(settings?.positioningSubheadline) ??
       DEFAULT_SITE_PROFILE.positioningSubheadline,
     positioningHighlight:
-      normalizeString(settings?.positioningHighlight) ??
+      blankToUndefined(settings?.positioningHighlight) ??
       DEFAULT_SITE_PROFILE.positioningHighlight,
     credentialLine:
-      normalizeString(settings?.credentialLine) ?? DEFAULT_SITE_PROFILE.credentialLine,
+      blankToUndefined(settings?.credentialLine) ?? DEFAULT_SITE_PROFILE.credentialLine,
     industriesLine:
-      normalizeString(settings?.industriesLine) ?? DEFAULT_SITE_PROFILE.industriesLine,
+      blankToUndefined(settings?.industriesLine) ?? DEFAULT_SITE_PROFILE.industriesLine,
     locationLine:
-      normalizeString(settings?.locationLine) ?? DEFAULT_SITE_PROFILE.locationLine,
+      blankToUndefined(settings?.locationLine) ?? DEFAULT_SITE_PROFILE.locationLine,
     primaryCtaLabel:
-      normalizeString(settings?.primaryCtaLabel) ?? DEFAULT_SITE_PROFILE.primaryCtaLabel,
+      blankToUndefined(settings?.primaryCtaLabel) ?? DEFAULT_SITE_PROFILE.primaryCtaLabel,
     primaryCtaHref:
-      normalizeString(settings?.primaryCtaHref) ?? DEFAULT_SITE_PROFILE.primaryCtaHref,
+      blankToUndefined(settings?.primaryCtaHref) ?? DEFAULT_SITE_PROFILE.primaryCtaHref,
     secondaryCtaLabel:
-      normalizeString(settings?.secondaryCtaLabel) ?? DEFAULT_SITE_PROFILE.secondaryCtaLabel,
+      blankToUndefined(settings?.secondaryCtaLabel) ?? DEFAULT_SITE_PROFILE.secondaryCtaLabel,
     secondaryCtaHref:
-      normalizeString(settings?.secondaryCtaHref) ?? DEFAULT_SITE_PROFILE.secondaryCtaHref,
+      blankToUndefined(settings?.secondaryCtaHref) ?? DEFAULT_SITE_PROFILE.secondaryCtaHref,
     contactPrompt:
-      normalizeString(settings?.contactPrompt) ?? DEFAULT_SITE_PROFILE.contactPrompt,
+      blankToUndefined(settings?.contactPrompt) ?? DEFAULT_SITE_PROFILE.contactPrompt,
     authorName: canonicalAuthor.name,
     authorRole: canonicalAuthor.jobTitle,
     authorBioShort: canonicalAuthor.bioShort,
-    footerText: normalizeString(settings?.footerText) ?? DEFAULT_SITE_PROFILE.footerText,
+    footerText: blankToUndefined(settings?.footerText) ?? DEFAULT_SITE_PROFILE.footerText,
     bookCallHref:
-      normalizeString(settings?.bookCallHref) ?? DEFAULT_SITE_PROFILE.bookCallHref,
+      blankToUndefined(settings?.bookCallHref) ?? DEFAULT_SITE_PROFILE.bookCallHref,
     knowsAbout: [...canonicalAuthor.knowsAbout],
     navItems: normalizeNavItems(settings?.navItems),
     socialLinks: [...canonicalAuthor.sameAs],

--- a/apps/web/src/lib/strings.ts
+++ b/apps/web/src/lib/strings.ts
@@ -1,0 +1,53 @@
+/**
+ * The single definition of "blank" for CMS-sourced copy.
+ *
+ * Strapi returns `""` for a field a content editor cleared and `"   "` for one
+ * they left a space in. Both are *present* to `??` and truthy to `{value && …}`,
+ * so without this rule a cleared field wins over its fallback and a
+ * whitespace-only field renders an empty element. Every fix in this class
+ * (#75, #77, #79, #80, #83, #89) is an application of the same rule, which is
+ * why it lives in one module rather than being restated per surface.
+ *
+ * `unknown` rather than `string | null | undefined`: Strapi `json` attributes
+ * and loosely-typed API responses can put a number or an object in a slot the
+ * types call a string, and a caller wants `undefined` there, not `"0"`.
+ */
+export function blankToUndefined(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Picks the first candidate that is not blank, trimmed, or `undefined` if none
+ * is. The replacement for `a ?? b ?? c` wherever the values come from the CMS:
+ * candidate order is preserved, so callers pass the CMS value first and the
+ * Site Profile fallback last.
+ */
+export function firstFilled(...values: unknown[]): string | undefined {
+  for (const value of values) {
+    const filled = blankToUndefined(value);
+    if (filled !== undefined) {
+      return filled;
+    }
+  }
+
+  return undefined;
+}
+
+/**
+ * Title-cases a slug for use as a last-resort display label: `agent-frameworks`
+ * becomes `Agent Frameworks`. Lives here rather than in `blog-listing.ts`
+ * because it is a pure string rule with no taxonomy or CMS dependency, and
+ * `blog-listing.ts` pulls in the Strapi client (and with it `server-only`).
+ */
+export function formatSlugName(slug: string): string {
+  return slug
+    .split("-")
+    .filter(Boolean)
+    .map((part) => part[0].toUpperCase() + part.slice(1))
+    .join(" ");
+}

--- a/apps/web/src/lib/taxonomy-seed.ts
+++ b/apps/web/src/lib/taxonomy-seed.ts
@@ -1,4 +1,5 @@
 import taxonomy from "../../../../data/taxonomy.json";
+import { blankToUndefined } from "./strings";
 
 interface TaxonomyCategoryNode {
   name?: unknown;
@@ -46,64 +47,55 @@ export interface TagSeed {
   intro?: string;
 }
 
-function normalizeString(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
 function toCategorySeed(
   node: TaxonomyCategoryNode,
   parentSlug?: string
 ): CategorySeed | null {
-  const slug = normalizeString(node.slug);
+  const slug = blankToUndefined(node.slug);
   if (!slug) {
     return null;
   }
 
   const children = (node.children ?? [])
     .map((child) => {
-      const childSlug = normalizeString(child.slug);
+      const childSlug = blankToUndefined(child.slug);
       if (!childSlug) {
         return null;
       }
 
       return {
-        name: normalizeString(child.name),
+        name: blankToUndefined(child.name),
         slug: childSlug,
-        description: normalizeString(child.description),
-        headline: normalizeString(child.headline),
-        intro: normalizeString(child.intro),
+        description: blankToUndefined(child.description),
+        headline: blankToUndefined(child.headline),
+        intro: blankToUndefined(child.intro),
       };
     })
     .filter((child): child is NonNullable<typeof child> => child !== null);
 
   return {
-    name: normalizeString(node.name),
+    name: blankToUndefined(node.name),
     slug,
-    description: normalizeString(node.description),
-    headline: normalizeString(node.headline),
-    intro: normalizeString(node.intro),
+    description: blankToUndefined(node.description),
+    headline: blankToUndefined(node.headline),
+    intro: blankToUndefined(node.intro),
     parentSlug,
     children,
   };
 }
 
 function toTagSeed(node: TaxonomyTagNode): TagSeed | null {
-  const slug = normalizeString(node.slug);
+  const slug = blankToUndefined(node.slug);
   if (!slug) {
     return null;
   }
 
   return {
-    name: normalizeString(node.name),
+    name: blankToUndefined(node.name),
     slug,
-    description: normalizeString(node.description),
-    headline: normalizeString(node.headline),
-    intro: normalizeString(node.intro),
+    description: blankToUndefined(node.description),
+    headline: blankToUndefined(node.headline),
+    intro: blankToUndefined(node.intro),
   };
 }
 

--- a/apps/web/src/lib/url-normalization.ts
+++ b/apps/web/src/lib/url-normalization.ts
@@ -49,6 +49,14 @@ export function normalizeIdentityUrl(
     return null;
   }
 
+  // `identityUrlKey` builds its key from protocol + host + path only, so
+  // userinfo that survives here keys identically to the clean URL while
+  // serializing differently: the credentialed copy takes the dedupe slot and
+  // evicts the canonical one. Credentials are also never valid in a `Person`
+  // `url` / `sameAs`, and an embedded password would be published verbatim.
+  parsed.username = "";
+  parsed.password = "";
+
   const canonicalApex = stripWww(canonical.hostname).toLowerCase();
   const parsedApex = stripWww(parsed.hostname).toLowerCase();
 

--- a/apps/web/src/lib/url-normalization.ts
+++ b/apps/web/src/lib/url-normalization.ts
@@ -1,3 +1,9 @@
+// Everything this module returns is rendered into an `href` or into `Person`
+// JSON-LD `url` / `sameAs`. `new URL()` happily parses `javascript:alert(1)`
+// and `data:text/html,…`, so parsing alone is not a validity check — an
+// identity URL has to be a web address (#83).
+const WEB_PROTOCOLS = new Set(["http:", "https:"]);
+
 function stripWww(hostname: string): string {
   return hostname.startsWith("www.") ? hostname.slice(4) : hostname;
 }
@@ -36,6 +42,10 @@ export function normalizeIdentityUrl(
     parsed = new URL(value.trim());
     canonical = new URL(canonicalOrigin);
   } catch {
+    return null;
+  }
+
+  if (!WEB_PROTOCOLS.has(parsed.protocol)) {
     return null;
   }
 

--- a/apps/web/tests/about-blank-descriptions.test.ts
+++ b/apps/web/tests/about-blank-descriptions.test.ts
@@ -1,0 +1,141 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+
+import { CareerTimeline } from "../src/components/about/CareerTimeline.tsx";
+import { EducationList } from "../src/components/about/EducationList.tsx";
+import type { Education, Experience } from "../src/types/strapi.ts";
+
+// #89. `{value && <p>…</p>}` suppresses `""` but not `"   "` — a whitespace-only
+// CMS string is truthy, so it renders an empty paragraph and leaves a stray
+// vertical gap. #80 fixed this on category cards; these are the /about
+// surfaces that still carried the raw pattern.
+//
+// These render the real components rather than grepping their source, so they
+// fail on the rendered output regardless of how the guard is spelled.
+
+function baseExperience(overrides: Partial<Experience> = {}): Experience {
+  return {
+    id: 1,
+    title: "Principal AI Engineer",
+    company: "Sev1Tech",
+    startDate: "2023-01-01",
+    current: true,
+    ...overrides,
+  };
+}
+
+function baseEducation(overrides: Partial<Education> = {}): Education {
+  return {
+    id: 1,
+    degree: "MBA",
+    institution: "University of Maryland, Smith School of Business",
+    ...overrides,
+  };
+}
+
+/** Paragraphs whose entire content is markup-free whitespace, or nothing. */
+function emptyParagraphs(html: string): string[] {
+  return html.match(/<p[^>]*>\s*<\/p>/g) ?? [];
+}
+
+function paragraphTexts(html: string): string[] {
+  return [...html.matchAll(/<p[^>]*>([\s\S]*?)<\/p>/g)].map((match) => match[1]);
+}
+
+test("career timeline renders no paragraph for a whitespace-only description", () => {
+  const html = renderToStaticMarkup(
+    createElement(CareerTimeline, {
+      experiences: [baseExperience({ description: "   " })],
+    })
+  );
+
+  assert.deepEqual(emptyParagraphs(html), []);
+});
+
+test("career timeline renders no paragraph for an empty description", () => {
+  const html = renderToStaticMarkup(
+    createElement(CareerTimeline, {
+      experiences: [baseExperience({ description: "" })],
+    })
+  );
+
+  assert.deepEqual(emptyParagraphs(html), []);
+});
+
+test("career timeline still renders a filled description, trimmed", () => {
+  const html = renderToStaticMarkup(
+    createElement(CareerTimeline, {
+      experiences: [baseExperience({ description: "  Shipping production AI.  " })],
+    })
+  );
+
+  assert.ok(
+    paragraphTexts(html).includes("Shipping production AI."),
+    `expected the description paragraph, got ${JSON.stringify(paragraphTexts(html))}`
+  );
+});
+
+test("education list renders no paragraph for a whitespace-only description", () => {
+  const html = renderToStaticMarkup(
+    createElement(EducationList, {
+      education: [baseEducation({ description: "   " })],
+    })
+  );
+
+  assert.deepEqual(emptyParagraphs(html), []);
+});
+
+test("education list renders no paragraph for an empty description", () => {
+  const html = renderToStaticMarkup(
+    createElement(EducationList, {
+      education: [baseEducation({ description: "" })],
+    })
+  );
+
+  assert.deepEqual(emptyParagraphs(html), []);
+});
+
+test("education list still renders a filled description, trimmed", () => {
+  const html = renderToStaticMarkup(
+    createElement(EducationList, {
+      education: [baseEducation({ description: "  Finance concentration.  " })],
+    })
+  );
+
+  assert.ok(
+    paragraphTexts(html).includes("Finance concentration."),
+    `expected the description paragraph, got ${JSON.stringify(paragraphTexts(html))}`
+  );
+});
+
+test("education list keeps the degree and field heading it already rendered", () => {
+  // The education block moved out of about/page.tsx into its own component so
+  // it could be rendered here; this pins the markup that move had to preserve.
+  const html = renderToStaticMarkup(
+    createElement(EducationList, {
+      education: [baseEducation({ field: "Finance" })],
+    })
+  );
+
+  assert.match(html, /MBA, Finance/);
+  assert.match(html, /University of Maryland, Smith School of Business/);
+});
+
+test("education list omits the field separator when there is no field", () => {
+  const html = renderToStaticMarkup(
+    createElement(EducationList, { education: [baseEducation()] })
+  );
+
+  assert.match(html, /MBA/);
+  assert.doesNotMatch(html, /MBA,/);
+});
+
+test("education list treats a whitespace-only field as absent", () => {
+  const html = renderToStaticMarkup(
+    createElement(EducationList, { education: [baseEducation({ field: "   " })] })
+  );
+
+  assert.doesNotMatch(html, /MBA,/);
+});

--- a/apps/web/tests/about-blank-descriptions.test.ts
+++ b/apps/web/tests/about-blank-descriptions.test.ts
@@ -1,10 +1,13 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { renderToStaticMarkup } from "react-dom/server";
 import { createElement } from "react";
 
 import { CareerTimeline } from "../src/components/about/CareerTimeline.tsx";
 import { EducationList } from "../src/components/about/EducationList.tsx";
+import { assertRendersComponent } from "./contract-assertions.ts";
 import type { Education, Experience } from "../src/types/strapi.ts";
 
 // #89. `{value && <p>…</p>}` suppresses `""` but not `"   "` — a whitespace-only
@@ -138,4 +141,52 @@ test("education list treats a whitespace-only field as absent", () => {
   );
 
   assert.doesNotMatch(html, /MBA,/);
+});
+
+// `degree` and `institution` are `required` in the Strapi component, but
+// Strapi's `required` rejects `""` and accepts `"   "` — the same reachability
+// argument #89 makes for `description`. Both were rendered raw until now.
+
+test("education list treats a whitespace-only institution as absent", () => {
+  const html = renderToStaticMarkup(
+    createElement(EducationList, {
+      education: [baseEducation({ institution: "   " })],
+    })
+  );
+
+  assert.deepEqual(emptyParagraphs(html), []);
+});
+
+test("education list omits the leading separator for a whitespace-only degree", () => {
+  const html = renderToStaticMarkup(
+    createElement(EducationList, {
+      education: [baseEducation({ degree: "   ", field: "Finance" })],
+    })
+  );
+
+  assert.match(html, /Finance/);
+  assert.doesNotMatch(html, /, Finance/);
+});
+
+test("education list renders no heading when degree and field are both blank", () => {
+  const html = renderToStaticMarkup(
+    createElement(EducationList, {
+      education: [baseEducation({ degree: "  ", field: "" })],
+    })
+  );
+
+  assert.doesNotMatch(html, /<h3[^>]*>\s*<\/h3>/);
+});
+
+// Everything above renders the components in isolation. That only protects
+// /about while /about still routes through them -- re-inlining either block
+// would regress the page with every assertion above still green.
+test("the about page renders the extracted components instead of re-inlining them", () => {
+  const source = readFileSync(
+    resolve(process.cwd(), "src/app/about/page.tsx"),
+    "utf8"
+  );
+
+  assertRendersComponent(source, "CareerTimeline", "#89", "about page");
+  assertRendersComponent(source, "EducationList", "#89", "about page");
 });

--- a/apps/web/tests/author-identity.test.ts
+++ b/apps/web/tests/author-identity.test.ts
@@ -1,0 +1,283 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  authorIdentityFallbacks,
+  buildAuthorListingDescription,
+  composeAuthorTitle,
+  resolveArticleAuthorIdentity,
+  resolveAuthorPageIdentity,
+} from "../src/lib/author-identity.ts";
+
+// #83. `??` treats a CMS empty string as *present*, so a cleared author field
+// beats its Site Profile fallback and reaches the <title>, the visible byline
+// and the Person JSON-LD. On the article route the two identity URLs also
+// skipped `normalizeIdentityUrl`, which the author route already applied --
+// so a blank `websiteUrl` could reach Person `url` / `sameAs` as `""`.
+
+const ORIGIN = "https://www.mehdi-zare.com";
+
+const FALLBACKS = {
+  authorName: "Mehdi Zare, CFA",
+  authorRole: "Principal AI Engineer",
+  authorBioShort: "Principal AI engineer shipping production systems.",
+  websiteUrl: "https://www.mehdi-zare.com",
+  linkedinUrl: "https://linkedin.com/in/mehdizare",
+};
+
+// ---------------------------------------------------------------------------
+// composeAuthorTitle
+// ---------------------------------------------------------------------------
+
+test("composeAuthorTitle joins a name and role with the separator", () => {
+  assert.equal(composeAuthorTitle("Jane Doe", "Staff Engineer"), "Jane Doe | Staff Engineer");
+});
+
+test("composeAuthorTitle drops the separator when the role is missing", () => {
+  // page.tsx:62 produced "Jane Doe | " for a blank CMS jobTitle.
+  assert.equal(composeAuthorTitle("Jane Doe", ""), "Jane Doe");
+  assert.equal(composeAuthorTitle("Jane Doe", "   "), "Jane Doe");
+  assert.equal(composeAuthorTitle("Jane Doe", undefined), "Jane Doe");
+});
+
+test("composeAuthorTitle drops the separator when the name is missing", () => {
+  assert.equal(composeAuthorTitle("", "Staff Engineer"), "Staff Engineer");
+  assert.equal(composeAuthorTitle("   ", "Staff Engineer"), "Staff Engineer");
+});
+
+test("composeAuthorTitle returns an empty string when both halves are blank", () => {
+  assert.equal(composeAuthorTitle("  ", ""), "");
+});
+
+// ---------------------------------------------------------------------------
+// buildAuthorListingDescription
+// ---------------------------------------------------------------------------
+
+test("buildAuthorListingDescription prefers a filled bio", () => {
+  assert.equal(
+    buildAuthorListingDescription("Jane Doe", "  Writes about evals.  "),
+    "Writes about evals."
+  );
+});
+
+test("buildAuthorListingDescription falls back to the articles-by sentence", () => {
+  assert.equal(buildAuthorListingDescription("Jane Doe", "   "), "Articles by Jane Doe.");
+  assert.equal(buildAuthorListingDescription("Jane Doe", null), "Articles by Jane Doe.");
+});
+
+test("buildAuthorListingDescription never renders a nameless articles-by sentence", () => {
+  // page.tsx:30 produced the literal "Articles by ." for a blank CMS name.
+  assert.doesNotMatch(buildAuthorListingDescription("", null), /Articles by \./);
+  assert.doesNotMatch(buildAuthorListingDescription("   ", ""), /Articles by \./);
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthorPageIdentity -- /author/[slug]
+// ---------------------------------------------------------------------------
+
+test("author page identity resolves name, role and bio from filled CMS values", () => {
+  const identity = resolveAuthorPageIdentity(
+    {
+      slug: "jane-doe",
+      name: "Jane Doe",
+      jobTitle: "Staff Engineer",
+      bioShort: "Writes about evals.",
+    },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(identity.name, "Jane Doe");
+  assert.equal(identity.role, "Staff Engineer");
+  assert.equal(identity.title, "Jane Doe | Staff Engineer");
+  assert.equal(identity.description, "Writes about evals.");
+});
+
+test("author page identity prefers jobTitle, then headline, then the profile role", () => {
+  const fromHeadline = resolveAuthorPageIdentity(
+    { slug: "jane-doe", name: "Jane Doe", jobTitle: "   ", headline: "Eval Lead" },
+    FALLBACKS,
+    ORIGIN
+  );
+  const fromProfile = resolveAuthorPageIdentity(
+    { slug: "jane-doe", name: "Jane Doe", jobTitle: "", headline: "  " },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(fromHeadline.role, "Eval Lead");
+  assert.equal(fromProfile.role, FALLBACKS.authorRole);
+});
+
+test("author page identity falls back to the slug label rather than another author's name", () => {
+  // The page describes *this* author. Borrowing the site owner's name for a
+  // record whose name is blank would attribute their articles to someone else.
+  const identity = resolveAuthorPageIdentity(
+    { slug: "jane-doe", name: "   " },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(identity.name, "Jane Doe");
+  assert.notEqual(identity.name, FALLBACKS.authorName);
+});
+
+test("author page identity never emits a dangling title separator", () => {
+  const identity = resolveAuthorPageIdentity(
+    { slug: "jane-doe", name: "", jobTitle: "", headline: "" },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.doesNotMatch(identity.title, /\|\s*$/);
+  assert.doesNotMatch(identity.title, /^\s*\|/);
+});
+
+test("author page identity normalizes identity URLs and rejects blank ones", () => {
+  const blank = resolveAuthorPageIdentity(
+    { slug: "jane-doe", name: "Jane Doe", websiteUrl: "   ", linkedinUrl: "" },
+    FALLBACKS,
+    ORIGIN
+  );
+  const filled = resolveAuthorPageIdentity(
+    {
+      slug: "jane-doe",
+      name: "Jane Doe",
+      websiteUrl: "https://mehdi-zare.com/",
+      linkedinUrl: "https://linkedin.com/in/janedoe/",
+    },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(blank.websiteUrl, FALLBACKS.websiteUrl);
+  assert.equal(blank.linkedinUrl, FALLBACKS.linkedinUrl);
+  assert.equal(filled.websiteUrl, "https://www.mehdi-zare.com");
+  assert.equal(filled.linkedinUrl, "https://linkedin.com/in/janedoe");
+});
+
+// ---------------------------------------------------------------------------
+// resolveArticleAuthorIdentity -- /blog/[slug]
+// ---------------------------------------------------------------------------
+
+test("article author identity uses the article's author when filled", () => {
+  const identity = resolveArticleAuthorIdentity(
+    {
+      slug: "jane-doe",
+      name: "Jane Doe",
+      jobTitle: "Staff Engineer",
+      bioShort: "Writes about evals.",
+    },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(identity.name, "Jane Doe");
+  assert.equal(identity.role, "Staff Engineer");
+  assert.equal(identity.bioShort, "Writes about evals.");
+});
+
+test("article author identity falls back to the site owner when there is no author relation", () => {
+  const identity = resolveArticleAuthorIdentity(undefined, FALLBACKS, ORIGIN);
+
+  assert.equal(identity.name, FALLBACKS.authorName);
+  assert.equal(identity.role, FALLBACKS.authorRole);
+  assert.equal(identity.bioShort, FALLBACKS.authorBioShort);
+  assert.equal(identity.websiteUrl, FALLBACKS.websiteUrl);
+  assert.equal(identity.linkedinUrl, FALLBACKS.linkedinUrl);
+});
+
+test("article author identity treats blank CMS values as absent, not as present", () => {
+  // This is the `??` bug: every one of these fields would otherwise win as "".
+  const identity = resolveArticleAuthorIdentity(
+    {
+      slug: "jane-doe",
+      name: "   ",
+      jobTitle: "",
+      headline: "  ",
+      bioShort: "",
+    },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(identity.name, FALLBACKS.authorName);
+  assert.equal(identity.role, FALLBACKS.authorRole);
+  assert.equal(identity.bioShort, FALLBACKS.authorBioShort);
+});
+
+test("article author identity never lets a blank URL reach Person url or sameAs", () => {
+  // The most severe leak in #83: "" is invalid structured data, not just blank
+  // copy. The author route already guarded this; the article route did not.
+  const identity = resolveArticleAuthorIdentity(
+    { slug: "jane-doe", name: "Jane Doe", websiteUrl: "   ", linkedinUrl: "" },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(identity.websiteUrl, FALLBACKS.websiteUrl);
+  assert.equal(identity.linkedinUrl, FALLBACKS.linkedinUrl);
+  assert.notEqual(identity.websiteUrl, "");
+  assert.notEqual(identity.linkedinUrl, "");
+});
+
+test("article author identity rejects an unparseable URL instead of emitting it", () => {
+  const identity = resolveArticleAuthorIdentity(
+    { slug: "jane-doe", name: "Jane Doe", websiteUrl: "not a url", linkedinUrl: "javascript:alert(1)" },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(identity.websiteUrl, FALLBACKS.websiteUrl);
+  assert.equal(identity.linkedinUrl, FALLBACKS.linkedinUrl);
+});
+
+test("article author identity normalizes a canonical-origin URL the same way the author route does", () => {
+  // The two routes emitting different `url` values for the same Person is the
+  // inconsistency #83 calls out.
+  const article = resolveArticleAuthorIdentity(
+    { slug: "jane-doe", name: "Jane Doe", websiteUrl: "https://mehdi-zare.com/" },
+    FALLBACKS,
+    ORIGIN
+  );
+  const authorPage = resolveAuthorPageIdentity(
+    { slug: "jane-doe", name: "Jane Doe", websiteUrl: "https://mehdi-zare.com/" },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.equal(article.websiteUrl, authorPage.websiteUrl);
+  assert.equal(article.websiteUrl, "https://www.mehdi-zare.com");
+});
+
+test("article author identity produces initials-safe names", () => {
+  // authorName feeds buildInitials(); a blank name produced a blank avatar.
+  const identity = resolveArticleAuthorIdentity(
+    { slug: "jane-doe", name: "" },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.ok(identity.name.trim().length > 0);
+});
+
+// ---------------------------------------------------------------------------
+// authorIdentityFallbacks
+// ---------------------------------------------------------------------------
+
+test("authorIdentityFallbacks projects the Site Profile fields both routes need", () => {
+  // Both routes must derive their fallbacks the same way; deriving them inline
+  // is how the article route ended up reading siteProfile.author.websiteUrl
+  // without the normalization the author route applied.
+  const siteProfile = {
+    authorName: "Mehdi Zare, CFA",
+    authorRole: "Principal AI Engineer",
+    authorBioShort: "Principal AI engineer shipping production systems.",
+    author: {
+      websiteUrl: "https://www.mehdi-zare.com",
+      linkedinUrl: "https://linkedin.com/in/mehdizare",
+    },
+  };
+
+  assert.deepEqual(authorIdentityFallbacks(siteProfile), FALLBACKS);
+});

--- a/apps/web/tests/author-identity.test.ts
+++ b/apps/web/tests/author-identity.test.ts
@@ -123,14 +123,25 @@ test("author page identity falls back to the slug label rather than another auth
 });
 
 test("author page identity never emits a dangling title separator", () => {
-  const identity = resolveAuthorPageIdentity(
-    { slug: "jane-doe", name: "", jobTitle: "", headline: "" },
-    FALLBACKS,
+  // The slug and the authorRole fallback both have to be blank for a half to
+  // actually come out empty -- with either one filled, the separator can never
+  // dangle and this test cannot fail.
+  const bothBlank = resolveAuthorPageIdentity(
+    { slug: "", name: "", jobTitle: "", headline: "" },
+    { ...FALLBACKS, authorRole: "" },
     ORIGIN
   );
 
-  assert.doesNotMatch(identity.title, /\|\s*$/);
-  assert.doesNotMatch(identity.title, /^\s*\|/);
+  assert.equal(bothBlank.title, "");
+
+  const roleBlank = resolveAuthorPageIdentity(
+    { slug: "jane-doe", name: "Jane Doe", jobTitle: "", headline: "" },
+    { ...FALLBACKS, authorRole: "  " },
+    ORIGIN
+  );
+
+  assert.equal(roleBlank.title, "Jane Doe");
+  assert.doesNotMatch(roleBlank.title, /\|/);
 });
 
 test("author page identity normalizes identity URLs and rejects blank ones", () => {
@@ -201,9 +212,44 @@ test("article author identity treats blank CMS values as absent, not as present"
     ORIGIN
   );
 
-  assert.equal(identity.name, FALLBACKS.authorName);
+  // The name falls back to the slug label, not to the site owner: the route
+  // still links the byline to /author/jane-doe, so borrowing `authorName` here
+  // would name one person above a profile link to another.
+  assert.equal(identity.name, "Jane Doe");
   assert.equal(identity.role, FALLBACKS.authorRole);
   assert.equal(identity.bioShort, FALLBACKS.authorBioShort);
+});
+
+test("article author identity never borrows the site owner's name for a linked author", () => {
+  // #83's cross-route rule, from the article side. `/blog/[slug]` derives
+  // authorPath and BlogPosting.author.@id from the *relation's* slug, so a
+  // byline naming the owner over a link to /author/jane-doe attributes Jane's
+  // article to the owner in the structured data.
+  const article = resolveArticleAuthorIdentity(
+    { slug: "jane-doe", name: "   " },
+    FALLBACKS,
+    ORIGIN
+  );
+  const page = resolveAuthorPageIdentity(
+    { slug: "jane-doe", name: "   " },
+    FALLBACKS,
+    ORIGIN
+  );
+
+  assert.notEqual(article.name, FALLBACKS.authorName);
+  assert.equal(
+    article.name,
+    page.name,
+    "the two routes render the same Person, so they must resolve the same name"
+  );
+});
+
+test("article author identity still falls back to the site owner with no relation at all", () => {
+  // The other half of the rule: an article with no author relation *is* the
+  // owner's, and authorPath falls back to the owner's profile path with it.
+  const identity = resolveArticleAuthorIdentity(null, FALLBACKS, ORIGIN);
+
+  assert.equal(identity.name, FALLBACKS.authorName);
 });
 
 test("article author identity never lets a blank URL reach Person url or sameAs", () => {

--- a/apps/web/tests/blog-listing.test.ts
+++ b/apps/web/tests/blog-listing.test.ts
@@ -3,10 +3,12 @@ import assert from "node:assert/strict";
 import { DEFAULT_SITE_PROFILE } from "../src/lib/site-profile-defaults.ts";
 
 const { buildPageMetadata } = await import("../src/lib/seo.ts");
+// `formatSlugName` comes from the leaf module, not through blog-listing:
+// blog-listing reaches `server-only`, and there is one import path for it now.
+const { formatSlugName } = await import("../src/lib/strings.ts");
 const {
   buildTagListingDescription,
   buildCategoryListingDescription,
-  formatSlugName,
   resolveTaxonomyDisplayName,
   resolveTagListingCopy,
   resolveCategoryListingCopy,

--- a/apps/web/tests/blog-listing.test.ts
+++ b/apps/web/tests/blog-listing.test.ts
@@ -321,3 +321,47 @@ test("subcategory cards key seed children by slug when the CMS id is absent", ()
   assert.equal(zeroId.id, 0);
   assert.equal(seedChild.id, "evals");
 });
+
+// #90: the category `slug` attribute is a Strapi `uid` with `targetField: name`
+// and, unlike the author content type, it is *not* `required` — so an empty
+// slug is reachable from the CMS. It would otherwise produce a card linking to
+// `/blog/category/` (a dead path), an empty title from `formatSlugName("")`,
+// and an entry in `childSlugs` costing a pointless `getArticles` call on every
+// render of the parent page. The seed path already drops these in
+// `toCategorySeed`; this puts the same guarantee on the CMS path.
+test("subcategory cards drop a child whose slug is blank", () => {
+  const cards = resolveSubcategoryCards([
+    { id: 1, name: "Agents", slug: "agents" },
+    { id: 2, name: "No Slug", slug: "" },
+    { id: 3, name: "Whitespace Slug", slug: "   " },
+    { id: 4, name: "Evals", slug: "evals" },
+  ]);
+
+  assert.deepEqual(
+    cards.map((card) => card.slug),
+    ["agents", "evals"]
+  );
+});
+
+test("subcategory cards drop a child whose slug is missing entirely", () => {
+  // Strapi can return `null` for an unset uid; the declared type says `string`,
+  // so only a runtime guard catches it.
+  const cards = resolveSubcategoryCards([
+    { id: 1, name: "Agents", slug: "agents" },
+    { id: 2, name: "Null Slug", slug: null as unknown as string },
+    { id: 3, name: "Undefined Slug", slug: undefined as unknown as string },
+  ]);
+
+  assert.deepEqual(
+    cards.map((card) => card.slug),
+    ["agents"]
+  );
+});
+
+test("subcategory cards trim a slug they keep so the href has no stray space", () => {
+  const [card] = resolveSubcategoryCards([
+    { id: 1, name: "Agents", slug: "  agents  " },
+  ]);
+
+  assert.equal(card.slug, "agents");
+});

--- a/apps/web/tests/resolve-ts-hook.mjs
+++ b/apps/web/tests/resolve-ts-hook.mjs
@@ -1,3 +1,6 @@
+import { readFile } from "node:fs/promises";
+import ts from "typescript";
+
 const SRC_BASE = new URL("../src/", import.meta.url);
 const SERVER_ONLY_STUB = new URL("./server-only-stub.mjs", import.meta.url);
 const TAXONOMY_STUB = new URL("./taxonomy-stub.mjs", import.meta.url);
@@ -70,4 +73,32 @@ export async function resolve(specifier, context, nextResolve) {
     }
     throw error;
   }
+}
+
+// `--experimental-strip-types` erases type annotations but does not transform
+// JSX, so a `.tsx` import fails with ERR_UNKNOWN_FILE_EXTENSION. That is why
+// every component contract in this suite used to read source text instead of
+// rendering. This hook hands `.tsx` to the TypeScript compiler (already a
+// devDependency, already used by motion-visibility.test.ts) so components can
+// be rendered with `renderToStaticMarkup` and asserted on their actual output.
+//
+// Transpile-only: no type checking happens here. `pnpm typecheck` is what
+// checks types, and it runs over the same files.
+export async function load(url, context, nextLoad) {
+  if (!url.startsWith("file:") || !url.endsWith(".tsx")) {
+    return nextLoad(url, context);
+  }
+
+  const source = await readFile(new URL(url), "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    fileName: new URL(url).pathname,
+    compilerOptions: {
+      target: ts.ScriptTarget.ES2022,
+      module: ts.ModuleKind.ESNext,
+      jsx: ts.JsxEmit.ReactJSX,
+      verbatimModuleSyntax: false,
+    },
+  });
+
+  return { format: "module", source: outputText, shortCircuit: true };
 }

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -55,15 +55,55 @@ test("not-found generateMetadata call sites use buildNoIndexMetadata", () => {
 test("author metadata does not fall back to the homepage site description", () => {
   const pageSource = readSource("src/app/author/[slug]/page.tsx");
   assert.doesNotMatch(pageSource, /siteDescription/);
-  assert.match(pageSource, /authorListingDescription\(author\.name, author\.bioShort\)/);
-  assert.match(pageSource, /bioShort\?\.trim\(\)/);
-  assert.match(pageSource, /Articles by \$\{name\}\./);
+  assertCallsHelper(pageSource, "resolveAuthorPageIdentity", "#83, #94");
+  assertCallsHelper(pageSource, "authorIdentityFallbacks", "#83, #94");
+});
+
+test("author identity is not re-derived with the raw nullish chains it replaced", () => {
+  // #83. Each of these is a shape that shipped and leaked a blank CMS value:
+  // `??` past an empty jobTitle, and a template that left "Name | " behind.
+  const pageSource = readSource("src/app/author/[slug]/page.tsx");
+  assert.doesNotMatch(
+    pageSource,
+    /author\.jobTitle\s*\?\?/,
+    "author role must come from resolveAuthorPageIdentity, not a ?? chain (#83)"
+  );
+  assert.doesNotMatch(
+    pageSource,
+    /\$\{author\.name\}\s*\|/,
+    "author title must come from composeAuthorTitle, which drops the dangling separator (#83)"
+  );
+  assert.doesNotMatch(
+    pageSource,
+    /Articles by \$\{/,
+    "the articles-by sentence lives in buildAuthorListingDescription, which refuses a blank name (#83)"
+  );
 });
 
 test("article metadata does not fall back to the homepage site description", () => {
   const pageSource = readSource("src/app/blog/[slug]/page.tsx");
   assert.doesNotMatch(pageSource, /siteDescription/);
   assert.match(pageSource, /article\.excerpt\?\.trim\(\) \|\| article\.title/);
+});
+
+test("article author identity shares the author-route resolver", () => {
+  const pageSource = readSource("src/app/blog/[slug]/page.tsx");
+  assertCallsHelper(pageSource, "resolveArticleAuthorIdentity", "#83, #94");
+  assertCallsHelper(pageSource, "authorIdentityFallbacks", "#83, #94");
+});
+
+test("article author identity is not re-derived with the raw nullish chains it replaced", () => {
+  // Lines 164-165 of the old page let a blank websiteUrl / linkedinUrl reach
+  // Person `url` and `sameAs` as "" -- invalid structured data, and the exact
+  // inconsistency with the author route that #83 was filed for.
+  const pageSource = readSource("src/app/blog/[slug]/page.tsx");
+  for (const field of ["name", "jobTitle", "bioShort", "websiteUrl", "linkedinUrl"]) {
+    assert.doesNotMatch(
+      pageSource,
+      new RegExp(`articleAuthor\\?\\.${field}\\s*\\?\\?`),
+      `article ${field} must come from resolveArticleAuthorIdentity, not a ?? chain (#83)`
+    );
+  }
 });
 
 test("bina-print metadata does not fall back to the homepage site description", () => {

--- a/apps/web/tests/strings.test.ts
+++ b/apps/web/tests/strings.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { blankToUndefined, firstFilled } from "../src/lib/strings.ts";
+
+// One definition of "blank" for CMS-sourced copy (#89). Before this module the
+// rule was written out three times -- `firstFilled` in blog-listing.ts and a
+// `normalizeString` in each of site-profile.ts and taxonomy-seed.ts -- which is
+// how two /about surfaces ended up with neither.
+
+test("blankToUndefined treats an empty string as absent", () => {
+  assert.equal(blankToUndefined(""), undefined);
+});
+
+test("blankToUndefined treats a whitespace-only string as absent", () => {
+  // The defect the whole class turns on: `"   "` is truthy, so `{value && ...}`
+  // renders an empty element rather than nothing (#80, #89).
+  assert.equal(blankToUndefined("   "), undefined);
+  assert.equal(blankToUndefined("\n\t "), undefined);
+});
+
+test("blankToUndefined returns a filled string trimmed", () => {
+  assert.equal(blankToUndefined("  Miami, FL  "), "Miami, FL");
+});
+
+test("blankToUndefined treats null and undefined as absent", () => {
+  assert.equal(blankToUndefined(null), undefined);
+  assert.equal(blankToUndefined(undefined), undefined);
+});
+
+test("blankToUndefined treats non-string values as absent", () => {
+  // Strapi JSON fields are typed loosely enough that a number or object can
+  // reach a string slot; callers want `undefined`, not `"0"` or `"[object …]"`.
+  assert.equal(blankToUndefined(0), undefined);
+  assert.equal(blankToUndefined(42), undefined);
+  assert.equal(blankToUndefined({}), undefined);
+  assert.equal(blankToUndefined([]), undefined);
+  assert.equal(blankToUndefined(false), undefined);
+});
+
+test("firstFilled picks the first non-blank candidate", () => {
+  assert.equal(firstFilled("", "  ", "Principal AI Engineer"), "Principal AI Engineer");
+});
+
+test("firstFilled skips blank candidates rather than letting them win", () => {
+  // This is the `??` bug: nullish-coalescing stops at `""` because `""` is not
+  // nullish, so a blank CMS value beats a good fallback (#75/#77/#79/#83).
+  assert.equal(firstFilled("", "fallback"), "fallback");
+  assert.equal(firstFilled("   ", "fallback"), "fallback");
+});
+
+test("firstFilled trims the candidate it returns", () => {
+  assert.equal(firstFilled(null, "  spaced  "), "spaced");
+});
+
+test("firstFilled returns undefined when every candidate is blank", () => {
+  assert.equal(firstFilled(), undefined);
+  assert.equal(firstFilled("", "   ", null, undefined), undefined);
+});
+
+test("firstFilled keeps candidate order when several are filled", () => {
+  // Callers pass CMS value first and the Site Profile fallback last, so a
+  // reordering or a `findLast` rewrite must fail here.
+  assert.equal(firstFilled("cms", "fallback"), "cms");
+  assert.equal(firstFilled("jobTitle", "headline", "authorRole"), "jobTitle");
+});

--- a/apps/web/tests/url-normalization.test.ts
+++ b/apps/web/tests/url-normalization.test.ts
@@ -1,0 +1,79 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { identityUrlKey, normalizeIdentityUrl } from "../src/lib/url-normalization.ts";
+
+// `normalizeIdentityUrl` is the single gate every identity URL passes through:
+// an author's `websiteUrl` / `linkedinUrl`, their `sameAs` entries, and the
+// site-settings social links. Everything it returns is rendered into an `href`
+// (author page, article byline, footer) or into `Person` JSON-LD `url` /
+// `sameAs`. Anything it lets through is therefore live in the page.
+
+const ORIGIN = "https://www.mehdi-zare.com";
+
+test("normalizeIdentityUrl keeps an https URL", () => {
+  assert.equal(
+    normalizeIdentityUrl("https://linkedin.com/in/janedoe", ORIGIN),
+    "https://linkedin.com/in/janedoe"
+  );
+});
+
+test("normalizeIdentityUrl keeps an http URL", () => {
+  assert.equal(normalizeIdentityUrl("http://example.com/x", ORIGIN), "http://example.com/x");
+});
+
+test("normalizeIdentityUrl rejects a javascript: URL", () => {
+  // `new URL("javascript:alert(1)")` parses fine, so the parse-only guard let
+  // this through into an href. CMS-write-gated, but it is a script URL in a
+  // link, and invalid structured data in Person `url`.
+  assert.equal(normalizeIdentityUrl("javascript:alert(1)", ORIGIN), null);
+  assert.equal(normalizeIdentityUrl("  JavaScript:alert(1)  ", ORIGIN), null);
+});
+
+test("normalizeIdentityUrl rejects a data: URL", () => {
+  assert.equal(
+    normalizeIdentityUrl("data:text/html;base64,PHNjcmlwdD4=", ORIGIN),
+    null
+  );
+});
+
+test("normalizeIdentityUrl rejects other non-web schemes", () => {
+  assert.equal(normalizeIdentityUrl("mailto:someone@example.com", ORIGIN), null);
+  assert.equal(normalizeIdentityUrl("file:///etc/passwd", ORIGIN), null);
+  assert.equal(normalizeIdentityUrl("vbscript:msgbox(1)", ORIGIN), null);
+});
+
+test("normalizeIdentityUrl rejects blank and unparseable input", () => {
+  assert.equal(normalizeIdentityUrl("", ORIGIN), null);
+  assert.equal(normalizeIdentityUrl("   ", ORIGIN), null);
+  assert.equal(normalizeIdentityUrl(null, ORIGIN), null);
+  assert.equal(normalizeIdentityUrl(undefined, ORIGIN), null);
+  assert.equal(normalizeIdentityUrl("not a url", ORIGIN), null);
+});
+
+test("normalizeIdentityUrl canonicalizes the apex host onto the canonical origin", () => {
+  assert.equal(normalizeIdentityUrl("https://mehdi-zare.com/", ORIGIN), ORIGIN);
+});
+
+test("normalizeIdentityUrl strips a trailing slash from a path", () => {
+  assert.equal(
+    normalizeIdentityUrl("https://linkedin.com/in/janedoe/", ORIGIN),
+    "https://linkedin.com/in/janedoe"
+  );
+});
+
+test("identityUrlKey returns an empty key for a rejected URL", () => {
+  // dedupeUrls and dedupeSocialLinks skip empty keys, so a rejected scheme
+  // must not produce a key that could occupy a slot.
+  assert.equal(identityUrlKey("javascript:alert(1)", ORIGIN), "");
+  assert.equal(identityUrlKey("   ", ORIGIN), "");
+});
+
+test("identityUrlKey matches http and https forms of the same address", () => {
+  assert.equal(
+    identityUrlKey("https://example.com/a", ORIGIN) ===
+      identityUrlKey("http://example.com/a", ORIGIN),
+    false,
+    "protocol is part of the key today -- this pins the current behavior so a change is deliberate"
+  );
+});

--- a/apps/web/tests/url-normalization.test.ts
+++ b/apps/web/tests/url-normalization.test.ts
@@ -62,6 +62,21 @@ test("normalizeIdentityUrl strips a trailing slash from a path", () => {
   );
 });
 
+test("normalizeIdentityUrl strips embedded credentials", () => {
+  // `https://www.mehdi-zare.com@evil.example.com/` parses with hostname
+  // evil.example.com and the apex as *userinfo*, so the serialized href reads
+  // as one host and navigates to another. Nothing here should ever carry
+  // credentials anyway -- a password in a CMS field would be published.
+  assert.equal(
+    normalizeIdentityUrl("https://user:pass@example.com/a", ORIGIN),
+    "https://example.com/a"
+  );
+  assert.equal(
+    normalizeIdentityUrl("https://www.mehdi-zare.com@evil.example.com/", ORIGIN),
+    "https://evil.example.com"
+  );
+});
+
 test("identityUrlKey returns an empty key for a rejected URL", () => {
   // dedupeUrls and dedupeSocialLinks skip empty keys, so a rejected scheme
   // must not produce a key that could occupy a slot.
@@ -69,11 +84,21 @@ test("identityUrlKey returns an empty key for a rejected URL", () => {
   assert.equal(identityUrlKey("   ", ORIGIN), "");
 });
 
-test("identityUrlKey matches http and https forms of the same address", () => {
+test("identityUrlKey treats http and https forms as distinct addresses", () => {
+  // Protocol is part of the key, so dedupeUrls / dedupeSocialLinks keep both
+  // forms. This pins that as deliberate rather than accidental.
+  assert.notEqual(
+    identityUrlKey("https://example.com/a", ORIGIN),
+    identityUrlKey("http://example.com/a", ORIGIN)
+  );
+});
+
+test("identityUrlKey ignores embedded credentials when deduping", () => {
+  // The key is built from protocol + host + path, so a credentialed copy of a
+  // URL keys the same as the clean one -- it must not be able to take the
+  // dedupe slot and evict the canonical form.
   assert.equal(
-    identityUrlKey("https://example.com/a", ORIGIN) ===
-      identityUrlKey("http://example.com/a", ORIGIN),
-    false,
-    "protocol is part of the key today -- this pins the current behavior so a change is deliberate"
+    identityUrlKey("https://user:pass@example.com/a", ORIGIN),
+    identityUrlKey("https://example.com/a", ORIGIN)
   );
 });


### PR DESCRIPTION
Closes #83, closes #89, closes #90.

`??` treats a CMS empty string as *present*, so a field a content editor cleared beat its fallback and reached the page. `{value && <p>}` suppresses `""` but not `"   "`, so a field left with a space rendered an empty paragraph. Both are the same rule stated three different ways — which is why two `/about` surfaces had neither.

## One definition of blank

`firstFilled` (`blog-listing.ts`) and two copies of `normalizeString` (`site-profile.ts`, `taxonomy-seed.ts`) collapse into `src/lib/strings.ts`. `formatSlugName` moves there too: it is a pure string rule, and importing it from `blog-listing.ts` dragged in the Strapi client and `server-only`.

## #83 — author identity (P1)

`resolveAuthorPageIdentity` / `resolveArticleAuthorIdentity` in `src/lib/author-identity.ts` now serve both routes, so they cannot drift again.

- The article route previously skipped `normalizeIdentityUrl`, which the author route already applied — letting `""` reach Person `url` / `sameAs` as invalid structured data. This was the most severe leak in the issue.
- Titles compose through `composeAuthorTitle`, so a blank half no longer leaves `Name | `.
- The articles-by sentence refuses a blank name instead of rendering `Articles by .`.
- On `/author/[slug]` a blank name falls back to the **slug label**, not to `authorName` — borrowing the site owner's name would attribute another person's articles to them.

## #89 — /about (P2)

`CareerTimeline` and the education grid route descriptions through `blankToUndefined`. The education grid moved into `EducationList` so its output can be asserted directly.

Found while writing the test: a whitespace-only `field` also produced a dangling `MBA, ` heading. Fixed with it.

## #90 — blank subcategory slugs (P3)

The issue asked to confirm reachability first. **Answer: reachable.** The category `slug` attribute is a Strapi `uid` with `targetField: name` and is **not** `required` (the author content type's *is*), and the uid charset forbids spaces but permits empty. So `""` is reachable; `"   "` is not.

`resolveSubcategoryCards` now drops those children, matching what `toCategorySeed` already did on the seed path. They were rendering a card linking to `/blog/category/` under an empty title and adding a slug to `childSlugs`, costing a `getArticles` call that can never match.

## Also: identity URL scheme restriction

Not on the board. `normalizeIdentityUrl` parsed `javascript:` and `data:` URLs happily — `new URL()` accepts them — and everything it returns is rendered into an `href` (author page, article byline, footer) or into Person JSON-LD `url` / `sameAs`. It now accepts only http/https.

Reachable only with CMS write access, so low severity, but free to close and it was directly in the path of the #83 fix.

## Test harness change

`tests/resolve-ts-hook.mjs` now transpiles `.tsx` through the TypeScript compiler (already a devDependency, already used by `motion-visibility.test.ts`). `--experimental-strip-types` does not transform JSX, which is why every component contract in this suite read source text instead of rendering.

#89's acceptance asked for *behavioral tests, not source-text assertions* — this is what makes them possible. The `/about` tests render the real components and assert on the emitted HTML.

## Verification

- 265/265 web tests, 21/21 scripts tests
- `pnpm typecheck`, `pnpm lint`, `pnpm --filter=web build` all clean
- The five new source-text guards were each confirmed against a mutant that reintroduces the shape they pin (raw `??` chains, the dangling-separator template, the articles-by template, and import-only satisfaction of the shared resolver). All five killed; baseline restored green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Update — review pass

Six confirmed defects found reviewing this branch, all fixed in `963eb84`. Full write-up in the review comment below.

- `EducationList` left `degree`/`institution` unguarded, keeping the #89 empty-paragraph and dangling-comma bugs it was extracted to fix
- no page-side tripwire that /about still renders the extracted components
- `resolveArticleAuthorIdentity` borrowed the site owner's name for a linked author whose name was blank, while the byline still linked to that author's own profile — a behaviour change this PR introduced
- `normalizeIdentityUrl` kept embedded credentials, which also let a credentialed URL take the clean one's `identityUrlKey` dedupe slot
- the `formatSlugName` re-export from `blog-listing.ts` was dead and re-exposed the `server-only` chain the move existed to escape
- two tests could not fail

Follow-ups filed, not addressed here — #103 (two `CANONICAL_IDENTITY_ORIGIN` constants with different sources).

**Verification is now 273/273 web tests** (was 265/265), typecheck and lint clean, three mutants killed. The build is not runnable in a worktree (Turbopack rejects the symlinked `node_modules`); CI is green on it.