### PR TITLE
fix(web): retire three duplicated-identity defects and rename the employer

### DIFF
--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -15,7 +15,7 @@
     "seed": "npx tsx scripts/seed.ts",
     "upgrade": "npx @strapi/upgrade latest",
     "upgrade:dry": "npx @strapi/upgrade latest --dry",
-    "sync:location": "npx tsx scripts/sync-site-location.ts"
+    "sync:identity": "npx tsx scripts/sync-site-identity.ts"
   },
   "dependencies": {
     "@strapi/plugin-cloud": "5.52.2",

--- a/apps/cms/scripts/seed.ts
+++ b/apps/cms/scripts/seed.ts
@@ -469,14 +469,23 @@ if (!primaryAuthor) {
 // Content: HomePage (draftAndPublish: true)
 // ---------------------------------------------------------------------------
 
+// Derived from `siteSettings`, not restated (#101).
+//
+// The home page prefers this seeded `home-page` record over the Site Profile
+// fallback, and `buildHomeFallback` in apps/web/src/content/fallbacks/home.ts
+// already maps every one of these fields back to the same positioning copy --
+// so the two can never legitimately differ. Written out as literals they were
+// a fourth hand-maintained copy that nothing compared: rewording the
+// positioning copy in siteSettings and DEFAULT_SITE_PROFILE left this block
+// stale, and the next seed shipped a hero contradicting the site's own
+// structured data. Referencing the source makes that drift unrepresentable.
 const homePage = {
-  heroHeadline: "I take AI from prototype to production.",
-  heroSubheadline:
-    "Most AI projects stall between demo and deployment. I'm the engineer who gets them across that gap — because I learn your domain before I write a line of code.",
-  heroPrimaryCtaLabel: "Let's Talk",
-  heroPrimaryCtaHref: "/consulting#book",
-  heroSecondaryCtaLabel: "How I work",
-  heroSecondaryCtaHref: "/about",
+  heroHeadline: siteSettings.positioningHeadline,
+  heroSubheadline: siteSettings.positioningSubheadline,
+  heroPrimaryCtaLabel: siteSettings.primaryCtaLabel,
+  heroPrimaryCtaHref: siteSettings.primaryCtaHref,
+  heroSecondaryCtaLabel: siteSettings.secondaryCtaLabel,
+  heroSecondaryCtaHref: siteSettings.secondaryCtaHref,
 };
 
 // ---------------------------------------------------------------------------
@@ -485,8 +494,9 @@ const homePage = {
 
 const aboutPage = {
   title: "About Mehdi Zare",
-  positioningStatement:
-    "Most AI projects stall between demo and deployment. I'm the engineer who gets them across that gap — because I learn your domain before I write a line of code.",
+  // Same derivation as homePage above (#101): buildAboutFallback maps
+  // positioningStatement <- siteProfile.positioningSubheadline.
+  positioningStatement: siteSettings.positioningSubheadline,
   stats: [
     { value: "12+", label: "Years building software and AI systems" },
     { value: "10+", label: "AI systems shipped to production" },
@@ -507,11 +517,11 @@ const aboutPage = {
   experiences: [
     {
       title: "Principal AI Engineer / Cloud Architect",
-      company: "Sev1Tech",
+      company: "Entarian",
       startDate: "2025",
       current: true,
       description:
-        "Built GenAI systems for CISA cybersecurity operations, focused on production observability and threat-informed monitoring in federal environments where reliability is non-negotiable.",
+        "Built GenAI systems for federal cybersecurity operations, focused on production observability and threat-informed monitoring in federal environments where reliability is non-negotiable.",
     },
     {
       title: "Senior AI/ML Engineer",
@@ -587,8 +597,12 @@ const aboutPage = {
 
 const consultingPage = {
   title: "AI Consulting for High-Stakes Teams",
-  subtitle:
-    "Most AI projects stall between demo and deployment. I'm the engineer who gets them across that gap — because I learn your domain before I write a line of code.",
+  // Same derivation as homePage above (#101). This one is live-exposed:
+  // apps/web/src/app/consulting/page.tsx prefers `cmsData.subtitle` over the
+  // fallback, and it reaches both the visible lede and the page's JSON-LD
+  // description, so a stale literal here shipped wrong copy and wrong
+  // structured data together.
+  subtitle: siteSettings.positioningSubheadline,
   audiences: [
     {
       title: "Financial Services Teams",

--- a/apps/cms/scripts/sync-site-identity.ts
+++ b/apps/cms/scripts/sync-site-identity.ts
@@ -1,22 +1,29 @@
 /**
- * Pushes the repo's canonical site location into the two Strapi records that
+ * Pushes the repo's canonical site identity into the two Strapi records that
  * override it at runtime.
  *
- * Why this exists (#91): both location values are CMS-backed and the CMS wins.
+ * Why this exists (#91, #100): these values are CMS-backed and the CMS wins.
  *
  *   site-setting.locationLine        -> the footer
  *   author(mehdi-zare).address*      -> Person JSON-LD on /, /contact,
  *                                       /consulting and /author/[slug]
+ *   author(mehdi-zare).worksFor*     -> Person `worksFor` in the same markup
+ *
+ * Started life as `sync-site-location.ts` for the address alone. The employer
+ * fields turned out to need exactly the same treatment for exactly the same
+ * reason -- #100's Sev1Tech -> Entarian rename was invisible in production
+ * until the CMS author record was written, because `/author/[slug]` reads that
+ * record raw with no repo-side fallback at all. Renamed rather than duplicated.
  *
  * `seed.ts` would also fix them, but it is a full upsert: it rewrites
  * site-settings, the home/about/consulting pages, and every tag and category,
  * so any hand-edit made in the Strapi admin since the last seed is lost. This
- * sends exactly the four fields above and nothing else.
+ * sends exactly the fields above and nothing else.
  *
  * *Sends* -- not "changes". `author` has Draft & Publish enabled, and Strapi 5's
  * REST update writes the payload onto the DRAFT; `?status=published` then
  * publishes the whole draft row, not just the fields in the payload. So an
- * unrelated, deliberately-unpublished admin edit would go live with the address
+ * unrelated, deliberately-unpublished admin edit would go live with the identity
  * change. The script therefore reads the draft first and refuses to write when
  * it diverges from the published record outside the fields below (override with
  * `--allow-draft-publish`). `site-setting` has Draft & Publish disabled, so its
@@ -30,7 +37,7 @@
  * Usage (dry run -- prints the diff, writes nothing):
  *
  *   STRAPI_URL=https://cms.example.com STRAPI_API_TOKEN=<token> \
- *     npx tsx scripts/sync-site-location.ts
+ *     npx tsx scripts/sync-site-identity.ts
  *
  * Add `--apply` to write. Fields already correct are never sent.
  */
@@ -66,6 +73,8 @@ interface TaxonomyAuthor {
   addressLocality?: string;
   addressRegion?: string;
   addressCountry?: string;
+  worksForName?: string;
+  worksForUrl?: string;
 }
 
 interface StrapiEntity {
@@ -299,7 +308,14 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const { addressLocality, addressRegion, addressCountry } = primaryAuthor;
+  const {
+    addressLocality,
+    addressRegion,
+    addressCountry,
+    worksForName,
+    worksForUrl,
+  } = primaryAuthor;
+
   if (!addressLocality || !addressRegion || !addressCountry) {
     console.error(
       `data/taxonomy.json: author ${primaryAuthor.slug} is missing part of its address; refusing to write a partial one.`
@@ -307,7 +323,21 @@ async function main(): Promise<void> {
     process.exit(1);
   }
 
-  const desiredAuthor = { addressLocality, addressRegion, addressCountry };
+  // Same all-or-nothing rule as the address, for the same reason: `worksFor` is
+  // one Organization node, and half of one is worse than none.
+  if (!worksForName !== !worksForUrl) {
+    console.error(
+      `data/taxonomy.json: author ${primaryAuthor.slug} has only one of worksForName/worksForUrl; refusing to write a partial employer.`
+    );
+    process.exit(1);
+  }
+
+  const desiredAuthor: Record<string, string> = {
+    addressLocality,
+    addressRegion,
+    addressCountry,
+    ...(worksForName && worksForUrl ? { worksForName, worksForUrl } : {}),
+  };
   const desiredSettings = { locationLine: `${addressLocality}, ${addressRegion}` };
 
   console.log(`Strapi: ${STRAPI_URL}`);

--- a/apps/web/src/components/home/TrackRecord.tsx
+++ b/apps/web/src/components/home/TrackRecord.tsx
@@ -16,12 +16,12 @@ interface TrackRecordEntry {
 
 const entries: TrackRecordEntry[] = [
   {
-    org: "Sev1Tech",
-    monogram: "S1",
+    org: "Entarian",
+    monogram: "EN",
     role: "Principal AI Engineer / Cloud Architect",
     dates: "2025 – Present",
     description:
-      "Built GenAI systems for CISA cybersecurity operations, focused on production observability and threat-informed monitoring in federal environments where reliability is non-negotiable.",
+      "Built GenAI systems for federal cybersecurity operations, focused on production observability and threat-informed monitoring in federal environments where reliability is non-negotiable.",
     category: "Cybersecurity",
     categoryColor: "bg-red-500/10 text-red-700",
     current: true,

--- a/apps/web/src/content/fallbacks/about.ts
+++ b/apps/web/src/content/fallbacks/about.ts
@@ -41,11 +41,11 @@ export const fallbackExperiences: Experience[] = [
   {
     id: 1,
     title: "Principal AI Engineer / Cloud Architect",
-    company: "Sev1Tech",
+    company: "Entarian",
     startDate: "2025",
     current: true,
     description:
-      "Built GenAI systems for CISA cybersecurity operations, focused on production observability and threat-informed monitoring in federal environments where reliability is non-negotiable.",
+      "Built GenAI systems for federal cybersecurity operations, focused on production observability and threat-informed monitoring in federal environments where reliability is non-negotiable.",
   },
   {
     id: 2,

--- a/apps/web/src/lib/author-identity.ts
+++ b/apps/web/src/lib/author-identity.ts
@@ -1,4 +1,3 @@
-import { getSiteUrl } from "@/lib/seo";
 import { blankToUndefined, firstFilled, formatSlugName } from "@/lib/strings";
 import { normalizeIdentityUrl } from "@/lib/url-normalization";
 
@@ -19,12 +18,18 @@ import { normalizeIdentityUrl } from "@/lib/url-normalization";
  */
 
 /**
- * The origin identity URLs are canonicalized against. Exported so
+ * The origin identity URLs are canonicalized against. Re-exported so
  * `/author/[slug]` and `/blog/[slug]` cannot pick different ones -- the two
  * routes emitting different `url` values for the same Person is the drift #83
  * calls out.
+ *
+ * Defined in `site-profile-defaults` rather than here: this constant used to be
+ * `getSiteUrl()` while `site-profile.ts` had a second one of the same name
+ * bound to `DEFAULT_SITE_PROFILE.authorWebsiteUrl`, so the guarantee in the
+ * paragraph above held only for these two routes and not against the Person the
+ * root layout emits alongside them (#103).
  */
-export const CANONICAL_IDENTITY_ORIGIN = getSiteUrl();
+export { CANONICAL_IDENTITY_ORIGIN } from "@/lib/site-profile-defaults";
 
 const TITLE_SEPARATOR = " | ";
 
@@ -218,6 +223,20 @@ export interface AuthorAddress {
  * be a worse error than omitting it, so a non-owner gets only their own values.
  * `isPrimary` is optional on the CMS record, so a slug match against the
  * resolved site owner is accepted as the same signal.
+ *
+ * The address is resolved as **one unit**, not field by field (#102). A record
+ * that supplies any of the three supplies all of it; only a record with no
+ * address at all inherits the owner's. Merging per field published a Person at
+ * an address that never existed: clearing `addressRegion` while setting
+ * `addressLocality` to `Berlin` -- the ordinary shape of an international move,
+ * where there is no state to name -- emitted `Berlin, FL, DE`. Google reads
+ * `PostalAddress` as a single unit, and because every property on it is
+ * optional free text, no validator flags the result. It is wrong in a way
+ * nothing reports.
+ *
+ * Failing toward an incomplete address rather than a confidently wrong one is
+ * the same rule `apps/cms/scripts/sync-site-location.ts` already applies when
+ * it refuses to write a partial address.
  */
 export function resolveAuthorAddress(
   source: {
@@ -238,15 +257,23 @@ export function resolveAuthorAddress(
     source.isPrimary === true ||
     blankToUndefined(source.slug) === blankToUndefined(siteOwner.slug);
 
-  const resolve = (
-    own: string | null | undefined,
-    fallback: string | undefined
-  ): string | undefined =>
-    isSiteOwner ? firstFilled(own, fallback) : blankToUndefined(own);
+  const own: AuthorAddress = {
+    addressLocality: blankToUndefined(source.addressLocality),
+    addressRegion: blankToUndefined(source.addressRegion),
+    addressCountry: blankToUndefined(source.addressCountry),
+  };
+
+  const suppliesAnyAddress = Boolean(
+    firstFilled(own.addressLocality, own.addressRegion, own.addressCountry)
+  );
+
+  if (!isSiteOwner || suppliesAnyAddress) {
+    return own;
+  }
 
   return {
-    addressLocality: resolve(source.addressLocality, siteOwner.addressLocality),
-    addressRegion: resolve(source.addressRegion, siteOwner.addressRegion),
-    addressCountry: resolve(source.addressCountry, siteOwner.addressCountry),
+    addressLocality: siteOwner.addressLocality,
+    addressRegion: siteOwner.addressRegion,
+    addressCountry: siteOwner.addressCountry,
   };
 }

--- a/apps/web/src/lib/author-identity.ts
+++ b/apps/web/src/lib/author-identity.ts
@@ -235,7 +235,7 @@ export interface AuthorAddress {
  * nothing reports.
  *
  * Failing toward an incomplete address rather than a confidently wrong one is
- * the same rule `apps/cms/scripts/sync-site-location.ts` already applies when
+ * the same rule `apps/cms/scripts/sync-site-identity.ts` already applies when
  * it refuses to write a partial address.
  */
 export function resolveAuthorAddress(

--- a/apps/web/src/lib/site-profile-defaults.ts
+++ b/apps/web/src/lib/site-profile-defaults.ts
@@ -39,8 +39,8 @@ export const DEFAULT_SITE_PROFILE = {
   authorAddressLocality: "Miami",
   authorAddressRegion: "FL",
   authorAddressCountry: "US",
-  authorWorksForName: "Sev1Tech",
-  authorWorksForUrl: "https://sev1tech.com",
+  authorWorksForName: "Entarian",
+  authorWorksForUrl: "https://entarian.com",
   authorAlumniOf: [
     "University of Maryland, Smith School of Business",
     "University of Tehran",
@@ -59,3 +59,23 @@ export const DEFAULT_SITE_PROFILE = {
 } as const;
 
 export type DefaultSiteProfile = typeof DEFAULT_SITE_PROFILE;
+
+/**
+ * The one origin every Person surface canonicalizes identity URLs against.
+ *
+ * Declared here, in the leaf both `site-profile.ts` and `author-identity.ts`
+ * already import, because it previously existed twice under this exact name
+ * with two different sources (#103): `getSiteUrl()` in `author-identity.ts`
+ * and `DEFAULT_SITE_PROFILE.authorWebsiteUrl` here. The same Person was
+ * therefore canonicalized against a different origin depending on which
+ * surface rendered them -- and since the root layout emits its Person on
+ * *every* route, `/author/[slug]` and `/blog/[slug]` consumed both at once.
+ *
+ * Pinned to `authorWebsiteUrl` rather than to `NEXT_PUBLIC_SITE_URL` on
+ * purpose. This value is triple-guarded -- `site-identity-consistency.test.ts`
+ * compares it across `data/taxonomy.json`, the seed and these defaults --
+ * whereas the env var is guarded by nothing and is the *deployment* origin. On
+ * a preview deployment the two differ, which would stop the apex/www folding in
+ * `normalizeIdentityUrl` from recognising the site's own links.
+ */
+export const CANONICAL_IDENTITY_ORIGIN = DEFAULT_SITE_PROFILE.authorWebsiteUrl;

--- a/apps/web/src/lib/site-profile.ts
+++ b/apps/web/src/lib/site-profile.ts
@@ -1,4 +1,5 @@
 import {
+  CANONICAL_IDENTITY_ORIGIN,
   DEFAULT_SITE_PROFILE,
   DEFAULT_NAV_ITEMS,
   DEFAULT_SOCIAL_LINKS,
@@ -7,6 +8,7 @@ import { identityUrlKey, normalizeIdentityUrl } from "./url-normalization";
 import { isBinaPrintEnabled } from "./feature-flags";
 import { serverEnv } from "./server-env";
 import { blankToUndefined } from "./strings";
+import { resolveAuthorAddress } from "./author-identity";
 import type {
   Author,
   Credential,
@@ -16,8 +18,6 @@ import type {
   SocialLink,
   StrapiImage,
 } from "../types/strapi";
-
-const CANONICAL_IDENTITY_ORIGIN = DEFAULT_SITE_PROFILE.authorWebsiteUrl;
 
 const REQUIRED_SITE_PROFILE_FIELDS = [
   "siteName",
@@ -325,12 +325,21 @@ function buildAuthorProfile(
     alumniOf: alumniOf.length > 0 ? alumniOf : [...DEFAULT_SITE_PROFILE.authorAlumniOf],
     knowsAbout: knowsAbout.length > 0 ? knowsAbout : [...DEFAULT_SITE_PROFILE.knowsAbout],
     credentials: normalizeCredentials(author?.credentials),
-    addressLocality:
-      blankToUndefined(author?.addressLocality) ?? DEFAULT_SITE_PROFILE.authorAddressLocality,
-    addressRegion:
-      blankToUndefined(author?.addressRegion) ?? DEFAULT_SITE_PROFILE.authorAddressRegion,
-    addressCountry:
-      blankToUndefined(author?.addressCountry) ?? DEFAULT_SITE_PROFILE.authorAddressCountry,
+    // Delegated rather than repeated (#102). This resolved the three fields
+    // independently, each with its own `?? DEFAULT_SITE_PROFILE` fallback, so a
+    // record filling only some of them inherited the rest and published a
+    // mixed address -- `Berlin, FL, DE` from a single cleared field. Sharing
+    // the resolver with `/author/[slug]` is also what stops the two from
+    // drifting apart again, which is the whole point of #92 and #98.
+    ...resolveAuthorAddress(
+      { ...author, slug },
+      {
+        slug,
+        addressLocality: DEFAULT_SITE_PROFILE.authorAddressLocality,
+        addressRegion: DEFAULT_SITE_PROFILE.authorAddressRegion,
+        addressCountry: DEFAULT_SITE_PROFILE.authorAddressCountry,
+      }
+    ),
   };
 }
 

--- a/apps/web/tests/about-blank-descriptions.test.ts
+++ b/apps/web/tests/about-blank-descriptions.test.ts
@@ -22,7 +22,7 @@ function baseExperience(overrides: Partial<Experience> = {}): Experience {
   return {
     id: 1,
     title: "Principal AI Engineer",
-    company: "Sev1Tech",
+    company: "Entarian",
     startDate: "2023-01-01",
     current: true,
     ...overrides,

--- a/apps/web/tests/author-identity.test.ts
+++ b/apps/web/tests/author-identity.test.ts
@@ -402,7 +402,13 @@ test("author address keeps a guest author's own address untouched", () => {
 
 test("author address prefers the author's own values over the fallback", () => {
   const address = resolveAuthorAddress(
-    { slug: "mehdi-zare", isPrimary: true, addressLocality: "Austin", addressRegion: "TX" },
+    {
+      slug: "mehdi-zare",
+      isPrimary: true,
+      addressLocality: "Austin",
+      addressRegion: "TX",
+      addressCountry: "US",
+    },
     SITE_OWNER
   );
 
@@ -437,16 +443,15 @@ test("author address trims the values it returns", () => {
   assert.equal(address.addressLocality, "Berlin");
 });
 
-test("author address falls back field by field for the site owner (see #102)", () => {
-  // Pins today's behavior rather than endorsing it. The three components are
-  // resolved independently, so a site-owner record that fills some of them
-  // inherits the rest -- "Berlin, FL" is reachable from a half-finished edit in
-  // the Strapi admin.
+test("a partial site-owner address is emitted as-is, never merged with the fallback (#102)", () => {
+  // The regression this replaces: the three components used to resolve
+  // independently, so an owner record filling some of them inherited the rest
+  // and published "Berlin, FL, DE" -- a person in a state they do not live in.
+  // Google reads PostalAddress as one unit, and since every property on it is
+  // optional free text, no validator flags that. It was wrong silently.
   //
-  // Deliberately NOT changed here: `buildAuthorProfile` in site-profile.ts
-  // merges the same way for the other three Person surfaces, so fixing only
-  // this one would make /author/[slug] a fourth variant and re-open the very
-  // drift #92 closed. #102 tracks fixing both together.
+  // The shape below is the realistic trigger, not a contrived one: relocating
+  // abroad and clearing addressRegion because there is no state to name.
   const address = resolveAuthorAddress(
     {
       slug: "mehdi-zare",
@@ -458,7 +463,42 @@ test("author address falls back field by field for the site owner (see #102)", (
     SITE_OWNER
   );
 
-  assert.equal(address.addressLocality, "Berlin");
-  assert.equal(address.addressRegion, SITE_OWNER.addressRegion);
-  assert.equal(address.addressCountry, "DE");
+  assert.deepEqual(address, {
+    addressLocality: "Berlin",
+    addressRegion: undefined,
+    addressCountry: "DE",
+  });
+  assert.notEqual(
+    address.addressRegion,
+    SITE_OWNER.addressRegion,
+    "the owner's region must not leak into an address the CMS record already speaks for"
+  );
+});
+
+test("the site owner inherits the full fallback only with no address at all (#102)", () => {
+  // The other half of all-or-nothing: inheriting is still right when the record
+  // says nothing, which is what keeps /author/[slug] consistent with the Person
+  // the root layout emits (#92).
+  const blank = resolveAuthorAddress(
+    { slug: "mehdi-zare", isPrimary: true },
+    SITE_OWNER
+  );
+
+  assert.deepEqual(blank, {
+    addressLocality: SITE_OWNER.addressLocality,
+    addressRegion: SITE_OWNER.addressRegion,
+    addressCountry: SITE_OWNER.addressCountry,
+  });
+
+  // A single filled field is enough to make the record speak for itself.
+  const countryOnly = resolveAuthorAddress(
+    { slug: "mehdi-zare", isPrimary: true, addressCountry: "DE" },
+    SITE_OWNER
+  );
+
+  assert.deepEqual(countryOnly, {
+    addressLocality: undefined,
+    addressRegion: undefined,
+    addressCountry: "DE",
+  });
 });

--- a/apps/web/tests/site-identity-consistency.test.ts
+++ b/apps/web/tests/site-identity-consistency.test.ts
@@ -29,6 +29,15 @@ import {
 // a field added to two sources is covered the day it is added. A key that
 // genuinely lives in only one source has to be named in an exemption list
 // below, with a reason -- that is the only way to opt out.
+//
+// Three is the whole list because the seed's other page literals no longer
+// restate this copy (#101): `homePage`, `aboutPage.positioningStatement` and
+// `consultingPage.subtitle` now read from `siteSettings` instead of repeating
+// it. Do not re-inline them -- they were a fourth and fifth copy that nothing
+// here compared, and `consultingPage.subtitle` in particular is preferred over
+// the fallback at runtime, so a stale literal shipped wrong page copy and wrong
+// JSON-LD together. Only `siteSettings` is read below, and it must stay a flat
+// block of literals for that reader to work.
 
 const repoRoot = resolve(process.cwd(), "../..");
 

--- a/apps/web/tests/site-profile-social-normalization.test.ts
+++ b/apps/web/tests/site-profile-social-normalization.test.ts
@@ -2,6 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const { normalizeSiteProfile } = await import("../src/lib/site-profile.ts");
+const { resolveAuthorAddress } = await import("../src/lib/author-identity.ts");
+const { DEFAULT_SITE_PROFILE } = await import("../src/lib/site-profile-defaults.ts");
 
 const canonicalAuthor = {
   id: 1,
@@ -69,4 +71,59 @@ test("site profile prefers a CMS author address over the geo fallback", () => {
 
   assert.equal(profile.author.addressLocality, "Austin");
   assert.equal(profile.author.addressRegion, "TX");
+});
+
+// #102. The three Person surfaces fed by `resolveSiteProfile` -- the root
+// layout, /contact and /consulting -- used to merge the address field by field
+// here, independently of the rule /author/[slug] applies. That is how the two
+// drifted before (#92), and it is why this assertion lives on the site-profile
+// side rather than only on the resolver: without it, `buildAuthorProfile` can
+// quietly stop delegating and nothing fails.
+test("a partial CMS address is not completed from the geo fallback (#102)", () => {
+  const profile = normalizeSiteProfile(undefined, {
+    author: {
+      ...canonicalAuthor,
+      addressLocality: "Berlin",
+      addressRegion: "",
+      addressCountry: "DE",
+    },
+  });
+
+  assert.equal(profile.author.addressLocality, "Berlin");
+  assert.equal(
+    profile.author.addressRegion,
+    undefined,
+    'the "Berlin, FL" merge is back: a CMS record that speaks for its own address must not inherit the default region'
+  );
+  assert.equal(profile.author.addressCountry, "DE");
+});
+
+test("the site profile and /author/[slug] resolve the same address (#102)", () => {
+  // The two copies agreeing is the actual invariant. Comparing them directly
+  // means a change to either one that does not change the other fails here,
+  // which no per-surface assertion can catch.
+  const author = {
+    ...canonicalAuthor,
+    addressLocality: "Berlin",
+    addressRegion: "",
+    addressCountry: "DE",
+  };
+
+  const profile = normalizeSiteProfile(undefined, { author });
+  const routeAddress = resolveAuthorAddress(author, {
+    slug: DEFAULT_SITE_PROFILE.authorSlug,
+    addressLocality: DEFAULT_SITE_PROFILE.authorAddressLocality,
+    addressRegion: DEFAULT_SITE_PROFILE.authorAddressRegion,
+    addressCountry: DEFAULT_SITE_PROFILE.authorAddressCountry,
+  });
+
+  assert.deepEqual(
+    {
+      addressLocality: profile.author.addressLocality,
+      addressRegion: profile.author.addressRegion,
+      addressCountry: profile.author.addressCountry,
+    },
+    routeAddress,
+    "the Person on / , /contact and /consulting disagrees with the Person on /author/[slug] -- the #92 drift is back"
+  );
 });

--- a/data/taxonomy.json
+++ b/data/taxonomy.json
@@ -21,8 +21,8 @@
         { "platform": "Seeking Alpha", "url": "https://seekingalpha.com/author/mehdi-zare" }
       ],
       "jobTitle": "Principal AI Engineer",
-      "worksForName": "Sev1Tech",
-      "worksForUrl": "https://sev1tech.com",
+      "worksForName": "Entarian",
+      "worksForUrl": "https://entarian.com",
       "alumniOf": [
         "University of Maryland, Smith School of Business",
         "University of Tehran"


### PR DESCRIPTION
Board hygiene round: four issues, one theme — a value that exists in more than one place, where the copies can disagree and nothing says so.

## #100 — Sev1Tech is now Entarian

Not a strip, a stale fact: Entarian is the post-acquisition rebrand of Sev1Tech. Renamed in place across the four repo copies (`data/taxonomy.json`, `DEFAULT_SITE_PROFILE`, the homepage `TrackRecord` card, the `/about` fallback timeline) and the client agency is now generic — "federal cybersecurity operations" rather than CISA.

Worth recording, because the issue was written against a mistaken premise: **`/consulting` and `/ai-engineer` carried zero human-visible occurrences.** I byte-classified the live HTML by whether each hit fell inside a `<script>` — every one on those two routes was the site-wide Person `worksFor` in JSON-LD. `Entarian`, `DHS` and any Homeland-Security spelling had **zero** hits anywhere in the repo or any served page. So the visible-copy half of that ticket was already satisfied, and the real remaining work was the structured data plus a CMS write.

## #101 — three more unguarded copies of the positioning copy

The issue reported one (`homePage`). There were three: `homePage`, `aboutPage.positioningStatement`, and `consultingPage.subtitle`. All now read from `siteSettings`.

`consultingPage.subtitle` is the one that mattered — `consulting/page.tsx` prefers the CMS value over the fallback, so a stale literal shipped wrong visible copy and a wrong JSON-LD description together. (`aboutPage` is pinned to its fallback at the route, so it was latent.)

Verified value-identical before and after by resolving both ASTs and diffing every key: the seeded records do not change.

## #102 — `PostalAddress` merged field by field

Each of locality/region/country resolved independently with its own fallback, so an owner record filling some inherited the rest. Clearing `addressRegion` while setting `addressLocality` to `Berlin` — the ordinary shape of moving abroad, where there is no state to name — published **`Berlin, FL, DE`**. Every `PostalAddress` property is optional free text, so nothing flags it.

Now resolved as one unit, and `site-profile.ts` delegates to the same resolver `/author/[slug]` uses instead of keeping a second copy of the rule.

## #103 — two `CANONICAL_IDENTITY_ORIGIN` constants

Different sources, in the modules that exist to prevent that. Collapsed to one declaration in the leaf both already import.

Pinned to `authorWebsiteUrl`, not `NEXT_PUBLIC_SITE_URL`. That literal is compared across three sources by an existing test; the env var is guarded by nothing, is unset in every Vercel environment today, and is the *deployment* origin — on a preview host it would stop the apex/www folding from recognising the site's own links.

## Tooling

`sync-site-location.ts` → `sync-site-identity.ts`. The employer fields need the same targeted, dry-run-by-default, draft-safe write the address already had, for the same reason: `/author/[slug]` reads the CMS author raw with no repo-side fallback. Generalised rather than cloned.

## On the guards

The `site-profile.ts` side of the address rule had **no test at all** — a mutation making `buildAuthorProfile` stop delegating passed the entire suite. That is how this drift class kept reopening. Added a partial-address assertion and a direct equality check between the two resolvers; the same mutation now fails two tests.

Every new guard was mutation-verified red before green.

## Verification

- 316 tests pass (295 web, 21 shared)
- `pnpm typecheck` 3/3, `pnpm --filter=web lint`, production build all clean
- Seed de-duplication proven value-preserving by AST diff

## Post-merge (P0)

Run `pnpm --filter cms sync:identity --apply` against production Strapi so CMS-backed author records pick up Entarian + address. Code deploy alone does not update Strapi.

## Follow-ups (scoped out)

- **P1** #106 — atomic `resolveAuthorWorksFor` (same unit semantics as #102 address fix)
- **P2** #105 — source TrackRecord / experience `company` from `authorWorksForName`

Closes #100
Closes #101
Closes #102
Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)