### PR TITLE
test(web): cover CMS templates in CI and the revalidate webhook

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,8 @@ them. The Strapi types stay because dropping a single type drops its table.
 **The CMS owns** articles, categories, tags, and the Author record.
 `/author/[slug]` reads the author raw, with no repo-side fallback, so an
 identity change there does need a CMS write — that is what
-`apps/cms/scripts/sync-site-identity.ts` is for. Nothing else does.
+`apps/cms/scripts/sync-site-identity.ts` is for. Nothing else does. CI's
+CMS-off fixture catalog is gated on `DISABLE_STRAPI_CMS` and is not a
+production fallback.
 
 Before reaching for a production CMS write, check which side owns the value.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,8 +21,8 @@ from either side.
 `apps/web/src/content/fallbacks/` and `apps/web/src/lib/site-profile-defaults.ts`.
 Editing `home-page`, `about-page`, `consulting-page`, `bina-print-page` or
 `site-setting` in the Strapi admin has **no effect on the live site** — those
-records are no longer read. They are kept because dropping a Strapi single type
-drops its table, and their carrying cost is otherwise nil.
+records are no longer read, and `apps/cms/scripts/seed.ts` no longer writes
+them. The Strapi types stay because dropping a single type drops its table.
 
 **The CMS owns** articles, categories, tags, and the Author record.
 `/author/[slug]` reads the author raw, with no repo-side fallback, so an

