### PR TITLE
fix(web): unify worksFor/alumniOf resolution and current-employer copies

### DIFF
--- a/apps/cms/scripts/seed.ts
+++ b/apps/cms/scripts/seed.ts
@@ -517,7 +517,7 @@ const aboutPage = {
   experiences: [
     {
       title: "Principal AI Engineer / Cloud Architect",
-      company: "Entarian",
+      company: primaryAuthor.worksForName as string,
       startDate: "2025",
       current: true,
       description:

--- a/apps/web/src/app/author/[slug]/page.tsx
+++ b/apps/web/src/app/author/[slug]/page.tsx
@@ -21,7 +21,9 @@ import {
   CANONICAL_IDENTITY_ORIGIN,
   authorIdentityFallbacks,
   resolveAuthorAddress,
+  resolveAuthorAlumniOf,
   resolveAuthorPageIdentity,
+  resolveAuthorWorksFor,
 } from "@/lib/author-identity";
 
 interface AuthorPageProps {
@@ -159,6 +161,8 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
   // only -- inventing an address for a guest author would be worse than
   // omitting it.
   const address = resolveAuthorAddress(author, siteProfile.author);
+  const worksFor = resolveAuthorWorksFor(author, siteProfile.author);
+  const { alumniOf } = resolveAuthorAlumniOf(author, siteProfile.author);
   const sameAs = dedupeUrls([
     websiteUrl,
     linkedinUrl,
@@ -186,9 +190,9 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
           description,
           url: websiteUrl,
           imageUrl: toAbsoluteMediaUrl(author.profileImage?.url),
-          worksForName: author.worksForName,
-          worksForUrl: author.worksForUrl,
-          alumniOf: author.alumniOf,
+          worksForName: worksFor.worksForName,
+          worksForUrl: worksFor.worksForUrl,
+          alumniOf,
           credentials:
             author.credentials?.map((credential) => ({
               name: credential.title,

--- a/apps/web/src/components/home/TrackRecord.tsx
+++ b/apps/web/src/components/home/TrackRecord.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { Label } from "@/components/shared/Label";
+import { DEFAULT_SITE_PROFILE } from "@/lib/site-profile-defaults";
 
 interface TrackRecordEntry {
   org: string;
@@ -16,7 +17,7 @@ interface TrackRecordEntry {
 
 const entries: TrackRecordEntry[] = [
   {
-    org: "Entarian",
+    org: DEFAULT_SITE_PROFILE.authorWorksForName,
     monogram: "EN",
     role: "Principal AI Engineer / Cloud Architect",
     dates: "2025 – Present",

--- a/apps/web/src/content/fallbacks/about.ts
+++ b/apps/web/src/content/fallbacks/about.ts
@@ -7,6 +7,7 @@ import type {
   BlocksContent,
 } from "@/types/strapi";
 import type { SiteProfile } from "@/lib/site-profile";
+import { DEFAULT_SITE_PROFILE } from "@/lib/site-profile-defaults";
 
 function buildCanonicalAboutStory(): string[] {
   return [
@@ -41,7 +42,7 @@ export const fallbackExperiences: Experience[] = [
   {
     id: 1,
     title: "Principal AI Engineer / Cloud Architect",
-    company: "Entarian",
+    company: DEFAULT_SITE_PROFILE.authorWorksForName,
     startDate: "2025",
     current: true,
     description:

--- a/apps/web/src/lib/author-identity.ts
+++ b/apps/web/src/lib/author-identity.ts
@@ -277,3 +277,99 @@ export function resolveAuthorAddress(
     addressCountry: siteOwner.addressCountry,
   };
 }
+
+/** The two Organization fields the Person JSON-LD `worksFor` node carries. */
+export interface AuthorWorksFor {
+  worksForName?: string;
+  worksForUrl?: string;
+}
+
+/**
+ * Resolves the employer for `/author/[slug]`'s `Person` JSON-LD (#106).
+ *
+ * Same unit semantics as {@link resolveAuthorAddress}: `worksFor` is one
+ * Organization node, and merging name and url independently published mixed
+ * employers -- `Entarian` with another org's careers URL, or the inverse.
+ * A record that supplies either field supplies both as-is; only a record with
+ * neither inherits the site owner's pair.
+ *
+ * The fallback is scoped to the **site owner** for the same reason as address:
+ * stamping the owner's employer onto a guest author's Person would be worse
+ * than omitting it.
+ */
+export function resolveAuthorWorksFor(
+  source: {
+    slug?: string | null;
+    isPrimary?: boolean;
+    worksForName?: string | null;
+    worksForUrl?: string | null;
+  },
+  siteOwner: {
+    slug: string;
+    worksForName?: string;
+    worksForUrl?: string;
+  }
+): AuthorWorksFor {
+  const isSiteOwner =
+    source.isPrimary === true ||
+    blankToUndefined(source.slug) === blankToUndefined(siteOwner.slug);
+
+  const own: AuthorWorksFor = {
+    worksForName: blankToUndefined(source.worksForName),
+    worksForUrl: blankToUndefined(source.worksForUrl),
+  };
+
+  const suppliesAnyWorksFor = Boolean(firstFilled(own.worksForName, own.worksForUrl));
+
+  if (!isSiteOwner || suppliesAnyWorksFor) {
+    return own;
+  }
+
+  return {
+    worksForName: siteOwner.worksForName,
+    worksForUrl: siteOwner.worksForUrl,
+  };
+}
+
+function normalizeStringArray(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .map((item) => blankToUndefined(item))
+    .filter((item): item is string => Boolean(item));
+}
+
+/**
+ * Resolves `alumniOf` for `/author/[slug]`'s `Person` JSON-LD (#106).
+ *
+ * Arrays do not merge field-by-field like address or worksFor, but the author
+ * page still read the raw CMS record while the root layout fell back to
+ * `DEFAULT_SITE_PROFILE` -- the same NAP inconsistency #92 fixed for address.
+ * The site owner inherits the default list only when the CMS record carries
+ * none; guest authors never borrow the owner's alumni list.
+ */
+export function resolveAuthorAlumniOf(
+  source: {
+    slug?: string | null;
+    isPrimary?: boolean;
+    alumniOf?: string[] | null;
+  },
+  siteOwner: {
+    slug: string;
+    alumniOf: readonly string[];
+  }
+): { alumniOf: string[] } {
+  const isSiteOwner =
+    source.isPrimary === true ||
+    blankToUndefined(source.slug) === blankToUndefined(siteOwner.slug);
+
+  const own = normalizeStringArray(source.alumniOf);
+
+  if (!isSiteOwner || own.length > 0) {
+    return { alumniOf: own };
+  }
+
+  return { alumniOf: [...siteOwner.alumniOf] };
+}

--- a/apps/web/src/lib/site-profile.ts
+++ b/apps/web/src/lib/site-profile.ts
@@ -8,7 +8,11 @@ import { identityUrlKey, normalizeIdentityUrl } from "./url-normalization";
 import { isBinaPrintEnabled } from "./feature-flags";
 import { serverEnv } from "./server-env";
 import { blankToUndefined } from "./strings";
-import { resolveAuthorAddress } from "./author-identity";
+import {
+  resolveAuthorAddress,
+  resolveAuthorAlumniOf,
+  resolveAuthorWorksFor,
+} from "./author-identity";
 import type {
   Author,
   Credential,
@@ -299,7 +303,6 @@ function buildAuthorProfile(
     DEFAULT_SITE_PROFILE.authorLinkedinUrl;
 
   const knowsAbout = normalizeStringArray(author?.knowsAbout);
-  const alumniOf = normalizeStringArray(author?.alumniOf);
 
   return {
     id: author?.id,
@@ -318,11 +321,21 @@ function buildAuthorProfile(
     sameAs: canonicalSocialLinks,
     profileImage: author?.profileImage,
     jobTitle: deriveRole(author, settings),
-    worksForName:
-      blankToUndefined(author?.worksForName) ?? DEFAULT_SITE_PROFILE.authorWorksForName,
-    worksForUrl:
-      blankToUndefined(author?.worksForUrl) ?? DEFAULT_SITE_PROFILE.authorWorksForUrl,
-    alumniOf: alumniOf.length > 0 ? alumniOf : [...DEFAULT_SITE_PROFILE.authorAlumniOf],
+    ...resolveAuthorWorksFor(
+      { ...author, slug },
+      {
+        slug,
+        worksForName: DEFAULT_SITE_PROFILE.authorWorksForName,
+        worksForUrl: DEFAULT_SITE_PROFILE.authorWorksForUrl,
+      }
+    ),
+    ...resolveAuthorAlumniOf(
+      { ...author, slug },
+      {
+        slug,
+        alumniOf: DEFAULT_SITE_PROFILE.authorAlumniOf,
+      }
+    ),
     knowsAbout: knowsAbout.length > 0 ? knowsAbout : [...DEFAULT_SITE_PROFILE.knowsAbout],
     credentials: normalizeCredentials(author?.credentials),
     // Delegated rather than repeated (#102). This resolved the three fields

--- a/apps/web/tests/author-identity.test.ts
+++ b/apps/web/tests/author-identity.test.ts
@@ -7,7 +7,9 @@ import {
   composeAuthorTitle,
   resolveArticleAuthorIdentity,
   resolveAuthorAddress,
+  resolveAuthorAlumniOf,
   resolveAuthorPageIdentity,
+  resolveAuthorWorksFor,
 } from "../src/lib/author-identity.ts";
 
 // #83. `??` treats a CMS empty string as *present*, so a cleared author field
@@ -501,4 +503,129 @@ test("the site owner inherits the full fallback only with no address at all (#10
     addressRegion: undefined,
     addressCountry: "DE",
   });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthorWorksFor -- /author/[slug] (#106)
+// ---------------------------------------------------------------------------
+
+const SITE_OWNER_WORKS_FOR = {
+  slug: "mehdi-zare",
+  worksForName: "Entarian",
+  worksForUrl: "https://entarian.com",
+};
+
+test("author worksFor falls back to the site profile for the primary author", () => {
+  const worksFor = resolveAuthorWorksFor(
+    { slug: "mehdi-zare", isPrimary: true },
+    SITE_OWNER_WORKS_FOR
+  );
+
+  assert.deepEqual(worksFor, {
+    worksForName: "Entarian",
+    worksForUrl: "https://entarian.com",
+  });
+});
+
+test("author worksFor does not invent an employer for a different author", () => {
+  const worksFor = resolveAuthorWorksFor({ slug: "jane-doe" }, SITE_OWNER_WORKS_FOR);
+
+  assert.deepEqual(worksFor, {
+    worksForName: undefined,
+    worksForUrl: undefined,
+  });
+});
+
+test("author worksFor keeps a guest author's own employer untouched", () => {
+  const worksFor = resolveAuthorWorksFor(
+    {
+      slug: "jane-doe",
+      worksForName: "Acme Corp",
+      worksForUrl: "https://acme.example",
+    },
+    SITE_OWNER_WORKS_FOR
+  );
+
+  assert.deepEqual(worksFor, {
+    worksForName: "Acme Corp",
+    worksForUrl: "https://acme.example",
+  });
+});
+
+test("a partial site-owner worksFor is emitted as-is, never merged with the fallback (#106)", () => {
+  const worksFor = resolveAuthorWorksFor(
+    {
+      slug: "mehdi-zare",
+      isPrimary: true,
+      worksForName: "Entarian",
+      worksForUrl: "",
+    },
+    SITE_OWNER_WORKS_FOR
+  );
+
+  assert.equal(worksFor.worksForName, "Entarian");
+  assert.equal(worksFor.worksForUrl, undefined);
+  assert.notEqual(
+    worksFor.worksForUrl,
+    SITE_OWNER_WORKS_FOR.worksForUrl,
+    "the owner's URL must not leak into an employer the CMS record already speaks for"
+  );
+});
+
+test("the site owner inherits the full worksFor fallback only with no employer at all (#106)", () => {
+  const blank = resolveAuthorWorksFor(
+    { slug: "mehdi-zare", isPrimary: true },
+    SITE_OWNER_WORKS_FOR
+  );
+
+  assert.deepEqual(blank, {
+    worksForName: SITE_OWNER_WORKS_FOR.worksForName,
+    worksForUrl: SITE_OWNER_WORKS_FOR.worksForUrl,
+  });
+
+  const nameOnly = resolveAuthorWorksFor(
+    { slug: "mehdi-zare", isPrimary: true, worksForName: "Entarian" },
+    SITE_OWNER_WORKS_FOR
+  );
+
+  assert.deepEqual(nameOnly, {
+    worksForName: "Entarian",
+    worksForUrl: undefined,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveAuthorAlumniOf -- /author/[slug] (#106)
+// ---------------------------------------------------------------------------
+
+const SITE_OWNER_ALUMNI = {
+  slug: "mehdi-zare",
+  alumniOf: [
+    "University of Maryland, Smith School of Business",
+    "University of Tehran",
+  ],
+};
+
+test("author alumniOf falls back to the site profile for the primary author", () => {
+  const { alumniOf } = resolveAuthorAlumniOf(
+    { slug: "mehdi-zare", isPrimary: true },
+    SITE_OWNER_ALUMNI
+  );
+
+  assert.deepEqual(alumniOf, [...SITE_OWNER_ALUMNI.alumniOf]);
+});
+
+test("author alumniOf does not borrow the site owner's list for a guest author", () => {
+  const { alumniOf } = resolveAuthorAlumniOf({ slug: "jane-doe" }, SITE_OWNER_ALUMNI);
+
+  assert.deepEqual(alumniOf, []);
+});
+
+test("author alumniOf keeps a guest author's own list untouched", () => {
+  const { alumniOf } = resolveAuthorAlumniOf(
+    { slug: "jane-doe", alumniOf: ["State University"] },
+    SITE_OWNER_ALUMNI
+  );
+
+  assert.deepEqual(alumniOf, ["State University"]);
 });

--- a/apps/web/tests/seo-contract.test.ts
+++ b/apps/web/tests/seo-contract.test.ts
@@ -103,6 +103,26 @@ test("author page address routes through the shared site-owner fallback", () => 
   }
 });
 
+test("author page worksFor routes through the shared site-owner fallback", () => {
+  const pageSource = readSource("src/app/author/[slug]/page.tsx");
+  assertCallsHelper(pageSource, "resolveAuthorWorksFor", "#106");
+  for (const field of ["worksForName", "worksForUrl"]) {
+    assertDoesNotReadField(
+      pageSource,
+      "author",
+      field,
+      "#106",
+      "author page"
+    );
+  }
+});
+
+test("author page alumniOf routes through the shared site-owner fallback", () => {
+  const pageSource = readSource("src/app/author/[slug]/page.tsx");
+  assertCallsHelper(pageSource, "resolveAuthorAlumniOf", "#106");
+  assertDoesNotReadField(pageSource, "author", "alumniOf", "#106", "author page");
+});
+
 test("article metadata does not fall back to the homepage site description", () => {
   const pageSource = readSource("src/app/blog/[slug]/page.tsx");
   assert.doesNotMatch(pageSource, /siteDescription/);

--- a/apps/web/tests/site-identity-consistency.test.ts
+++ b/apps/web/tests/site-identity-consistency.test.ts
@@ -8,6 +8,7 @@ import {
   DEFAULT_SITE_PROFILE,
   DEFAULT_SOCIAL_LINKS,
 } from "../src/lib/site-profile-defaults.ts";
+import { fallbackExperiences } from "../src/content/fallbacks/about.ts";
 
 // Site identity copy lives in three hand-maintained places (#93):
 //
@@ -406,5 +407,43 @@ test("the footer location line matches the structured address defaults", () => {
   assert.equal(
     DEFAULT_SITE_PROFILE.locationLine,
     `${DEFAULT_SITE_PROFILE.authorAddressLocality}, ${DEFAULT_SITE_PROFILE.authorAddressRegion}`
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Visible current-employer copies (#105)
+// ---------------------------------------------------------------------------
+
+test("the current employer name agrees across visible copies and structured data (#105)", () => {
+  assert.ok(primaryAuthor, "data/taxonomy.json: expected a primary author");
+
+  const canonical = primaryAuthor.worksForName;
+  assert.equal(
+    canonical,
+    DEFAULT_SITE_PROFILE.authorWorksForName,
+    "taxonomy worksForName and DEFAULT_SITE_PROFILE.authorWorksForName must agree before comparing visible copies"
+  );
+
+  const trackRecordSource = readFileSync(
+    resolve(repoRoot, "apps/web/src/components/home/TrackRecord.tsx"),
+    "utf8"
+  );
+  assert.match(
+    trackRecordSource,
+    /DEFAULT_SITE_PROFILE\.authorWorksForName/,
+    "TrackRecord must source the current employer from DEFAULT_SITE_PROFILE.authorWorksForName, not a hardcoded literal"
+  );
+
+  const seedSource = readFileSync(SEED_PATH, "utf8");
+  assert.match(
+    seedSource,
+    /company:\s*primaryAuthor\.worksForName/,
+    "the seed's current experience company must read from taxonomy via primaryAuthor.worksForName"
+  );
+
+  assert.equal(
+    fallbackExperiences[0]?.company,
+    DEFAULT_SITE_PROFILE.authorWorksForName,
+    "the about fallback's current experience company must match authorWorksForName"
   );
 });

--- a/apps/web/tests/site-profile-social-normalization.test.ts
+++ b/apps/web/tests/site-profile-social-normalization.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 const { normalizeSiteProfile } = await import("../src/lib/site-profile.ts");
-const { resolveAuthorAddress } = await import("../src/lib/author-identity.ts");
+const { resolveAuthorAddress, resolveAuthorWorksFor } = await import("../src/lib/author-identity.ts");
 const { DEFAULT_SITE_PROFILE } = await import("../src/lib/site-profile-defaults.ts");
 
 const canonicalAuthor = {
@@ -125,5 +125,46 @@ test("the site profile and /author/[slug] resolve the same address (#102)", () =
     },
     routeAddress,
     "the Person on / , /contact and /consulting disagrees with the Person on /author/[slug] -- the #92 drift is back"
+  );
+});
+
+test("a partial CMS worksFor is not completed from the employer fallback (#106)", () => {
+  const profile = normalizeSiteProfile(undefined, {
+    author: {
+      ...canonicalAuthor,
+      worksForName: "Entarian",
+      worksForUrl: "",
+    },
+  });
+
+  assert.equal(profile.author.worksForName, "Entarian");
+  assert.equal(
+    profile.author.worksForUrl,
+    undefined,
+    'the mixed-employer merge is back: a CMS record that speaks for its own employer must not inherit the default URL'
+  );
+});
+
+test("the site profile and /author/[slug] resolve the same worksFor (#106)", () => {
+  const author = {
+    ...canonicalAuthor,
+    worksForName: "Entarian",
+    worksForUrl: "",
+  };
+
+  const profile = normalizeSiteProfile(undefined, { author });
+  const routeWorksFor = resolveAuthorWorksFor(author, {
+    slug: DEFAULT_SITE_PROFILE.authorSlug,
+    worksForName: DEFAULT_SITE_PROFILE.authorWorksForName,
+    worksForUrl: DEFAULT_SITE_PROFILE.authorWorksForUrl,
+  });
+
+  assert.deepEqual(
+    {
+      worksForName: profile.author.worksForName,
+      worksForUrl: profile.author.worksForUrl,
+    },
+    routeWorksFor,
+    "the Person on / , /contact and /consulting disagrees with the Person on /author/[slug] -- the #92 worksFor drift is back"
   );
 });


### PR DESCRIPTION
## Summary

- **#106 (P1):** Add `resolveAuthorWorksFor` and `resolveAuthorAlumniOf` with the same site-owner, all-or-nothing semantics as `resolveAuthorAddress`. `buildAuthorProfile` and `/author/[slug]` now share both resolvers — no more field-by-field worksFor merge or raw CMS alumniOf on the author page.
- **#105 (P2):** Source current employer from `authorWorksForName` in TrackRecord, about fallback, and seed experiences. New consistency tripwire compares visible copies against taxonomy/defaults.
- **#91 (P1):** Code path unchanged — production Strapi still needs `sync:identity --apply` (see test plan).

## Test plan

- [x] 308 web tests pass
- [x] `pnpm typecheck` 3/3, `pnpm --filter=web lint`
- [ ] **P0 for #91:** After merge, run production CMS sync:
  ```bash
  cd apps/cms && pnpm sync:identity        # dry-run first
  cd apps/cms && pnpm sync:identity --apply
  ```
- [ ] Verify live site shows Miami, FL + Entarian in footer and Person JSON-LD on `/` and `/author/mehdi-zare`

Closes #105
Closes #106

Related: #91 (closes after production sync confirmed)

Made with [Cursor](https://cursor.com)