--- a/apps/cms/scripts/seed.ts
+++ b/apps/cms/scripts/seed.ts
@@ -1,8 +1,13 @@
 /**
  * Seed script for Strapi CMS.
  *
- * Pushes fallback content into Strapi single-type endpoints via the REST API.
- * Uses PUT (upsert) so it is idempotent and safe to re-run.
+ * Writes the records apps/web still reads: author, categories, tags, and the
+ * author relation on articles. Page copy and site identity live in the repo
+ * (`apps/web/src/content/fallbacks/` and `site-profile-defaults.ts`); seeding
+ * `home-page` / `about-page` / `consulting-page` / `bina-print-page` /
+ * `site-setting` / `newsletter-page` was writing rows whose admin edits now
+ * silently do nothing (#116). The Strapi types stay so their tables are not
+ * dropped.
  *
  * Usage:
  *   STRAPI_URL=https://cms-production-a749.up.railway.app \
@@ -122,22 +127,6 @@ async function strapiFetch<T>(
   }
 
   return (await response.json()) as T;
-}
-
-async function putSingleType(
-  singularName: string,
-  payload: Record<string, unknown>,
-  options: { publish?: boolean } = {}
-): Promise<void> {
-  const body: Record<string, unknown> = { data: payload };
-
-  console.log(`PUT /api/${singularName}`);
-  await strapiFetch<unknown>(singularName, {
-    method: "PUT",
-    body: JSON.stringify(body),
-  }, options.publish ? { status: "published" } : {});
-
-  console.log(`  ✓ ${singularName} seeded`);
 }
 
 async function upsertAuthorBySlug(
@@ -412,45 +401,6 @@ async function seedTags(): Promise<void> {
   }
 }
 
-// ---------------------------------------------------------------------------
-// Content: SiteSettings (draftAndPublish: false)
-// ---------------------------------------------------------------------------
-
-const siteSettings = {
-  siteName: "Mehdi Zare",
-  siteDescription:
-    "Principal AI Engineer who ships production AI systems across finance, defense, healthcare, and enterprise. From prototype to production.",
-  positioningHeadline: "I take AI from prototype to production.",
-  positioningSubheadline:
-    "Most AI projects stall between demo and deployment. I'm the engineer who gets them across that gap — because I learn your domain before I write a line of code.",
-  positioningHighlight: "because I learn your domain before I write a line of code.",
-  credentialLine: "Principal AI Engineer · CFA Charterholder",
-  industriesLine: "Finance · Defense · Healthcare · Enterprise",
-  locationLine: "Miami, FL",
-  primaryCtaLabel: "Let's Talk",
-  primaryCtaHref: "/consulting#book",
-  secondaryCtaLabel: "How I work",
-  secondaryCtaHref: "/about",
-  contactPrompt: "Working on an AI initiative that needs to ship?",
-  authorName: "Mehdi Zare, CFA",
-  authorRole: "Principal AI Engineer",
-  authorBioShort:
-    "Principal AI engineer shipping production systems across finance, defense, healthcare, and enterprise.",
-  footerText: "© Mehdi Zare",
-  bookCallHref: "/consulting#book",
-  navItems: [
-    { label: "About", href: "/about" },
-    { label: "Writing", href: "/blog" },
-  ],
-  socialLinks: [
-    { platform: "Website", url: "https://www.mehdi-zare.com" },
-    { platform: "LinkedIn", url: "https://linkedin.com/in/mehdizare" },
-    { platform: "GitHub", url: "https://github.com/mehdizare" },
-    { platform: "Medium", url: "https://medium.com/@mehdi-zare" },
-    { platform: "Seeking Alpha", url: "https://seekingalpha.com/author/mehdi-zare" },
-  ],
-};
-
 if (!Array.isArray(taxonomy.authors)) {
   console.error("taxonomy.json: expected 'authors' to be an array.");
   process.exit(1);
@@ -465,248 +415,6 @@ if (!primaryAuthor) {
   process.exit(1);
 }
 
-// ---------------------------------------------------------------------------
-// Content: HomePage (draftAndPublish: true)
-// ---------------------------------------------------------------------------
-
-// Derived from `siteSettings`, not restated (#101).
-//
-// Seed-only after #100: apps/web reads `buildHomeFallback` / DEFAULT_SITE_PROFILE
-// directly and no longer prefers this `home-page` row at runtime. Kept so an
-// admin who opens Strapi still sees copy that matches the repo, and so the
-// identity tripwire can flag seed↔repo drift before anyone reintroduces the
-// round trip. Referencing siteSettings (instead of restating literals) is what
-// keeps that drift unrepresentable.
-const homePage = {
-  heroHeadline: siteSettings.positioningHeadline,
-  heroSubheadline: siteSettings.positioningSubheadline,
-  heroPrimaryCtaLabel: siteSettings.primaryCtaLabel,
-  heroPrimaryCtaHref: siteSettings.primaryCtaHref,
-  heroSecondaryCtaLabel: siteSettings.secondaryCtaLabel,
-  heroSecondaryCtaHref: siteSettings.secondaryCtaHref,
-};
-
-// ---------------------------------------------------------------------------
-// Content: AboutPage (draftAndPublish: true)
-// ---------------------------------------------------------------------------
-
-const aboutPage = {
-  title: "About Mehdi Zare",
-  // Same derivation as homePage above (#101): buildAboutFallback maps
-  // positioningStatement <- siteProfile.positioningSubheadline.
-  positioningStatement: siteSettings.positioningSubheadline,
-  stats: [
-    { value: "12+", label: "Years building software and AI systems" },
-    { value: "10+", label: "AI systems shipped to production" },
-    { value: "6+", label: "Products built and shipped end-to-end" },
-    { value: "4", label: "Regulated industries shipped in" },
-    { value: "CFA", label: "Charterholder" },
-    { value: "Secret", label: "Active clearance" },
-  ],
-  credentials: [
-    { title: "CFA Charterholder", issuer: "CFA Institute" },
-    {
-      title: "AWS Certified Solutions Architect - Associate",
-      issuer: "Amazon Web Services",
-    },
-    { title: "Secret Security Clearance", issuer: "U.S. Government" },
-    { title: "Founder Fellow (ODF21)", issuer: "On Deck" },
-  ],
-  experiences: [
-    {
-      title: "Principal AI Engineer / Cloud Architect",
-      company: primaryAuthor.worksForName as string,
-      startDate: "2025",
-      current: true,
-      description:
-        "Built GenAI systems for federal cybersecurity operations, focused on production observability and threat-informed monitoring in federal environments where reliability is non-negotiable.",
-    },
-    {
-      title: "Senior AI/ML Engineer",
-      company: "Booz Allen",
-      startDate: "2024",
-      endDate: "2025",
-      description:
-        "Delivered containerized GenAI solutions for government and enterprise teams that needed secure, scalable deployments rather than lab demos.",
-    },
-    {
-      title: "Co-Founder",
-      company: "Adviser",
-      startDate: "2024",
-      endDate: "2024",
-      description:
-        "Co-built a virtual investment adviser for underrepresented groups, turning natural conversation into personalized financial visualizations people could actually use.",
-    },
-    {
-      title: "Quantitative Analysis Manager",
-      company: "Capital One",
-      startDate: "2020",
-      endDate: "2024",
-      description:
-        "Led ML-driven liquidity forecasting across finance, data engineering, and compliance teams, bridging quantitative analysis and enterprise decision-making.",
-    },
-    {
-      title: "Senior Consultant",
-      company: "FI Consulting",
-      startDate: "2019",
-      endDate: "2020",
-      description:
-        "Earned the CFA charter while contributing to financial data series work with the Office of Financial Research, translating policy and market context into usable analytical outputs.",
-    },
-    {
-      title: "Chief AI Scientist",
-      company: "Effective World",
-      startDate: "2024",
-      description:
-        "Led AI and data science initiatives to improve audience intelligence and campaign optimization, connecting model outputs to operational marketing decisions.",
-    },
-    {
-      title: "Founder & CEO",
-      company: "Fardabook.com",
-      startDate: "2011",
-      endDate: "2014",
-      description:
-        "Founded and scaled a textbook-focused online bookstore, owning product, operations, and go-to-market from zero to running business.",
-    },
-  ],
-  education: [
-    {
-      degree: "MBA",
-      field: "Finance",
-      institution: "University of Maryland, Smith School of Business",
-    },
-    {
-      degree: "B.S.",
-      field: "Physics",
-      institution: "University of Tehran",
-    },
-  ],
-  socialLinks: [
-    { platform: "LinkedIn", url: "https://linkedin.com/in/mehdizare" },
-    { platform: "GitHub", url: "https://github.com/mehdizare" },
-    { platform: "Medium", url: "https://medium.com/@mehdi-zare" },
-    { platform: "Seeking Alpha", url: "https://seekingalpha.com/author/mehdi-zare" },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Content: ConsultingPage (draftAndPublish: true)
-// ---------------------------------------------------------------------------
-
-const consultingPage = {
-  title: "AI Consulting for High-Stakes Teams",
-  // Same derivation as homePage above (#101). Seed-only after #100: apps/web
-  // reads buildConsultingFallback for both the <h1> and generateMetadata, so a
-  // stale literal here no longer reaches production. Still derived from
-  // siteSettings so seed↔repo drift stays unrepresentable until the CMS page
-  // types are retired.
-  subtitle: siteSettings.positioningSubheadline,
-  audiences: [
-    {
-      title: "Financial Services Teams",
-      description:
-        "Production-ready AI systems for research, risk, operations, and decision support in regulated financial environments.",
-    },
-    {
-      title: "Healthcare and Life Sciences",
-      description:
-        "Deploy AI workflows where reliability, explainability, and operational safety are requirements, not nice-to-haves.",
-    },
-    {
-      title: "Enterprise AI Teams",
-      description:
-        "Move AI initiatives from pilot experiments to robust production systems with clear ownership and observability.",
-    },
-    {
-      title: "Government / Defense",
-      description: "AI-powered threat and intelligence workflows under strict constraints.",
-    },
-  ],
-  tiers: [
-    {
-      name: "Advisory",
-      priceRange: "Contact for pricing",
-      scope: "AI strategy, architecture review, and vendor evaluation.",
-    },
-    {
-      name: "Hands-On Implementation",
-      priceRange: "Contact for pricing",
-      scope: "Hands-on development with strategic leadership and team mentoring.",
-    },
-    {
-      name: "Fractional AI Lead",
-      priceRange: "Contact for pricing",
-      scope: "Embedded AI leadership for mission-critical programs with delivery ownership.",
-    },
-  ],
-  faq: [
-    {
-      question: "What types of organizations do you work with?",
-      answer:
-        "Most engagements are with regulated or high-stakes teams in finance, healthcare, government, and enterprise settings that need AI outcomes they can defend to stakeholders.",
-    },
-    {
-      question: "How does an engagement begin?",
-      answer:
-        "We start with a 20-minute discovery call, align on target outcomes, and move into a scoped proposal.",
-    },
-    {
-      question: "Can you work with our existing team?",
-      answer:
-        "Yes. I typically embed into existing engineering and product teams while transferring delivery practices.",
-    },
-  ],
-};
-
-// ---------------------------------------------------------------------------
-// Content: BinaPrintPage (draftAndPublish: true)
-// ---------------------------------------------------------------------------
-
-const binaPrintPage = {
-  heroHeadline: "Bina Print - A Zestimate for Stocks",
-  heroSubheadline:
-    "AI-powered company scoring that helps match investment opportunities to your profile.",
-  searchPlaceholder: "Look up any company ticker (e.g., MSFT)",
-  howItWorks: [
-    {
-      title: "We analyze fundamentals",
-      description:
-        "AI agents process financial statements, earnings calls, and SEC filings into structured signals.",
-    },
-    {
-      title: "We score companies 0-100",
-      description:
-        "The Bina Score summarizes investment quality with explainable sub-score components.",
-    },
-    {
-      title: "We match to your profile",
-      description:
-        "Scores are interpreted by risk tolerance, sector preference, and time horizon.",
-    },
-  ],
-  topMovers: [
-    { ticker: "MSFT", company: "Microsoft", score: 88, scoreChange: 4.2 },
-    { ticker: "NVDA", company: "NVIDIA", score: 91, scoreChange: 3.7 },
-    { ticker: "AMZN", company: "Amazon", score: 82, scoreChange: 2.9 },
-    { ticker: "JPM", company: "JPMorgan", score: 79, scoreChange: 2.5 },
-    { ticker: "AAPL", company: "Apple", score: 84, scoreChange: 2.1 },
-  ],
-  exampleTicker: "MSFT",
-  exampleOverallScore: 88,
-  exampleSubScores: {
-    fundamentals: 90,
-    sentiment: 83,
-    momentum: 86,
-    risk: 81,
-  },
-  methodologySummary:
-    "Bina Print combines structured financial analysis with production-tested AI workflows to produce transparent scores. Methodology prioritizes explainability over black-box outputs.",
-};
-
-// ---------------------------------------------------------------------------
-// Run
-// ---------------------------------------------------------------------------
-
 async function main(): Promise<void> {
   console.log(`Seeding Strapi at ${STRAPI_URL}\n`);
 
@@ -715,15 +423,9 @@ async function main(): Promise<void> {
 
   await seedCategories();
   await seedTags();
-
-  await putSingleType("site-setting", siteSettings);
-  await putSingleType("home-page", homePage, { publish: true });
-  await putSingleType("about-page", aboutPage, { publish: true });
-  await putSingleType("consulting-page", consultingPage, { publish: true });
-  await putSingleType("bina-print-page", binaPrintPage, { publish: true });
   await linkAllArticlesToAuthor(author);
 
-  console.log("\nDone — all content types seeded.");
+  console.log("\nDone — author, categories, and tags seeded.");
 }
 
 main().catch((error) => {

--- a/apps/cms/scripts/seed.ts
+++ b/apps/cms/scripts/seed.ts
@@ -5,9 +5,8 @@
  * author relation on articles. Page copy and site identity live in the repo
  * (`apps/web/src/content/fallbacks/` and `site-profile-defaults.ts`); seeding
  * `home-page` / `about-page` / `consulting-page` / `bina-print-page` /
- * `site-setting` / `newsletter-page` was writing rows whose admin edits now
- * silently do nothing (#116). The Strapi types stay so their tables are not
- * dropped.
+ * `site-setting` was writing rows whose admin edits now silently do
+ * nothing (#116). The Strapi types stay so their tables are not dropped.
  *
  * Usage:
  *   STRAPI_URL=https://cms-production-a749.up.railway.app \

--- a/apps/cms/scripts/sync-site-identity.ts
+++ b/apps/cms/scripts/sync-site-identity.ts
@@ -21,10 +21,9 @@
  * until the CMS author record was written, because `/author/[slug]` reads that
  * record raw with no repo-side fallback at all. Renamed rather than duplicated.
  *
- * `seed.ts` would also fix them, but it is a full upsert: it rewrites
- * site-settings, the home/about/consulting pages, and every tag and category,
- * so any hand-edit made in the Strapi admin since the last seed is lost. This
- * sends exactly the fields above and nothing else.
+ * `seed.ts` would also fix them, but it is a full upsert of author, categories
+ * and tags, so any hand-edit made in the Strapi admin since the last seed is
+ * lost. This sends exactly the fields above and nothing else.
  *
  * *Sends* -- not "changes". `author` has Draft & Publish enabled, and Strapi 5's
  * REST update writes the payload onto the DRAFT; `?status=published` then

--- a/apps/web/src/app/author/[slug]/page.tsx
+++ b/apps/web/src/app/author/[slug]/page.tsx
@@ -7,6 +7,11 @@ import { JsonLd } from "@/components/seo/JsonLd";
 import { StrapiImage } from "@/components/shared/StrapiImage";
 import { getSiteProfile } from "@/lib/site-profile";
 import { fetchAllPages, getArticles, getAuthorBySlug, getAuthors } from "@/lib/strapi";
+import { serverEnv } from "@/lib/server-env";
+import {
+  CMS_PRERENDER_AUTHOR_SLUG,
+  findCmsPrerenderAuthor,
+} from "@/content/fixtures/cms-prerender";
 import {
   buildBreadcrumbJsonLd,
   buildNoIndexMetadata,
@@ -39,6 +44,10 @@ function getAllAuthors(): Promise<AuthorList> {
 }
 
 export async function generateStaticParams() {
+  if (serverEnv.strapiDisabled) {
+    return [{ slug: CMS_PRERENDER_AUTHOR_SLUG }];
+  }
+
   try {
     const authors = await getAllAuthors();
     return authors.map((author) => ({ slug: author.slug }));
@@ -53,8 +62,9 @@ export async function generateMetadata({ params }: AuthorPageProps): Promise<Met
 
   try {
     const { slug } = await params;
-    const response = await getAuthorBySlug(slug);
-    const author = response.data[0];
+    const author = serverEnv.strapiDisabled
+      ? findCmsPrerenderAuthor(slug)
+      : (await getAuthorBySlug(slug)).data[0];
 
     if (!author) {
       return buildNoIndexMetadata("Author Not Found");
@@ -120,11 +130,15 @@ export default async function AuthorPage({ params }: AuthorPageProps) {
   const { slug } = await params;
 
   let author;
-  try {
-    const response = await getAuthorBySlug(slug);
-    author = response.data[0];
-  } catch {
-    notFound();
+  if (serverEnv.strapiDisabled) {
+    author = findCmsPrerenderAuthor(slug);
+  } else {
+    try {
+      const response = await getAuthorBySlug(slug);
+      author = response.data[0];
+    } catch {
+      notFound();
+    }
   }
 
   if (!author) {

--- a/apps/web/src/app/blog/[slug]/page.tsx
+++ b/apps/web/src/app/blog/[slug]/page.tsx
@@ -6,6 +6,11 @@ import { AiEngineerProfileLink } from "@/components/seo/AiEngineerProfileLink";
 import { CmsStructuredData } from "@/components/seo/CmsStructuredData";
 import { JsonLd } from "@/components/seo/JsonLd";
 import { fetchAllPages, getArticles, getArticleBySlug } from "@/lib/strapi";
+import { serverEnv } from "@/lib/server-env";
+import {
+  CMS_PRERENDER_ARTICLE_SLUG,
+  findCmsPrerenderArticle,
+} from "@/content/fixtures/cms-prerender";
 import { StrapiImage } from "@/components/shared/StrapiImage";
 import { BlocksRenderer } from "@/components/blog/BlocksRenderer";
 import { TableOfContents } from "@/components/blog/TableOfContents";
@@ -46,6 +51,10 @@ function getAllArticles(): Promise<ArticleList> {
 }
 
 export async function generateStaticParams() {
+  if (serverEnv.strapiDisabled) {
+    return [{ slug: CMS_PRERENDER_ARTICLE_SLUG }];
+  }
+
   try {
     const articles = await getAllArticles();
     return articles.map((article) => ({
@@ -62,8 +71,9 @@ export async function generateMetadata({
 }: BlogPostPageProps): Promise<Metadata> {
   try {
     const { slug } = await params;
-    const res = await getArticleBySlug(slug);
-    const article = res.data[0];
+    const article = serverEnv.strapiDisabled
+      ? findCmsPrerenderArticle(slug)
+      : (await getArticleBySlug(slug)).data[0];
 
     if (!article) {
       return buildNoIndexMetadata("Post Not Found");
@@ -123,11 +133,15 @@ export default async function BlogPostPage({ params }: BlogPostPageProps) {
   const { slug } = await params;
 
   let article;
-  try {
-    const res = await getArticleBySlug(slug);
-    article = res.data[0];
-  } catch {
-    notFound();
+  if (serverEnv.strapiDisabled) {
+    article = findCmsPrerenderArticle(slug);
+  } else {
+    try {
+      const res = await getArticleBySlug(slug);
+      article = res.data[0];
+    } catch {
+      notFound();
+    }
   }
 
   if (!article) {

--- a/apps/web/src/app/blog/category/[slug]/page.tsx
+++ b/apps/web/src/app/blog/category/[slug]/page.tsx
@@ -11,6 +11,8 @@ import {
 } from "@/lib/blog-listing";
 import { getCategorySeedBySlug } from "@/lib/taxonomy-seed";
 import { getCategories, getCategoryBySlug, getArticles } from "@/lib/strapi";
+import { serverEnv } from "@/lib/server-env";
+import { CMS_PRERENDER_CATEGORY_SLUG } from "@/content/fixtures/cms-prerender";
 import {
   buildBreadcrumbJsonLd,
   buildNoIndexMetadata,
@@ -47,6 +49,10 @@ function buildWhatYouWillFindPoints(
 }
 
 export async function generateStaticParams() {
+  if (serverEnv.strapiDisabled) {
+    return [{ slug: CMS_PRERENDER_CATEGORY_SLUG }];
+  }
+
   try {
     const res = await getCategories();
     const categories = res.data;

--- a/apps/web/src/app/blog/tag/[slug]/page.tsx
+++ b/apps/web/src/app/blog/tag/[slug]/page.tsx
@@ -5,6 +5,8 @@ import { PostCard } from "@/components/blog/PostCard";
 import { resolveTagListingCopy } from "@/lib/blog-listing";
 import { getTagSeedBySlug } from "@/lib/taxonomy-seed";
 import { getTags, getTagBySlug, getArticles } from "@/lib/strapi";
+import { serverEnv } from "@/lib/server-env";
+import { CMS_PRERENDER_TAG_SLUG } from "@/content/fixtures/cms-prerender";
 import { buildBreadcrumbJsonLd, buildNoIndexMetadata, buildPageMetadata, buildWebPageJsonLd } from "@/lib/seo";
 
 interface TagPageProps {
@@ -20,6 +22,10 @@ function buildTagHighlights(tagTitle: string): string[] {
 }
 
 export async function generateStaticParams(): Promise<Array<{ slug: string }>> {
+  if (serverEnv.strapiDisabled) {
+    return [{ slug: CMS_PRERENDER_TAG_SLUG }];
+  }
+
   try {
     const tagsRes = await getTags();
     return tagsRes.data.map((tag) => ({ slug: tag.slug }));

--- a/apps/web/src/content/fixtures/cms-prerender.ts
+++ b/apps/web/src/content/fixtures/cms-prerender.ts
@@ -91,6 +91,13 @@ export const CMS_PRERENDER_ARTICLE: Article = {
   category: CMS_PRERENDER_CATEGORY,
   tags: [CMS_PRERENDER_TAG],
   author: CMS_PRERENDER_AUTHOR,
+  // Fake slug, not a real post. If DISABLE_STRAPI_CMS is ever set on a
+  // public deploy, this URL must not be indexed. The author/category/tag
+  // fixtures reuse live identity slugs, so they stay indexable.
+  seo: {
+    id: 9005,
+    metaRobots: "noindex, nofollow",
+  },
   publishedDate: STAMP,
   readingTime: 1,
   createdAt: STAMP,

--- a/apps/web/src/content/fixtures/cms-prerender.ts
+++ b/apps/web/src/content/fixtures/cms-prerender.ts
@@ -1,0 +1,107 @@
+import type { Article, Author, BlocksContent, Category, Tag } from "@/types/strapi";
+import { DEFAULT_SITE_PROFILE, DEFAULT_SOCIAL_LINKS } from "@/lib/site-profile-defaults";
+
+/**
+ * Tiny CMS catalog used when `DISABLE_STRAPI_CMS=true` so CI's post-build
+ * SSR-visibility scan can see article / author / category / tag templates
+ * (#114). Production builds with Strapi reachable never consult this file.
+ *
+ * Keep this set small. Category and tag pages already fall back to
+ * `data/taxonomy.json` once `generateStaticParams` emits a slug; the article
+ * and author templates have no seed fallback and need a full record.
+ */
+
+export const CMS_PRERENDER_ARTICLE_SLUG = "ssr-visibility-fixture";
+export const CMS_PRERENDER_AUTHOR_SLUG = DEFAULT_SITE_PROFILE.authorSlug;
+export const CMS_PRERENDER_CATEGORY_SLUG = "ai-engineering";
+export const CMS_PRERENDER_TAG_SLUG = "llms";
+
+export const CMS_PRERENDER_HTML_FILES = [
+  `blog/${CMS_PRERENDER_ARTICLE_SLUG}.html`,
+  `author/${CMS_PRERENDER_AUTHOR_SLUG}.html`,
+  `blog/category/${CMS_PRERENDER_CATEGORY_SLUG}.html`,
+  `blog/tag/${CMS_PRERENDER_TAG_SLUG}.html`,
+] as const;
+
+const STAMP = "2026-01-15T12:00:00.000Z";
+
+const fixtureBody: BlocksContent = [
+  {
+    type: "paragraph",
+    children: [
+      {
+        type: "text",
+        text: "Fixture body for the post-build SSR visibility scan. Shared reveal components are already covered by repo-owned pages; this copy exists so the article template itself is prerendered in CI.",
+      },
+    ],
+  },
+];
+
+export const CMS_PRERENDER_CATEGORY: Category = {
+  id: 9001,
+  documentId: "ssr-fixture-category",
+  name: "AI Engineering",
+  slug: CMS_PRERENDER_CATEGORY_SLUG,
+  createdAt: STAMP,
+  updatedAt: STAMP,
+  publishedAt: STAMP,
+};
+
+export const CMS_PRERENDER_TAG: Tag = {
+  id: 9002,
+  documentId: "ssr-fixture-tag",
+  name: "LLMs",
+  slug: CMS_PRERENDER_TAG_SLUG,
+  createdAt: STAMP,
+  updatedAt: STAMP,
+  publishedAt: STAMP,
+};
+
+export const CMS_PRERENDER_AUTHOR: Author = {
+  id: 9003,
+  documentId: "ssr-fixture-author",
+  name: DEFAULT_SITE_PROFILE.authorName,
+  slug: CMS_PRERENDER_AUTHOR_SLUG,
+  isPrimary: true,
+  headline: DEFAULT_SITE_PROFILE.authorRole,
+  bioShort: DEFAULT_SITE_PROFILE.authorBioShort,
+  websiteUrl: DEFAULT_SITE_PROFILE.authorWebsiteUrl,
+  linkedinUrl: DEFAULT_SITE_PROFILE.authorLinkedinUrl,
+  sameAs: [...DEFAULT_SOCIAL_LINKS],
+  jobTitle: DEFAULT_SITE_PROFILE.authorRole,
+  worksForName: DEFAULT_SITE_PROFILE.authorWorksForName,
+  worksForUrl: DEFAULT_SITE_PROFILE.authorWorksForUrl,
+  alumniOf: [...DEFAULT_SITE_PROFILE.authorAlumniOf],
+  knowsAbout: [...DEFAULT_SITE_PROFILE.knowsAbout],
+  addressLocality: DEFAULT_SITE_PROFILE.authorAddressLocality,
+  addressRegion: DEFAULT_SITE_PROFILE.authorAddressRegion,
+  addressCountry: DEFAULT_SITE_PROFILE.authorAddressCountry,
+  createdAt: STAMP,
+  updatedAt: STAMP,
+  publishedAt: STAMP,
+};
+
+export const CMS_PRERENDER_ARTICLE: Article = {
+  id: 9004,
+  documentId: "ssr-fixture-article",
+  title: "SSR visibility fixture",
+  slug: CMS_PRERENDER_ARTICLE_SLUG,
+  excerpt: "Committed fixture so CI prerenders the article template without Strapi.",
+  content: fixtureBody,
+  category: CMS_PRERENDER_CATEGORY,
+  tags: [CMS_PRERENDER_TAG],
+  author: CMS_PRERENDER_AUTHOR,
+  publishedDate: STAMP,
+  readingTime: 1,
+  createdAt: STAMP,
+  updatedAt: STAMP,
+  publishedAt: STAMP,
+};
+
+export function findCmsPrerenderArticle(slug: string): Article | undefined {
+  return slug === CMS_PRERENDER_ARTICLE.slug ? CMS_PRERENDER_ARTICLE : undefined;
+}
+
+export function findCmsPrerenderAuthor(slug: string): Author | undefined {
+  return slug === CMS_PRERENDER_AUTHOR.slug ? CMS_PRERENDER_AUTHOR : undefined;
+}

--- a/apps/web/src/lib/site-profile.ts
+++ b/apps/web/src/lib/site-profile.ts
@@ -16,8 +16,6 @@ import type {
   Author,
   Credential,
   NavItem,
-  SEO,
-  SiteSettings,
   SocialLink,
   StrapiImage,
 } from "../types/strapi";
@@ -42,8 +40,6 @@ const REQUIRED_SITE_PROFILE_FIELDS = [
   "footerText",
   "bookCallHref",
 ] as const;
-
-type RequiredSiteProfileField = (typeof REQUIRED_SITE_PROFILE_FIELDS)[number];
 
 interface AuthorProfile {
   id?: number;
@@ -92,7 +88,6 @@ export interface SiteProfile {
   navItems: NavItem[];
   socialLinks: SocialLink[];
   author: AuthorProfile;
-  defaultSeo?: SEO;
 }
 
 interface SiteProfileOptions {
@@ -120,69 +115,12 @@ function normalizeStringArray(value: unknown): string[] {
     .filter((item): item is string => Boolean(item));
 }
 
-function normalizeNavItems(items: SiteSettings["navItems"]): NavItem[] {
-  if (!Array.isArray(items)) {
-    return filterHiddenNavItems(DEFAULT_NAV_ITEMS);
-  }
-
-  const normalized: NavItem[] = [];
-  items.forEach((item, index) => {
-    const label = blankToUndefined(item?.label);
-    const href = blankToUndefined(item?.href);
-    if (!label || !href) {
-      return;
-    }
-
-    normalized.push({
-      id: item.id ?? index + 1,
-      label,
-      href,
-      order: item.order,
-      external: Boolean(item.external),
-    });
-  });
-
-  normalized.sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
-
-  const visibleItems = filterHiddenNavItems(normalized);
-  if (visibleItems.length > 0) {
-    return visibleItems;
-  }
-
-  return filterHiddenNavItems(DEFAULT_NAV_ITEMS);
-}
-
 function filterHiddenNavItems(items: NavItem[]): NavItem[] {
   if (isBinaPrintEnabled()) {
     return items;
   }
 
   return items.filter((item) => !item.href.startsWith("/bina-print"));
-}
-
-function normalizeSocialLinks(items: SiteSettings["socialLinks"]): SocialLink[] {
-  if (!Array.isArray(items)) {
-    return DEFAULT_SOCIAL_LINKS;
-  }
-
-  const normalized = items
-    .map((item, index) => {
-      const platform = blankToUndefined(item?.platform);
-      const url = blankToUndefined(item?.url);
-      const normalizedUrl = normalizeIdentityUrl(url, CANONICAL_IDENTITY_ORIGIN);
-      if (!platform || !normalizedUrl) {
-        return null;
-      }
-
-      return {
-        id: item.id ?? index + 1,
-        platform,
-        url: normalizedUrl,
-      };
-    })
-    .filter((item): item is SocialLink => Boolean(item));
-
-  return normalized.length > 0 ? normalized : DEFAULT_SOCIAL_LINKS;
 }
 
 function dedupeSocialLinks(items: SocialLink[]): SocialLink[] {
@@ -210,10 +148,7 @@ function dedupeSocialLinks(items: SocialLink[]): SocialLink[] {
   return deduped;
 }
 
-function buildCanonicalSocialLinks(
-  author: Author | null | undefined,
-  fallbackLinks: SiteSettings["socialLinks"]
-): SocialLink[] {
+function buildCanonicalSocialLinks(author: Author | null | undefined): SocialLink[] {
   const normalizedAuthorLinks = Array.isArray(author?.sameAs)
     ? author.sameAs
         .map((item, index) => {
@@ -247,7 +182,7 @@ function buildCanonicalSocialLinks(
     { id: 1, platform: "Website", url: websiteUrl },
     { id: 2, platform: "LinkedIn", url: linkedinUrl },
     ...normalizedAuthorLinks,
-    ...normalizeSocialLinks(fallbackLinks),
+    ...DEFAULT_SOCIAL_LINKS,
   ]);
 
   return canonical.length > 0 ? canonical : DEFAULT_SOCIAL_LINKS;
@@ -276,22 +211,18 @@ function normalizeCredentials(credentials: Author["credentials"]): Credential[] 
     .filter((credential): credential is Credential => credential !== null);
 }
 
-function deriveRole(author: Author | null | undefined, settings: SiteSettings | null | undefined): string {
+function deriveRole(author: Author | null | undefined): string {
   return (
     blankToUndefined(author?.jobTitle) ??
     blankToUndefined(author?.headline) ??
-    blankToUndefined(settings?.authorRole) ??
     DEFAULT_SITE_PROFILE.authorRole
   );
 }
 
-function buildAuthorProfile(
-  author: Author | null | undefined,
-  settings: SiteSettings | null | undefined
-): AuthorProfile {
+function buildAuthorProfile(author: Author | null | undefined): AuthorProfile {
   const fallbackSlug = DEFAULT_SITE_PROFILE.authorSlug;
   const slug = blankToUndefined(author?.slug) ?? fallbackSlug;
-  const canonicalSocialLinks = buildCanonicalSocialLinks(author, settings?.socialLinks);
+  const canonicalSocialLinks = buildCanonicalSocialLinks(author);
   const websiteUrl =
     normalizeIdentityUrl(blankToUndefined(author?.websiteUrl), CANONICAL_IDENTITY_ORIGIN) ??
     canonicalSocialLinks.find((link) => link.platform.toLowerCase() === "website")?.url ??
@@ -306,20 +237,18 @@ function buildAuthorProfile(
   return {
     id: author?.id,
     documentId: author?.documentId,
-    name: blankToUndefined(author?.name) ?? blankToUndefined(settings?.authorName) ?? DEFAULT_SITE_PROFILE.authorName,
+    name: blankToUndefined(author?.name) ?? DEFAULT_SITE_PROFILE.authorName,
     slug,
     profilePath: `/author/${slug}`,
     headline: blankToUndefined(author?.headline),
     bioShort:
-      blankToUndefined(author?.bioShort) ??
-      blankToUndefined(settings?.authorBioShort) ??
-      DEFAULT_SITE_PROFILE.authorBioShort,
+      blankToUndefined(author?.bioShort) ?? DEFAULT_SITE_PROFILE.authorBioShort,
     bioLong: author?.bioLong,
     websiteUrl,
     linkedinUrl,
     sameAs: canonicalSocialLinks,
     profileImage: author?.profileImage,
-    jobTitle: deriveRole(author, settings),
+    jobTitle: deriveRole(author),
     ...resolveAuthorWorksFor(
       { ...author, slug },
       {
@@ -355,100 +284,22 @@ function buildAuthorProfile(
   };
 }
 
-function hasValidNavItems(items: SiteSettings["navItems"]): boolean {
-  if (!Array.isArray(items) || items.length === 0) {
-    return false;
+function collectMissingRequiredFields(author?: Author | null): string[] {
+  const profile = mergeProfile(author);
+  const missing: string[] = [];
+
+  for (const field of REQUIRED_SITE_PROFILE_FIELDS) {
+    const value = profile[field];
+    if (typeof value !== "string" || !value.trim()) {
+      missing.push(field);
+    }
   }
 
-  return items.some(
-    (item) => Boolean(blankToUndefined(item?.label)) && Boolean(blankToUndefined(item?.href))
-  );
-}
-
-function hasValidSocialLinks(items: SiteSettings["socialLinks"]): boolean {
-  if (!Array.isArray(items) || items.length === 0) {
-    return false;
-  }
-
-  return items.some(
-    (item) =>
-      Boolean(blankToUndefined(item?.platform)) &&
-      Boolean(normalizeIdentityUrl(blankToUndefined(item?.url), CANONICAL_IDENTITY_ORIGIN))
-  );
-}
-
-function hasCanonicalAuthorData(author: Author | null | undefined): boolean {
-  return Boolean(
-    blankToUndefined(author?.name) &&
-      deriveRole(author, undefined) &&
-      blankToUndefined(author?.bioShort)
-  );
-}
-
-function hasCanonicalSocialData(author: Author | null | undefined): boolean {
-  const hasWebsite = Boolean(
-    normalizeIdentityUrl(blankToUndefined(author?.websiteUrl), CANONICAL_IDENTITY_ORIGIN)
-  );
-  const hasLinkedIn = Boolean(
-    normalizeIdentityUrl(blankToUndefined(author?.linkedinUrl), CANONICAL_IDENTITY_ORIGIN)
-  );
-
-  if (hasWebsite && hasLinkedIn) {
-    return true;
-  }
-
-  if (!Array.isArray(author?.sameAs) || author.sameAs.length === 0) {
-    return false;
-  }
-
-  return author.sameAs.some(
-    (item) =>
-      Boolean(blankToUndefined(item?.platform)) &&
-      Boolean(normalizeIdentityUrl(blankToUndefined(item?.url), CANONICAL_IDENTITY_ORIGIN))
-  );
-}
-
-function collectMissingRequiredFields(
-  settings: SiteSettings | null | undefined,
-  author?: Author | null
-): string[] {
-  if (!settings) {
-    let missing = [...REQUIRED_SITE_PROFILE_FIELDS, "navItems", "socialLinks"];
-
-    if (hasCanonicalAuthorData(author)) {
-      missing = missing.filter(
-        (field) => field !== "authorName" && field !== "authorRole" && field !== "authorBioShort"
-      );
-    }
-
-    if (hasCanonicalSocialData(author)) {
-      missing = missing.filter((field) => field !== "socialLinks");
-    }
-
-    return missing;
-  }
-
-  const missing: string[] = REQUIRED_SITE_PROFILE_FIELDS.filter((field) => {
-    if (field === "authorName") {
-      return !blankToUndefined(settings.authorName) && !blankToUndefined(author?.name);
-    }
-
-    if (field === "authorRole") {
-      return !blankToUndefined(settings.authorRole) && !blankToUndefined(author?.jobTitle) && !blankToUndefined(author?.headline);
-    }
-
-    if (field === "authorBioShort") {
-      return !blankToUndefined(settings.authorBioShort) && !blankToUndefined(author?.bioShort);
-    }
-
-    return !blankToUndefined(settings[field as RequiredSiteProfileField]);
-  });
-
-  if (!hasValidNavItems(settings.navItems)) {
+  if (profile.navItems.length === 0) {
     missing.push("navItems");
   }
 
-  if (!hasValidSocialLinks(settings.socialLinks) && !hasCanonicalSocialData(author)) {
+  if (profile.socialLinks.length === 0) {
     missing.push("socialLinks");
   }
 
@@ -456,77 +307,48 @@ function collectMissingRequiredFields(
 }
 
 /**
- * Merges CMS site settings over the repo defaults.
- *
- * As of #100 the production path always passes `settings` as `undefined`:
- * `getSiteProfile` no longer reads the `site-setting` row, so every
- * `blankToUndefined(settings?.x) ?? DEFAULT_SITE_PROFILE.x` chain below now
- * resolves to the default. The parameter is kept because `normalizeSiteProfile`
- * is still called directly with settings in tests, and because deleting the
- * merge is a larger change than removing the read.
- *
- * If nothing comes to need CMS-supplied site settings, this collapses to a
- * spread of DEFAULT_SITE_PROFILE plus the author-derived fields.
+ * Repo defaults plus the CMS author record. Site settings are not a source:
+ * `getSiteProfile` stopped reading `site-setting` in #100, and #116 stopped
+ * seeding that row. Collapsing the merge makes that unrepresentable -- a
+ * `settings?.x ?? DEFAULT` chain cannot quietly start winning again.
  */
-function mergeProfile(settings: SiteSettings | null | undefined, author?: Author | null): SiteProfile {
-  const canonicalAuthor = buildAuthorProfile(author, settings);
+function mergeProfile(author?: Author | null): SiteProfile {
+  const canonicalAuthor = buildAuthorProfile(author);
 
   return {
-    siteName: blankToUndefined(settings?.siteName) ?? DEFAULT_SITE_PROFILE.siteName,
-    siteDescription:
-      blankToUndefined(settings?.siteDescription) ?? DEFAULT_SITE_PROFILE.siteDescription,
-    positioningHeadline:
-      blankToUndefined(settings?.positioningHeadline) ??
-      DEFAULT_SITE_PROFILE.positioningHeadline,
-    positioningSubheadline:
-      blankToUndefined(settings?.positioningSubheadline) ??
-      DEFAULT_SITE_PROFILE.positioningSubheadline,
-    positioningHighlight:
-      blankToUndefined(settings?.positioningHighlight) ??
-      DEFAULT_SITE_PROFILE.positioningHighlight,
-    credentialLine:
-      blankToUndefined(settings?.credentialLine) ?? DEFAULT_SITE_PROFILE.credentialLine,
-    industriesLine:
-      blankToUndefined(settings?.industriesLine) ?? DEFAULT_SITE_PROFILE.industriesLine,
-    locationLine:
-      blankToUndefined(settings?.locationLine) ?? DEFAULT_SITE_PROFILE.locationLine,
-    primaryCtaLabel:
-      blankToUndefined(settings?.primaryCtaLabel) ?? DEFAULT_SITE_PROFILE.primaryCtaLabel,
-    primaryCtaHref:
-      blankToUndefined(settings?.primaryCtaHref) ?? DEFAULT_SITE_PROFILE.primaryCtaHref,
-    secondaryCtaLabel:
-      blankToUndefined(settings?.secondaryCtaLabel) ?? DEFAULT_SITE_PROFILE.secondaryCtaLabel,
-    secondaryCtaHref:
-      blankToUndefined(settings?.secondaryCtaHref) ?? DEFAULT_SITE_PROFILE.secondaryCtaHref,
-    contactPrompt:
-      blankToUndefined(settings?.contactPrompt) ?? DEFAULT_SITE_PROFILE.contactPrompt,
+    siteName: DEFAULT_SITE_PROFILE.siteName,
+    siteDescription: DEFAULT_SITE_PROFILE.siteDescription,
+    positioningHeadline: DEFAULT_SITE_PROFILE.positioningHeadline,
+    positioningSubheadline: DEFAULT_SITE_PROFILE.positioningSubheadline,
+    positioningHighlight: DEFAULT_SITE_PROFILE.positioningHighlight,
+    credentialLine: DEFAULT_SITE_PROFILE.credentialLine,
+    industriesLine: DEFAULT_SITE_PROFILE.industriesLine,
+    locationLine: DEFAULT_SITE_PROFILE.locationLine,
+    primaryCtaLabel: DEFAULT_SITE_PROFILE.primaryCtaLabel,
+    primaryCtaHref: DEFAULT_SITE_PROFILE.primaryCtaHref,
+    secondaryCtaLabel: DEFAULT_SITE_PROFILE.secondaryCtaLabel,
+    secondaryCtaHref: DEFAULT_SITE_PROFILE.secondaryCtaHref,
+    contactPrompt: DEFAULT_SITE_PROFILE.contactPrompt,
     authorName: canonicalAuthor.name,
     authorRole: canonicalAuthor.jobTitle,
     authorBioShort: canonicalAuthor.bioShort,
-    footerText: blankToUndefined(settings?.footerText) ?? DEFAULT_SITE_PROFILE.footerText,
-    bookCallHref:
-      blankToUndefined(settings?.bookCallHref) ?? DEFAULT_SITE_PROFILE.bookCallHref,
+    footerText: DEFAULT_SITE_PROFILE.footerText,
+    bookCallHref: DEFAULT_SITE_PROFILE.bookCallHref,
     knowsAbout: [...canonicalAuthor.knowsAbout],
-    navItems: normalizeNavItems(settings?.navItems),
+    navItems: filterHiddenNavItems([...DEFAULT_NAV_ITEMS]),
     socialLinks: [...canonicalAuthor.sameAs],
     author: canonicalAuthor,
-    defaultSeo: settings?.defaultSeo,
   };
 }
 
-export function normalizeSiteProfile(
-  settings: SiteSettings | null | undefined,
-  options: SiteProfileOptions = {}
-): SiteProfile {
+export function normalizeSiteProfile(options: SiteProfileOptions = {}): SiteProfile {
   // Strict validation is opt-in per call, never ambient. It used to also turn
-  // on from `SITE_PROFILE_STRICT=true`, which existed to fail a build whose
-  // `site-setting` row was missing required fields. #100 took that row out of
-  // the read path, so production now passes `settings` as `undefined` -- and
-  // an ambient switch would have found every required field "missing" and
-  // thrown on every request. The check still means something for a caller that
-  // hands over settings to validate; it just cannot be turned on from outside.
+  // on from `SITE_PROFILE_STRICT=true` against a CMS `site-setting` row.
+  // Defaults fill every required field by construction, so `strict` now
+  // checks the resolved profile -- a way to notice a default going blank --
+  // and cannot be turned on from outside.
   if (options.strict === true) {
-    const missingFields = collectMissingRequiredFields(settings, options.author);
+    const missingFields = collectMissingRequiredFields(options.author);
     if (missingFields.length > 0) {
       throw new SiteProfileValidationError(
         `Site Profile is missing required fields: ${missingFields.join(", ")}`,
@@ -535,34 +357,19 @@ export function normalizeSiteProfile(
     }
   }
 
-  if (options.author) {
-    return mergeProfile(settings, options.author);
-  }
-
-  return mergeProfile(settings);
+  return mergeProfile(options.author);
 }
 
 export async function getSiteProfile(options: SiteProfileOptions = {}): Promise<SiteProfile> {
   try {
     const { getPrimaryAuthor } = await import("./strapi");
 
-    // `site-setting` is no longer read (#100). Its row was seeded once in
-    // February and never edited again, yet it *won* over the repo at runtime --
-    // so moving the site's location took a production CMS write (#87, #91), and
-    // so did renaming the employer. Every value it held was a copy of
-    // DEFAULT_SITE_PROFILE; the repo is now simply the source.
-    //
-    // The author record still comes from Strapi: articles relate to it, and
-    // `/author/[slug]` renders it.
+    // Page copy and site identity are repo-owned. The author record still
+    // comes from Strapi: articles relate to it, and `/author/[slug]` renders
+    // it raw.
     const author = await getPrimaryAuthor().catch(() => undefined);
 
-    // No strict validation here any more. It existed to fail the build when the
-    // CMS `site-setting` row was missing required fields; with the row out of
-    // the read path there is nothing to validate -- DEFAULT_SITE_PROFILE has
-    // every required field by construction, and passing `strict` now would
-    // throw on every request. `normalizeSiteProfile` keeps the option for
-    // callers that pass settings directly.
-    return normalizeSiteProfile(undefined, {
+    return normalizeSiteProfile({
       author: author ?? options.author,
     });
   } catch (error) {
@@ -570,7 +377,7 @@ export async function getSiteProfile(options: SiteProfileOptions = {}): Promise<
       "⚠ CMS author unavailable — site profile falling back to default content.",
       error instanceof Error ? error.message : error
     );
-    return mergeProfile(undefined, options.author);
+    return mergeProfile(options.author);
   }
 }
 

--- a/apps/web/src/lib/strapi.ts
+++ b/apps/web/src/lib/strapi.ts
@@ -446,7 +446,7 @@ export async function getTagBySlug(
 /**
  * Single-type page fetchers (`getHomePage`, `getAboutPage`, `getConsultingPage`,
  * `getBinaPrintPage`) and `getSiteSettings` used to live here. #100 moved that
- * copy into the repo, which left them with no callers; they are deleted rather
+ * copy into the repo; #116 stopped seeding those rows. They are deleted rather
  * than kept warm so the CMS round trip cannot quietly grow back. `git log` has
  * them if a page ever genuinely needs to be editor-owned again.
  *

--- a/apps/web/src/types/strapi.ts
+++ b/apps/web/src/types/strapi.ts
@@ -200,68 +200,7 @@ export interface NavItem {
   external?: boolean;
 }
 
-// Home page
-
-export interface HomeCredibilityItem {
-  id: number;
-  organization: string;
-  detail?: string;
-  url?: string;
-}
-
-export interface HomeFeaturedOnItem {
-  id: number;
-  platform: string;
-  url?: string;
-}
-
-export interface HomeValueCard {
-  id: number;
-  title: string;
-  description?: string;
-  ctaLabel?: string;
-  ctaHref?: string;
-}
-
-export interface HomePage {
-  id: number;
-  documentId: string;
-  heroHeadline?: string;
-  heroSubheadline?: string;
-  heroPrimaryCtaLabel?: string;
-  heroPrimaryCtaHref?: string;
-  heroSecondaryCtaLabel?: string;
-  heroSecondaryCtaHref?: string;
-  heroImage?: StrapiImage;
-  credibilityItems?: HomeCredibilityItem[];
-  featuredOnItems?: HomeFeaturedOnItem[];
-  whatIDoCards?: HomeValueCard[];
-  seo?: SEO;
-  createdAt: string;
-  updatedAt: string;
-  publishedAt: string;
-}
-
-// About page
-
-export interface AboutPage {
-  id: number;
-  documentId: string;
-  title?: string;
-  positioningStatement?: string;
-  bio?: BlocksContent;
-  stats?: StatItem[];
-  credentials?: Credential[];
-  experiences?: Experience[];
-  education?: Education[];
-  socialLinks?: SocialLink[];
-  seo?: SEO;
-  createdAt: string;
-  updatedAt: string;
-  publishedAt: string;
-}
-
-// Bina Print page
+// Bina Print (repo-owned page copy; these shapes are the fallback types)
 
 export interface BinaStep {
   id: number;
@@ -278,36 +217,6 @@ export interface BinaMover {
   analysisUrl?: string;
 }
 
-export interface BinaPrintPage {
-  id: number;
-  documentId: string;
-  heroHeadline?: string;
-  heroSubheadline?: string;
-  searchPlaceholder?: string;
-  howItWorks?: BinaStep[];
-  topMovers?: BinaMover[];
-  exampleTicker?: string;
-  exampleOverallScore?: number;
-  exampleSubScores?: Record<string, number>;
-  methodologySummary?: string;
-  seo?: SEO;
-  createdAt: string;
-  updatedAt: string;
-  publishedAt: string;
-}
-
-// Consulting page
-
-export interface ConsultingTier {
-  id: number;
-  name: string;
-  priceRange: string;
-  hoursPerMonth?: string;
-  scope?: string;
-  features?: string[];
-  ctaText?: string;
-}
-
 export interface FAQ {
   id: number;
   question: string;
@@ -318,53 +227,6 @@ export interface ConsultingAudience {
   id: number;
   title: string;
   description: string;
-}
-
-export interface ConsultingPage {
-  id: number;
-  documentId: string;
-  title?: string;
-  subtitle?: string;
-  audiences?: ConsultingAudience[];
-  tiers?: ConsultingTier[];
-  faq?: FAQ[];
-  leadMagnetTitle?: string;
-  leadMagnetDescription?: string;
-  seo?: SEO;
-  createdAt: string;
-  updatedAt: string;
-  publishedAt: string;
-}
-
-// Site settings
-
-export interface SiteSettings {
-  id: number;
-  documentId: string;
-  siteName?: string;
-  siteDescription?: string;
-  positioningHeadline?: string;
-  positioningSubheadline?: string;
-  positioningHighlight?: string;
-  credentialLine?: string;
-  industriesLine?: string;
-  locationLine?: string;
-  primaryCtaLabel?: string;
-  primaryCtaHref?: string;
-  secondaryCtaLabel?: string;
-  secondaryCtaHref?: string;
-  contactPrompt?: string;
-  authorName?: string;
-  authorRole?: string;
-  authorBioShort?: string;
-  footerText?: string;
-  bookCallHref?: string;
-  navItems?: NavItem[];
-  socialLinks?: SocialLink[];
-  defaultSeo?: SEO;
-  createdAt: string;
-  updatedAt: string;
-  publishedAt: string;
 }
 
 // Contact submission

--- a/apps/web/tests/cms-prerender.test.ts
+++ b/apps/web/tests/cms-prerender.test.ts
@@ -3,7 +3,6 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
-import { getCategorySeedBySlug, getTagSeedBySlug } from "../src/lib/taxonomy-seed.ts";
 import { DEFAULT_SITE_PROFILE } from "../src/lib/site-profile-defaults.ts";
 import {
   CMS_PRERENDER_ARTICLE,
@@ -38,16 +37,26 @@ test("the author fixture is the site owner, so Person JSON-LD stays on the ident
 });
 
 test("category and tag fixture slugs exist in the taxonomy seed, so those pages render without a CMS row", () => {
-  // The test runner stubs data/taxonomy.json (ai-engineering + llms). The
-  // production file has those slugs too. generateStaticParams emits these in
-  // a CMS-off build; missing them 404s the template.
+  // Read the production file, not the test runner's taxonomy stub. A rename
+  // in data/taxonomy.json must fail here, not only at postbuild.
+  const taxonomy = JSON.parse(
+    readFileSync(resolve(process.cwd(), "../../data/taxonomy.json"), "utf8")
+  ) as {
+    categories: Array<{ slug: string; children?: Array<{ slug: string }> }>;
+    tags: Array<{ slug: string }>;
+  };
+  const categorySlugs = taxonomy.categories.flatMap((category) => [
+    category.slug,
+    ...(category.children?.map((child) => child.slug) ?? []),
+  ]);
+
   assert.ok(
-    getCategorySeedBySlug(CMS_PRERENDER_CATEGORY_SLUG),
-    `${CMS_PRERENDER_CATEGORY_SLUG} must exist in the taxonomy seed or the category template 404s in a CMS-off build`
+    categorySlugs.includes(CMS_PRERENDER_CATEGORY_SLUG),
+    `${CMS_PRERENDER_CATEGORY_SLUG} must exist in data/taxonomy.json or the category template 404s in a CMS-off build`
   );
   assert.ok(
-    getTagSeedBySlug(CMS_PRERENDER_TAG_SLUG),
-    `${CMS_PRERENDER_TAG_SLUG} must exist in the taxonomy seed or the tag template 404s in a CMS-off build`
+    taxonomy.tags.some((tag) => tag.slug === CMS_PRERENDER_TAG_SLUG),
+    `${CMS_PRERENDER_TAG_SLUG} must exist in data/taxonomy.json or the tag template 404s in a CMS-off build`
   );
 });
 
@@ -56,6 +65,14 @@ test("finders return the fixture for its slug and nothing else", () => {
   assert.equal(findCmsPrerenderArticle("some-other-post"), undefined);
   assert.equal(findCmsPrerenderAuthor(CMS_PRERENDER_AUTHOR_SLUG)?.id, CMS_PRERENDER_AUTHOR.id);
   assert.equal(findCmsPrerenderAuthor("guest-author"), undefined);
+});
+
+test("the fake article slug is noindex so a CMS-off public deploy cannot rank it", () => {
+  assert.match(
+    CMS_PRERENDER_ARTICLE.seo?.metaRobots ?? "",
+    /noindex/i,
+    "ssr-visibility-fixture is not a real post; metaRobots must include noindex"
+  );
 });
 
 test("CMS-off generateStaticParams emits the fixture slugs", () => {

--- a/apps/web/tests/cms-prerender.test.ts
+++ b/apps/web/tests/cms-prerender.test.ts
@@ -1,0 +1,82 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import { getCategorySeedBySlug, getTagSeedBySlug } from "../src/lib/taxonomy-seed.ts";
+import { DEFAULT_SITE_PROFILE } from "../src/lib/site-profile-defaults.ts";
+import {
+  CMS_PRERENDER_ARTICLE,
+  CMS_PRERENDER_ARTICLE_SLUG,
+  CMS_PRERENDER_AUTHOR,
+  CMS_PRERENDER_AUTHOR_SLUG,
+  CMS_PRERENDER_CATEGORY_SLUG,
+  CMS_PRERENDER_HTML_FILES,
+  CMS_PRERENDER_TAG_SLUG,
+  findCmsPrerenderArticle,
+  findCmsPrerenderAuthor,
+} from "../src/content/fixtures/cms-prerender.ts";
+
+test("the prerender fixture slugs match the records and the HTML list", () => {
+  assert.equal(CMS_PRERENDER_ARTICLE.slug, CMS_PRERENDER_ARTICLE_SLUG);
+  assert.equal(CMS_PRERENDER_AUTHOR.slug, CMS_PRERENDER_AUTHOR_SLUG);
+  assert.deepEqual(
+    [...CMS_PRERENDER_HTML_FILES].sort(),
+    [
+      `author/${CMS_PRERENDER_AUTHOR_SLUG}.html`,
+      `blog/${CMS_PRERENDER_ARTICLE_SLUG}.html`,
+      `blog/category/${CMS_PRERENDER_CATEGORY_SLUG}.html`,
+      `blog/tag/${CMS_PRERENDER_TAG_SLUG}.html`,
+    ].sort()
+  );
+});
+
+test("the author fixture is the site owner, so Person JSON-LD stays on the identity contract", () => {
+  assert.equal(CMS_PRERENDER_AUTHOR_SLUG, DEFAULT_SITE_PROFILE.authorSlug);
+  assert.equal(CMS_PRERENDER_AUTHOR.isPrimary, true);
+  assert.equal(CMS_PRERENDER_AUTHOR.name, DEFAULT_SITE_PROFILE.authorName);
+});
+
+test("category and tag fixture slugs exist in the taxonomy seed, so those pages render without a CMS row", () => {
+  // The test runner stubs data/taxonomy.json (ai-engineering + llms). The
+  // production file has those slugs too. generateStaticParams emits these in
+  // a CMS-off build; missing them 404s the template.
+  assert.ok(
+    getCategorySeedBySlug(CMS_PRERENDER_CATEGORY_SLUG),
+    `${CMS_PRERENDER_CATEGORY_SLUG} must exist in the taxonomy seed or the category template 404s in a CMS-off build`
+  );
+  assert.ok(
+    getTagSeedBySlug(CMS_PRERENDER_TAG_SLUG),
+    `${CMS_PRERENDER_TAG_SLUG} must exist in the taxonomy seed or the tag template 404s in a CMS-off build`
+  );
+});
+
+test("finders return the fixture for its slug and nothing else", () => {
+  assert.equal(findCmsPrerenderArticle(CMS_PRERENDER_ARTICLE_SLUG)?.id, CMS_PRERENDER_ARTICLE.id);
+  assert.equal(findCmsPrerenderArticle("some-other-post"), undefined);
+  assert.equal(findCmsPrerenderAuthor(CMS_PRERENDER_AUTHOR_SLUG)?.id, CMS_PRERENDER_AUTHOR.id);
+  assert.equal(findCmsPrerenderAuthor("guest-author"), undefined);
+});
+
+test("CMS-off generateStaticParams emits the fixture slugs", () => {
+  const pages: Array<{ file: string; slug: string }> = [
+    { file: "src/app/blog/[slug]/page.tsx", slug: "CMS_PRERENDER_ARTICLE_SLUG" },
+    { file: "src/app/author/[slug]/page.tsx", slug: "CMS_PRERENDER_AUTHOR_SLUG" },
+    { file: "src/app/blog/category/[slug]/page.tsx", slug: "CMS_PRERENDER_CATEGORY_SLUG" },
+    { file: "src/app/blog/tag/[slug]/page.tsx", slug: "CMS_PRERENDER_TAG_SLUG" },
+  ];
+
+  for (const { file, slug } of pages) {
+    const source = readFileSync(resolve(process.cwd(), file), "utf8");
+    assert.match(
+      source,
+      /serverEnv\.strapiDisabled/,
+      `${file} must consult DISABLE_STRAPI_CMS before falling back to an empty generateStaticParams`
+    );
+    assert.match(
+      source,
+      new RegExp(slug),
+      `${file} must emit ${slug} when the CMS is disabled`
+    );
+  }
+});

--- a/apps/web/tests/cms-seed-no-page-types.test.ts
+++ b/apps/web/tests/cms-seed-no-page-types.test.ts
@@ -29,6 +29,11 @@ test("the CMS seed no longer upserts retired page single-types or site-setting",
       new RegExp(`putSingleType\\(\\s*["']${type}["']`),
       `seed.ts still writes ${type}; that row is not read by apps/web (#116)`
     );
+    assert.doesNotMatch(
+      seed,
+      new RegExp(`strapiFetch(?:<[^>]+>)?\\(\\s*["']${type}["']`),
+      `seed.ts still fetches ${type} as a write path; that row is not read by apps/web (#116)`
+    );
   }
 });
 

--- a/apps/web/tests/cms-seed-no-page-types.test.ts
+++ b/apps/web/tests/cms-seed-no-page-types.test.ts
@@ -1,0 +1,39 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// #116. After page copy became repo-owned, seeding these single-types wrote
+// rows that an admin can still edit -- and that edit now silently does
+// nothing in production. Stop writing them. The Strapi types stay (dropping
+// a single type drops its table); the seed must not keep them warm.
+
+const seed = readFileSync(
+  resolve(process.cwd(), "../../apps/cms/scripts/seed.ts"),
+  "utf8"
+);
+
+const retired = [
+  "site-setting",
+  "home-page",
+  "about-page",
+  "consulting-page",
+  "bina-print-page",
+  "newsletter-page",
+];
+
+test("the CMS seed no longer upserts retired page single-types or site-setting", () => {
+  for (const type of retired) {
+    assert.doesNotMatch(
+      seed,
+      new RegExp(`putSingleType\\(\\s*["']${type}["']`),
+      `seed.ts still writes ${type}; that row is not read by apps/web (#116)`
+    );
+  }
+});
+
+test("the CMS seed still writes the records the site actually reads", () => {
+  assert.match(seed, /upsertAuthorBySlug/);
+  assert.match(seed, /seedCategories/);
+  assert.match(seed, /seedTags/);
+});

--- a/apps/web/tests/next-cache-stub.mjs
+++ b/apps/web/tests/next-cache-stub.mjs
@@ -1,0 +1,19 @@
+/** @type {{ path: string, type?: string }[]} */
+export const revalidatePathCalls = [];
+/** @type {{ tag: string, profile?: string }[]} */
+export const revalidateTagCalls = [];
+
+/** @param {string} path @param {string} [type] */
+export function revalidatePath(path, type) {
+  revalidatePathCalls.push({ path, type });
+}
+
+/** @param {string} tag @param {string} [profile] */
+export function revalidateTag(tag, profile) {
+  revalidateTagCalls.push({ tag, profile });
+}
+
+export function resetRevalidateCalls() {
+  revalidatePathCalls.length = 0;
+  revalidateTagCalls.length = 0;
+}

--- a/apps/web/tests/post-build/ssr-visibility.test.ts
+++ b/apps/web/tests/post-build/ssr-visibility.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync, readdirSync, existsSync } from "node:fs";
 import { join, relative, resolve } from "node:path";
+import { CMS_PRERENDER_HTML_FILES } from "../../src/content/fixtures/cms-prerender.ts";
 
 // Framer Motion inlines the resolved `initial` state as a `style` attribute
 // during SSR. An initial state that zeroes opacity, scale or size therefore
@@ -23,9 +24,10 @@ import { join, relative, resolve } from "node:path";
 // Runs after `next build` rather than with the main suite -- see the
 // `test:postbuild` script and the CI step that follows Build.
 //
-// CI builds with DISABLE_STRAPI_CMS=true, so article/author/category/tag
-// templates are never scanned here. Shared reveal components still surface on
-// the seven repo-owned pages; template-local markup is tracked in #114.
+// CI builds with DISABLE_STRAPI_CMS=true. Article/author templates have no
+// seed fallback, so a committed fixture catalog prerenders one of each
+// (#114). Category/tag pages render from data/taxonomy.json once
+// generateStaticParams emits those fixture slugs.
 
 const BUILD_DIR = resolve(import.meta.dirname, "../../.next/server/app");
 
@@ -34,11 +36,12 @@ const BUILD_DIR = resolve(import.meta.dirname, "../../.next/server/app");
  * *any* build of this app.
  *
  * Naming them, rather than counting pages, is what makes this contract
- * CMS-independent: CI builds with `DISABLE_STRAPI_CMS=true`, so article,
- * category, tag and author pages emit no HTML there, while a local build with
- * Strapi reachable emits ~58 files. A page count calibrated on one is wrong on
- * the other; this list is right on both, and it says which page went missing
- * instead of only how many did.
+ * CMS-independent: CI builds with `DISABLE_STRAPI_CMS=true`, so the live CMS
+ * catalog is absent, while a local build with Strapi reachable emits ~58
+ * files. The fixture routes in `CMS_PRERENDER_HTML_FILES` are present in
+ * *both* configurations (CMS-off via the committed catalog, CMS-on if those
+ * slugs exist in Strapi, otherwise still via the DISABLE path in CI). A page
+ * count calibrated on one is wrong on the other; this list is right on both.
  *
  * Adding a static route without adding it here is deliberately not a failure
  * -- the scan below covers whatever the build emitted. The list exists to
@@ -51,6 +54,7 @@ const ALWAYS_PRERENDERED = [
   "blog.html",
   "consulting.html",
   "contact.html",
+  ...CMS_PRERENDER_HTML_FILES,
 ];
 
 /**

--- a/apps/web/tests/post-build/ssr-visibility.test.ts
+++ b/apps/web/tests/post-build/ssr-visibility.test.ts
@@ -32,16 +32,15 @@ import { CMS_PRERENDER_HTML_FILES } from "../../src/content/fixtures/cms-prerend
 const BUILD_DIR = resolve(import.meta.dirname, "../../.next/server/app");
 
 /**
- * Every route that prerenders from repo-owned data alone, so it is present in
- * *any* build of this app.
+ * Routes this contract requires to exist as 200s in a CMS-off build (CI).
  *
  * Naming them, rather than counting pages, is what makes this contract
  * CMS-independent: CI builds with `DISABLE_STRAPI_CMS=true`, so the live CMS
  * catalog is absent, while a local build with Strapi reachable emits ~58
- * files. The fixture routes in `CMS_PRERENDER_HTML_FILES` are present in
- * *both* configurations (CMS-off via the committed catalog, CMS-on if those
- * slugs exist in Strapi, otherwise still via the DISABLE path in CI). A page
- * count calibrated on one is wrong on the other; this list is right on both.
+ * files. This list is the CMS-off contract CI actually runs: repo-owned
+ * pages plus the committed fixture routes. A CMS-on local `test:postbuild`
+ * will fail on `blog/ssr-visibility-fixture.html` unless that slug exists
+ * in Strapi; run postbuild against a CMS-off build, as CI does.
  *
  * Adding a static route without adding it here is deliberately not a failure
  * -- the scan below covers whatever the build emitted. The list exists to

--- a/apps/web/tests/resolve-ts-hook.mjs
+++ b/apps/web/tests/resolve-ts-hook.mjs
@@ -4,6 +4,7 @@ import ts from "typescript";
 const SRC_BASE = new URL("../src/", import.meta.url);
 const SERVER_ONLY_STUB = new URL("./server-only-stub.mjs", import.meta.url);
 const TAXONOMY_STUB = new URL("./taxonomy-stub.mjs", import.meta.url);
+const NEXT_CACHE_STUB = new URL("./next-cache-stub.mjs", import.meta.url);
 
 async function tryResolveAlias(specifier, context, nextResolve) {
   const target = new URL(specifier.slice(2), SRC_BASE);
@@ -39,6 +40,13 @@ export async function resolve(specifier, context, nextResolve) {
   if (specifier === "server-only") {
     return {
       url: SERVER_ONLY_STUB.href,
+      shortCircuit: true,
+    };
+  }
+
+  if (specifier === "next/cache") {
+    return {
+      url: NEXT_CACHE_STUB.href,
       shortCircuit: true,
     };
   }

--- a/apps/web/tests/revalidate-route-behavior.test.ts
+++ b/apps/web/tests/revalidate-route-behavior.test.ts
@@ -1,0 +1,172 @@
+import test, { beforeEach } from "node:test";
+import assert from "node:assert/strict";
+
+// Behavioural coverage for the Strapi publish webhook (#115). Source contracts
+// in revalidate-route.test.ts pin the silent-type bug that cannot be loaded
+// here without a next/cache stub; this file is the loadable half.
+//
+// serverEnv freezes REVALIDATE_SECRET at import, so this file always has a
+// secret. The unconfigured (500) path is revalidate-route-unconfigured.test.ts.
+
+process.env.REVALIDATE_SECRET = "test-revalidate-secret";
+process.env.DISABLE_STRAPI_CMS = "true";
+
+const { POST } = await import("../src/app/api/revalidate/route.ts");
+const {
+  revalidatePathCalls,
+  revalidateTagCalls,
+  resetRevalidateCalls,
+}: {
+  revalidatePathCalls: Array<{ path: string; type?: string }>;
+  revalidateTagCalls: Array<{ tag: string; profile?: string }>;
+  resetRevalidateCalls: () => void;
+} = await import("./next-cache-stub.mjs");
+
+beforeEach(() => {
+  resetRevalidateCalls();
+});
+
+function request(init: {
+  secretIn?: "query" | "header" | "body" | "none" | "authorization";
+  secret?: string;
+  body?: unknown;
+  rawBody?: string;
+}): Request {
+  const secret = init.secret ?? "test-revalidate-secret";
+  const url = new URL("https://www.mehdi-zare.com/api/revalidate");
+  const headers = new Headers({ "content-type": "application/json" });
+
+  if (init.secretIn === "query") {
+    url.searchParams.set("secret", secret);
+  }
+  if (init.secretIn === "header") {
+    headers.set("x-revalidate-secret", secret);
+  }
+  if (init.secretIn === "authorization") {
+    headers.set("authorization", `Bearer ${secret}`);
+  }
+
+  let body: string | undefined;
+  if (init.rawBody !== undefined) {
+    body = init.rawBody;
+  } else if (init.body !== undefined) {
+    body = JSON.stringify(init.body);
+  } else if (init.secretIn === "body") {
+    body = JSON.stringify({ secret });
+  }
+
+  return new Request(url, { method: "POST", headers, body });
+}
+
+async function post(init: Parameters<typeof request>[0]) {
+  const response = await POST(request(init));
+  const json = (await response.json()) as Record<string, unknown>;
+  return { status: response.status, json };
+}
+
+test("401 when the secret is missing", async () => {
+  const { status, json } = await post({ secretIn: "none" });
+  assert.equal(status, 401);
+  assert.equal(json.ok, false);
+  assert.equal(revalidateTagCalls.length, 0);
+  assert.equal(revalidatePathCalls.length, 0);
+});
+
+test("401 when the secret is wrong", async () => {
+  const { status } = await post({ secretIn: "header", secret: "nope" });
+  assert.equal(status, 401);
+  assert.equal(revalidateTagCalls.length, 0);
+});
+
+test("401 when the secret is supplied only on an unexpected channel", async () => {
+  const { status } = await post({ secretIn: "authorization" });
+  assert.equal(status, 401);
+  assert.equal(revalidateTagCalls.length, 0);
+});
+
+test("header and query secrets are both accepted", async () => {
+  const header = await post({ secretIn: "header" });
+  assert.equal(header.status, 200);
+  assert.equal(header.json.ok, true);
+
+  resetRevalidateCalls();
+
+  const query = await post({ secretIn: "query" });
+  assert.equal(query.status, 200);
+  assert.equal(query.json.ok, true);
+});
+
+test("body secret is accepted the same way as header and query", async () => {
+  const { status, json } = await post({ secretIn: "body" });
+  assert.equal(status, 200);
+  assert.equal(json.ok, true);
+});
+
+test("a malformed or empty JSON body does not 500", async () => {
+  const empty = await post({ secretIn: "query", rawBody: "" });
+  assert.equal(empty.status, 200);
+
+  resetRevalidateCalls();
+
+  const malformed = await post({ secretIn: "header", rawBody: "{not-json" });
+  assert.equal(malformed.status, 200);
+});
+
+test("revalidateTag(strapi, max) is called exactly once per accepted request", async () => {
+  await post({ secretIn: "header" });
+  assert.deepEqual(revalidateTagCalls, [{ tag: "strapi", profile: "max" }]);
+});
+
+test("collectPaths maps a Strapi article publish payload to the expected path set", async () => {
+  const { json } = await post({
+    secretIn: "header",
+    body: {
+      event: "entry.publish",
+      model: "article",
+      entry: { slug: "ssr-visibility-fixture" },
+    },
+  });
+
+  const revalidated = json.revalidated as string[];
+  for (const path of [
+    "/",
+    "/blog",
+    "/sitemap.xml",
+    "/robots.txt",
+    "/author/[slug]",
+    "/blog/[slug]",
+    "/blog/page/[page]",
+    "/blog/category/[slug]",
+    "/blog/tag/[slug]",
+    "/blog/ssr-visibility-fixture",
+  ]) {
+    assert.ok(revalidated.includes(path), `missing ${path}`);
+  }
+});
+
+test("bracketed dynamic paths take the page type; everything else is typeless", async () => {
+  await post({ secretIn: "header" });
+
+  const pageTyped = revalidatePathCalls
+    .filter((call) => call.type === "page")
+    .map((call) => call.path)
+    .sort();
+  const typeless = revalidatePathCalls
+    .filter((call) => call.type === undefined)
+    .map((call) => call.path)
+    .sort();
+
+  assert.deepEqual(pageTyped, [
+    "/author/[slug]",
+    "/blog/[slug]",
+    "/blog/category/[slug]",
+    "/blog/page/[page]",
+    "/blog/tag/[slug]",
+  ]);
+
+  assert.ok(typeless.includes("/sitemap.xml"));
+  assert.ok(typeless.includes("/"));
+  assert.ok(typeless.includes("/blog"));
+  assert.ok(!typeless.some((path) => path.includes("[") && path.includes("]")));
+  assert.ok(!pageTyped.includes("/sitemap.xml"));
+});

--- a/apps/web/tests/revalidate-route-behavior.test.ts
+++ b/apps/web/tests/revalidate-route-behavior.test.ts
@@ -144,6 +144,30 @@ test("collectPaths maps a Strapi article publish payload to the expected path se
   }
 });
 
+test("collectPaths maps category, tag, and author publish payloads to their canonical URLs", async () => {
+  const category = await post({
+    secretIn: "header",
+    body: { model: "category", entry: { slug: "ai-engineering" } },
+  });
+  assert.ok(
+    (category.json.revalidated as string[]).includes("/blog/category/ai-engineering")
+  );
+
+  resetRevalidateCalls();
+  const tag = await post({
+    secretIn: "header",
+    body: { model: "tag", entry: { slug: "llms" } },
+  });
+  assert.ok((tag.json.revalidated as string[]).includes("/blog/tag/llms"));
+
+  resetRevalidateCalls();
+  const author = await post({
+    secretIn: "header",
+    body: { model: "author", entry: { slug: "mehdi-zare" } },
+  });
+  assert.ok((author.json.revalidated as string[]).includes("/author/mehdi-zare"));
+});
+
 test("bracketed dynamic paths take the page type; everything else is typeless", async () => {
   await post({ secretIn: "header" });
 

--- a/apps/web/tests/revalidate-route-unconfigured.test.ts
+++ b/apps/web/tests/revalidate-route-unconfigured.test.ts
@@ -1,0 +1,37 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+// Own process: serverEnv freezes REVALIDATE_SECRET at import. The configured
+// webhook lives in revalidate-route-behavior.test.ts.
+
+delete process.env.REVALIDATE_SECRET;
+delete process.env.STRAPI_WEBHOOK_SECRET;
+process.env.DISABLE_STRAPI_CMS = "true";
+
+const { POST } = await import("../src/app/api/revalidate/route.ts");
+const {
+  revalidateTagCalls,
+  resetRevalidateCalls,
+}: {
+  revalidateTagCalls: Array<{ tag: string; profile?: string }>;
+  resetRevalidateCalls: () => void;
+} = await import("./next-cache-stub.mjs");
+
+test("500 when REVALIDATE_SECRET is not configured, even with a matching request secret", async () => {
+  resetRevalidateCalls();
+  const response = await POST(
+    new Request("https://www.mehdi-zare.com/api/revalidate", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-revalidate-secret": "anything",
+      },
+      body: "{}",
+    })
+  );
+
+  assert.equal(response.status, 500);
+  const json = (await response.json()) as { ok: boolean };
+  assert.equal(json.ok, false);
+  assert.equal(revalidateTagCalls.length, 0);
+});

--- a/apps/web/tests/revalidate-route.test.ts
+++ b/apps/web/tests/revalidate-route.test.ts
@@ -19,9 +19,10 @@ import { resolve } from "node:path";
 // registers. A dynamic *page* route is the opposite case: `/blog/[slug]`
 // registers `_N_T_/blog/[slug]/page`, so it does need the type.
 //
-// This is a source contract rather than a behavioural test because the route
-// cannot be loaded by this runner: it imports `next/cache`, which plain Node
-// cannot resolve through Next's exports map. Making it renderable is #115.
+// Source contract for the silent-type bug. Behavioural coverage of POST
+// (auth, collectPaths, the two revalidatePath types) is in
+// revalidate-route-behavior.test.ts, which loads the route through a
+// next/cache stub (#115).
 
 const source = readFileSync(resolve(process.cwd(), "src/app/api/revalidate/route.ts"), "utf8");
 

--- a/apps/web/tests/site-identity-consistency.test.ts
+++ b/apps/web/tests/site-identity-consistency.test.ts
@@ -2,7 +2,6 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import ts from "typescript";
 
 import {
   DEFAULT_SITE_PROFILE,
@@ -10,41 +9,25 @@ import {
 } from "../src/lib/site-profile-defaults.ts";
 import { fallbackExperiences } from "../src/content/fallbacks/about.ts";
 
-// Site identity copy lives in three hand-maintained places (#93):
+// Site identity copy that the live site actually reads lives in two places:
 //
 //   data/taxonomy.json                     the primary author record, written
 //                                          to Strapi verbatim by the seed
-//   apps/cms/scripts/seed.ts               the inline `siteSettings` block,
-//                                          seeded into the `site-setting` type
 //   apps/web/src/lib/site-profile-defaults  DEFAULT_SITE_PROFILE, the runtime
 //                                          fallback apps/web actually reads
 //
-// After #100 the CMS page/site-setting rows are seed-only: web no longer
-// prefers them at runtime. This tripwire still guards seed↔repo drift so a
-// defaults-only edit cannot silently diverge from what the next seed would
-// write (and so reintroducing the round trip would not revive #87). #87 is the
-// proof of that class: a careful one-value change updated two of the three and
-// missed the third, and nothing in the suite caught it.
+// A third copy used to live in apps/cms/scripts/seed.ts as `siteSettings`,
+// seeded into the `site-setting` type. #116 stopped writing that row: web
+// never read it after #112, and seeding it kept a silent-no-op admin surface
+// warm. The tripwire is now taxonomy author ↔ defaults. #87 is still the
+// proof of the class: a careful one-value change updated two of three and
+// missed the third.
 //
-// The previous version of this file enumerated the *location* fields by hand,
-// which left the other ~15 shared literals unguarded and made every new shared
-// field silently exempt. These assertions instead DERIVE the shared key set, so
-// a field added to two sources is covered the day it is added. A key that
-// genuinely lives in only one source has to be named in an exemption list
-// below, with a reason -- that is the only way to opt out.
-//
-// Three is the whole list because the seed's other page literals no longer
-// restate this copy (#101): `homePage`, `aboutPage.positioningStatement` and
-// `consultingPage.subtitle` now read from `siteSettings` instead of repeating
-// it. Do not re-inline them -- they were a fourth and fifth copy that nothing
-// here compared. Only `siteSettings` is read below, and it must stay a flat
-// block of literals for that reader to work.
+// These assertions DERIVE the shared key set, so a field added to both
+// sources is covered the day it is added. A key that genuinely lives in only
+// one source has to be named in an exemption list below, with a reason.
 
 const repoRoot = resolve(process.cwd(), "../..");
-
-// ---------------------------------------------------------------------------
-// Source 1: data/taxonomy.json
-// ---------------------------------------------------------------------------
 
 interface TaxonomyAuthor {
   isPrimary?: boolean;
@@ -55,119 +38,8 @@ const taxonomy = JSON.parse(
   readFileSync(resolve(repoRoot, "data/taxonomy.json"), "utf8")
 ) as { authors: TaxonomyAuthor[] };
 
-// Mirrors the primary-author rule in apps/cms/scripts/seed.ts so this test
-// tracks whichever record the seed actually writes.
 const primaryAuthor =
   taxonomy.authors.find((author) => author.isPrimary) ?? taxonomy.authors[0];
-
-// ---------------------------------------------------------------------------
-// Source 2: the `siteSettings` object literal in apps/cms/scripts/seed.ts
-// ---------------------------------------------------------------------------
-
-const SEED_PATH = resolve(repoRoot, "apps/cms/scripts/seed.ts");
-
-/**
- * Evaluates a literal AST node. Deliberately total-or-throw: anything that is
- * not a plain literal (a computed value, a spread, an identifier reference)
- * means the seed stopped being a flat block of copy, and this test should say
- * so loudly rather than quietly skipping the key.
- */
-function literalValue(node: ts.Node, source: ts.SourceFile): unknown {
-  if (ts.isStringLiteral(node) || ts.isNoSubstitutionTemplateLiteral(node)) {
-    return node.text;
-  }
-  if (ts.isNumericLiteral(node)) {
-    return Number(node.text);
-  }
-  if (node.kind === ts.SyntaxKind.TrueKeyword) return true;
-  if (node.kind === ts.SyntaxKind.FalseKeyword) return false;
-  if (node.kind === ts.SyntaxKind.NullKeyword) return null;
-  if (ts.isArrayLiteralExpression(node)) {
-    return node.elements.map((element) => literalValue(element, source));
-  }
-  if (ts.isObjectLiteralExpression(node)) {
-    return objectLiteralValue(node, source);
-  }
-
-  throw new Error(
-    `apps/cms/scripts/seed.ts: siteSettings contains a non-literal value (${
-      ts.SyntaxKind[node.kind]
-    }: ${node.getText(source)}). This tripwire compares literals; teach it the new shape rather than removing the key.`
-  );
-}
-
-function objectLiteralValue(
-  node: ts.ObjectLiteralExpression,
-  source: ts.SourceFile
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const property of node.properties) {
-    assert.ok(
-      ts.isPropertyAssignment(property),
-      `apps/cms/scripts/seed.ts: expected a plain property assignment, got ${
-        ts.SyntaxKind[property.kind]
-      }`
-    );
-    const key = ts.isIdentifier(property.name)
-      ? property.name.text
-      : ts.isStringLiteral(property.name)
-        ? property.name.text
-        : null;
-    assert.ok(key, "apps/cms/scripts/seed.ts: computed keys are not supported here");
-    result[key] = literalValue(property.initializer, source);
-  }
-  return result;
-}
-
-function readSeedSiteSettings(): Record<string, unknown> {
-  const sourceText = readFileSync(SEED_PATH, "utf8");
-  const source = ts.createSourceFile(
-    "seed.ts",
-    sourceText,
-    ts.ScriptTarget.ES2022,
-    true
-  );
-
-  let literal: ts.ObjectLiteralExpression | null = null;
-  const visit = (node: ts.Node): void => {
-    if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.name.text === "siteSettings" &&
-      node.initializer &&
-      ts.isObjectLiteralExpression(node.initializer)
-    ) {
-      literal = node.initializer;
-    }
-    ts.forEachChild(node, visit);
-  };
-  visit(source);
-
-  assert.ok(
-    literal,
-    "apps/cms/scripts/seed.ts: expected a `const siteSettings = { … }` object literal"
-  );
-  return objectLiteralValue(literal, source);
-}
-
-const seedSettings = readSeedSiteSettings();
-
-// ---------------------------------------------------------------------------
-// Exemptions -- the only way a shared-looking key opts out
-// ---------------------------------------------------------------------------
-
-/** Keys in the seed's siteSettings with no DEFAULT_SITE_PROFILE counterpart. */
-const SEED_ONLY_KEYS = new Set<string>([]);
-
-/**
- * Keys present in both sources whose *shapes* legitimately differ, so a deep
- * comparison would fail on structure rather than on copy: the web defaults
- * carry `id` / `order` / `external` that the CMS assigns and the seed does not
- * write. Each has a dedicated test below comparing the fields that do
- * round-trip. This is an exemption from the comparison *method*, not from
- * being compared at all.
- */
-const STRUCTURED_KEYS = new Set(["navItems", "socialLinks"]);
 
 /**
  * Keys on the taxonomy author with no DEFAULT_SITE_PROFILE counterpart, and
@@ -231,45 +103,6 @@ function defaultsKeyFor(authorKey: string): string | undefined {
 
 const defaults = DEFAULT_SITE_PROFILE as unknown as Record<string, unknown>;
 
-// ---------------------------------------------------------------------------
-// seed siteSettings <-> DEFAULT_SITE_PROFILE
-// ---------------------------------------------------------------------------
-
-test("every key the seed and the web defaults share carries the same value", () => {
-  const shared = Object.keys(seedSettings).filter(
-    (key) => key in defaults && !STRUCTURED_KEYS.has(key)
-  );
-
-  assert.ok(
-    shared.length >= 18,
-    `expected the seed and the defaults to share the site identity copy, found only ${shared.length} shared keys (${shared.join(", ")}) -- a rename that empties this set would otherwise make the tripwire vacuous`
-  );
-
-  for (const key of shared) {
-    assert.deepEqual(
-      seedSettings[key],
-      defaults[key],
-      `${key} disagrees between apps/cms/scripts/seed.ts and site-profile-defaults.ts. The CMS copy wins at runtime, so this ships as a page that contradicts its own structured data (#93).`
-    );
-  }
-});
-
-test("a seed siteSettings key with no defaults counterpart is declared, not silent", () => {
-  const unmatched = Object.keys(seedSettings).filter(
-    (key) => !(key in defaults) && !SEED_ONLY_KEYS.has(key)
-  );
-
-  assert.deepEqual(
-    unmatched,
-    [],
-    `these seed siteSettings keys have no DEFAULT_SITE_PROFILE counterpart: ${unmatched.join(", ")}. Either add the counterpart so the value is guarded, or name the key in SEED_ONLY_KEYS with a reason.`
-  );
-});
-
-// ---------------------------------------------------------------------------
-// taxonomy author <-> DEFAULT_SITE_PROFILE
-// ---------------------------------------------------------------------------
-
 test("every taxonomy author field with a defaults counterpart carries the same value", () => {
   assert.ok(primaryAuthor, "data/taxonomy.json: expected a primary author");
 
@@ -292,10 +125,6 @@ test("every taxonomy author field with a defaults counterpart carries the same v
     );
   }
 
-  // A floor with slack (">= 12" against 13) lets one field leave the compared
-  // set unnoticed, which is the same silent-exemption hole the exemption lists
-  // exist to close. Naming the set means a deletion on either side, or a
-  // rename that drops a key out of the mapping, has to be declared here.
   assert.deepEqual(
     [...compared].sort(),
     [...COMPARED_AUTHOR_KEYS].sort(),
@@ -321,27 +150,9 @@ test("declared exemptions still exist, so the lists cannot rot into noise", () =
       key in primaryAuthor,
       `AUTHOR_ONLY_KEYS names "${key}", which is no longer a taxonomy author field -- drop it`
     );
-    // The author loop consults AUTHOR_ONLY_KEYS *before* defaultsKeyFor, so an
-    // exemption that later gains a counterpart shadows it forever -- the field
-    // becomes duplicated copy that nothing compares. The seed half has no
-    // equivalent hole, because its shared-key set is derived without consulting
-    // SEED_ONLY_KEYS at all. Without this, "covered the day it is added" is
-    // only true for keys nobody ever exempted.
     assert.ok(
       !defaultsKeyFor(key),
       `AUTHOR_ONLY_KEYS exempts "${key}", but DEFAULT_SITE_PROFILE now has a counterpart (${defaultsKeyFor(key)}) -- drop the exemption so the value is compared`
-    );
-  }
-  for (const key of SEED_ONLY_KEYS) {
-    assert.ok(
-      key in seedSettings,
-      `SEED_ONLY_KEYS names "${key}", which is no longer a seed siteSettings key -- drop it`
-    );
-  }
-  for (const key of STRUCTURED_KEYS) {
-    assert.ok(
-      key in seedSettings && key in defaults,
-      `STRUCTURED_KEYS names "${key}", which is no longer shared by both sources -- drop it, or its dedicated test is guarding nothing`
     );
   }
   for (const [authorKey, defaultsKey] of AUTHOR_KEY_ALIASES) {
@@ -356,63 +167,27 @@ test("declared exemptions still exist, so the lists cannot rot into noise", () =
   }
 });
 
-// ---------------------------------------------------------------------------
-// The social links, which use a different key name in each source
-// ---------------------------------------------------------------------------
-
 function platformUrlPairs(
   links: ReadonlyArray<{ platform?: unknown; url?: unknown }>
 ): Array<{ platform: unknown; url: unknown }> {
   return links.map((link) => ({ platform: link.platform, url: link.url }));
 }
 
-test("the social links agree across all three sources", () => {
-  // `sameAs` on the author, `socialLinks` in the seed's siteSettings, and
-  // DEFAULT_SOCIAL_LINKS on the web side are the same five pairs written out
-  // three times. The key names differ, so the derived intersection above
-  // cannot see them.
+test("the social links agree between the taxonomy author and the web defaults", () => {
   const fromDefaults = platformUrlPairs(DEFAULT_SOCIAL_LINKS);
-  const fromSeed = platformUrlPairs(
-    seedSettings.socialLinks as Array<{ platform?: unknown; url?: unknown }>
-  );
   const fromTaxonomy = platformUrlPairs(
     primaryAuthor.sameAs as Array<{ platform?: unknown; url?: unknown }>
   );
 
-  assert.deepEqual(fromSeed, fromDefaults);
   assert.deepEqual(fromTaxonomy, fromDefaults);
 });
 
-test("the nav items agree between the seed and the web defaults", () => {
-  // DEFAULT_NAV_ITEMS carries id/order/external that the seed does not, so
-  // compare the label/href pairs the CMS actually round-trips.
-  const seedNav = (
-    seedSettings.navItems as Array<{ label?: unknown; href?: unknown }>
-  ).map((item) => ({ label: item.label, href: item.href }));
-  const defaultNav = DEFAULT_SITE_PROFILE.navItems.map((item) => ({
-    label: item.label,
-    href: item.href,
-  }));
-
-  assert.deepEqual(seedNav, defaultNav);
-});
-
-// ---------------------------------------------------------------------------
-// Derived relationships within the defaults
-// ---------------------------------------------------------------------------
-
 test("the footer location line matches the structured address defaults", () => {
-  // Not a duplication across sources -- a composition within one. The footer
-  // string and the PostalAddress fields have to describe the same place.
   assert.equal(
     DEFAULT_SITE_PROFILE.locationLine,
     `${DEFAULT_SITE_PROFILE.authorAddressLocality}, ${DEFAULT_SITE_PROFILE.authorAddressRegion}`
   );
 });
-
-// ---------------------------------------------------------------------------
-// Visible current-employer copies (#105)
-// ---------------------------------------------------------------------------
 
 test("the current employer name agrees across visible copies and structured data (#105)", () => {
   assert.ok(primaryAuthor, "data/taxonomy.json: expected a primary author");
@@ -432,13 +207,6 @@ test("the current employer name agrees across visible copies and structured data
     trackRecordSource,
     /DEFAULT_SITE_PROFILE\.authorWorksForName/,
     "TrackRecord must source the current employer from DEFAULT_SITE_PROFILE.authorWorksForName, not a hardcoded literal"
-  );
-
-  const seedSource = readFileSync(SEED_PATH, "utf8");
-  assert.match(
-    seedSource,
-    /company:\s*primaryAuthor\.worksForName/,
-    "the seed's current experience company must read from taxonomy via primaryAuthor.worksForName"
   );
 
   assert.equal(

--- a/apps/web/tests/site-profile-social-normalization.test.ts
+++ b/apps/web/tests/site-profile-social-normalization.test.ts
@@ -25,7 +25,7 @@ const canonicalAuthor = {
 };
 
 test("site profile normalizes and dedupes canonical identity URLs", () => {
-  const profile = normalizeSiteProfile(undefined, {
+  const profile = normalizeSiteProfile({
     author: canonicalAuthor,
   });
 
@@ -46,7 +46,7 @@ test("site profile normalizes and dedupes canonical identity URLs", () => {
 });
 
 test("site profile provides stable geo fallback fields for author", () => {
-  const profile = normalizeSiteProfile(undefined, {
+  const profile = normalizeSiteProfile({
     author: canonicalAuthor,
   });
 
@@ -60,7 +60,7 @@ test("site profile provides stable geo fallback fields for author", () => {
 // pin that precedence, or a defaults-only edit looks like it changed the site
 // when it did not.
 test("site profile prefers a CMS author address over the geo fallback", () => {
-  const profile = normalizeSiteProfile(undefined, {
+  const profile = normalizeSiteProfile({
     author: {
       ...canonicalAuthor,
       addressLocality: "Austin",
@@ -80,7 +80,7 @@ test("site profile prefers a CMS author address over the geo fallback", () => {
 // side rather than only on the resolver: without it, `buildAuthorProfile` can
 // quietly stop delegating and nothing fails.
 test("a partial CMS address is not completed from the geo fallback (#102)", () => {
-  const profile = normalizeSiteProfile(undefined, {
+  const profile = normalizeSiteProfile({
     author: {
       ...canonicalAuthor,
       addressLocality: "Berlin",
@@ -109,7 +109,7 @@ test("the site profile and /author/[slug] resolve the same address (#102)", () =
     addressCountry: "DE",
   };
 
-  const profile = normalizeSiteProfile(undefined, { author });
+  const profile = normalizeSiteProfile({ author });
   const routeAddress = resolveAuthorAddress(author, {
     slug: DEFAULT_SITE_PROFILE.authorSlug,
     addressLocality: DEFAULT_SITE_PROFILE.authorAddressLocality,
@@ -129,7 +129,7 @@ test("the site profile and /author/[slug] resolve the same address (#102)", () =
 });
 
 test("a partial CMS worksFor is not completed from the employer fallback (#106)", () => {
-  const profile = normalizeSiteProfile(undefined, {
+  const profile = normalizeSiteProfile({
     author: {
       ...canonicalAuthor,
       worksForName: "Entarian",
@@ -152,7 +152,7 @@ test("the site profile and /author/[slug] resolve the same worksFor (#106)", () 
     worksForUrl: "",
   };
 
-  const profile = normalizeSiteProfile(undefined, { author });
+  const profile = normalizeSiteProfile({ author });
   const routeWorksFor = resolveAuthorWorksFor(author, {
     slug: DEFAULT_SITE_PROFILE.authorSlug,
     worksForName: DEFAULT_SITE_PROFILE.authorWorksForName,

--- a/apps/web/tests/site-profile.test.ts
+++ b/apps/web/tests/site-profile.test.ts
@@ -14,11 +14,10 @@ test("Site Profile enforces a required field contract", () => {
 });
 
 test("Site Profile keeps strict validation opt-in per call, never ambient", () => {
-  // #100 took the `site-setting` row out of the read path, so production passes
-  // `settings` as `undefined`. An ambient `SITE_PROFILE_STRICT=true` would find
-  // every required field missing and throw on every request, so the env switch
-  // is gone and must not come back. `options.strict` still validates settings a
-  // caller hands over.
+  // #100 took the `site-setting` row out of the read path. An ambient
+  // `SITE_PROFILE_STRICT=true` would have thrown on every request, so the env
+  // switch is gone and must not come back. `options.strict` still validates
+  // the resolved profile.
   // Asserted on `process.env` rather than on the variable name, so that naming
   // the retired switch in a comment does not trip the guard that removed it.
   assert.doesNotMatch(source, /process\.env/);
@@ -26,7 +25,8 @@ test("Site Profile keeps strict validation opt-in per call, never ambient", () =
   assert.match(source, /SiteProfileValidationError/);
 });
 
-test("Site Profile keeps non-strict fallback behavior", () => {
-  assert.match(source, /return mergeProfile\(undefined/);
-  assert.match(source, /return mergeProfile\(settings\)/);
+test("Site Profile no longer merges a CMS site-setting row (#116)", () => {
+  assert.doesNotMatch(source, /settings\?\.siteName/);
+  assert.doesNotMatch(source, /SiteSettings/);
+  assert.match(source, /return mergeProfile\(options\.author\)/);
 });


### PR DESCRIPTION
Follow-up from the remaining open board after #112 / #108 / #118.

## #114
CI builds with `DISABLE_STRAPI_CMS=true`, so article/author/category/tag templates were never in the post-build SSR-visibility scan. A committed fixture catalog now prerenders:

- `/blog/ssr-visibility-fixture`
- `/author/mehdi-zare`
- `/blog/category/ai-engineering` (taxonomy seed)
- `/blog/tag/llms` (taxonomy seed)

Those paths are in `ALWAYS_PRERENDERED`. Shared reveal components stay covered by the repo-owned pages.

## #115
`/api/revalidate` had source-contract tests only (the silent `revalidatePath` type). A `next/cache` stub makes `POST` loadable. Behavioural tests cover 401 channels, empty/malformed bodies, `revalidateTag("strapi", "max")` once, article path mapping, and page vs typeless `revalidatePath`. A separate file covers 500 when the server secret is unset.

## #116
`seed.ts` no longer writes `home-page`, `about-page`, `consulting-page`, `bina-print-page`, or `site-setting`. Strapi types stay so those tables are not dropped. `mergeProfile` is repo defaults plus the CMS author; there is no site-setting merge path left. Unused page/site-setting TypeScript interfaces are gone from `apps/web`.

## Out of scope
#109 is closed separately (`not_planned`): Entarian stays as the public current employer. Sev1Tech / CISA / DHS were already gone from live pages.

## Verification
- `pnpm typecheck`
- `pnpm --filter=web test`
- `pnpm --filter=web lint`
- CMS-off `next build` (fixture routes prerendered as 200s)
- `pnpm --filter=web test:postbuild`

Closes #114
Closes #115
Closes #116