### PR TITLE
test(web): prerender /blog/page/2 in CMS-off CI

### DIFF
--- a/apps/web/src/app/blog/page/[page]/page.tsx
+++ b/apps/web/src/app/blog/page/[page]/page.tsx
@@ -9,6 +9,8 @@ import {
 } from "@/lib/blog-listing";
 import { getSiteProfile } from "@/lib/site-profile";
 import { getArticles } from "@/lib/strapi";
+import { serverEnv } from "@/lib/server-env";
+import { CMS_PRERENDER_BLOG_PAGE } from "@/content/fixtures/cms-prerender";
 import { buildNoIndexMetadata, buildPageMetadata, toPersonId } from "@/lib/seo";
 
 interface BlogArchivePageProps {
@@ -16,6 +18,10 @@ interface BlogArchivePageProps {
 }
 
 export async function generateStaticParams(): Promise<Array<{ page: string }>> {
+  if (serverEnv.strapiDisabled) {
+    return [{ page: CMS_PRERENDER_BLOG_PAGE }];
+  }
+
   try {
     const firstPage = await getArticles({
       pagination: {

--- a/apps/web/src/content/fixtures/cms-prerender.ts
+++ b/apps/web/src/content/fixtures/cms-prerender.ts
@@ -3,24 +3,30 @@ import { DEFAULT_SITE_PROFILE, DEFAULT_SOCIAL_LINKS } from "@/lib/site-profile-d
 
 /**
  * Tiny CMS catalog used when `DISABLE_STRAPI_CMS=true` so CI's post-build
- * SSR-visibility scan can see article / author / category / tag templates
- * (#114). Production builds with Strapi reachable never consult this file.
+ * SSR-visibility scan can see article / author / category / tag / pagination
+ * templates (#114, #120). Production builds with Strapi reachable never
+ * consult this file. A Strapi outage (CMS on, fetch failing) still returns
+ * empty `generateStaticParams`, so these paths are not published by accident.
  *
  * Keep this set small. Category and tag pages already fall back to
  * `data/taxonomy.json` once `generateStaticParams` emits a slug; the article
- * and author templates have no seed fallback and need a full record.
+ * and author templates have no seed fallback and need a full record. Pagination
+ * reuses `BlogListPageContent`; the extra route is so that template is scanned.
  */
 
 export const CMS_PRERENDER_ARTICLE_SLUG = "ssr-visibility-fixture";
 export const CMS_PRERENDER_AUTHOR_SLUG = DEFAULT_SITE_PROFILE.authorSlug;
 export const CMS_PRERENDER_CATEGORY_SLUG = "ai-engineering";
 export const CMS_PRERENDER_TAG_SLUG = "llms";
+/** Pagination segment only. `/blog/page/1` redirects to `/blog`. */
+export const CMS_PRERENDER_BLOG_PAGE = "2";
 
 export const CMS_PRERENDER_HTML_FILES = [
   `blog/${CMS_PRERENDER_ARTICLE_SLUG}.html`,
   `author/${CMS_PRERENDER_AUTHOR_SLUG}.html`,
   `blog/category/${CMS_PRERENDER_CATEGORY_SLUG}.html`,
   `blog/tag/${CMS_PRERENDER_TAG_SLUG}.html`,
+  `blog/page/${CMS_PRERENDER_BLOG_PAGE}.html`,
 ] as const;
 
 const STAMP = "2026-01-15T12:00:00.000Z";

--- a/apps/web/tests/cms-prerender.test.ts
+++ b/apps/web/tests/cms-prerender.test.ts
@@ -10,6 +10,7 @@ import {
   CMS_PRERENDER_AUTHOR,
   CMS_PRERENDER_AUTHOR_SLUG,
   CMS_PRERENDER_CATEGORY_SLUG,
+  CMS_PRERENDER_BLOG_PAGE,
   CMS_PRERENDER_HTML_FILES,
   CMS_PRERENDER_TAG_SLUG,
   findCmsPrerenderArticle,
@@ -25,6 +26,7 @@ test("the prerender fixture slugs match the records and the HTML list", () => {
       `author/${CMS_PRERENDER_AUTHOR_SLUG}.html`,
       `blog/${CMS_PRERENDER_ARTICLE_SLUG}.html`,
       `blog/category/${CMS_PRERENDER_CATEGORY_SLUG}.html`,
+      `blog/page/${CMS_PRERENDER_BLOG_PAGE}.html`,
       `blog/tag/${CMS_PRERENDER_TAG_SLUG}.html`,
     ].sort()
   );
@@ -67,6 +69,11 @@ test("finders return the fixture for its slug and nothing else", () => {
   assert.equal(findCmsPrerenderAuthor("guest-author"), undefined);
 });
 
+test("the pagination fixture is page 2, not the /blog redirect", () => {
+  assert.equal(CMS_PRERENDER_BLOG_PAGE, "2");
+  assert.notEqual(CMS_PRERENDER_BLOG_PAGE, "1");
+});
+
 test("the fake article slug is noindex so a CMS-off public deploy cannot rank it", () => {
   assert.match(
     CMS_PRERENDER_ARTICLE.seo?.metaRobots ?? "",
@@ -81,6 +88,7 @@ test("CMS-off generateStaticParams emits the fixture slugs", () => {
     { file: "src/app/author/[slug]/page.tsx", slug: "CMS_PRERENDER_AUTHOR_SLUG" },
     { file: "src/app/blog/category/[slug]/page.tsx", slug: "CMS_PRERENDER_CATEGORY_SLUG" },
     { file: "src/app/blog/tag/[slug]/page.tsx", slug: "CMS_PRERENDER_TAG_SLUG" },
+    { file: "src/app/blog/page/[page]/page.tsx", slug: "CMS_PRERENDER_BLOG_PAGE" },
   ];
 
   for (const { file, slug } of pages) {

--- a/apps/web/tests/post-build/ssr-visibility.test.ts
+++ b/apps/web/tests/post-build/ssr-visibility.test.ts
@@ -27,7 +27,8 @@ import { CMS_PRERENDER_HTML_FILES } from "../../src/content/fixtures/cms-prerend
 // CI builds with DISABLE_STRAPI_CMS=true. Article/author templates have no
 // seed fallback, so a committed fixture catalog prerenders one of each
 // (#114). Category/tag pages render from data/taxonomy.json once
-// generateStaticParams emits those fixture slugs.
+// generateStaticParams emits those fixture slugs. Pagination is the same
+// catalog: CMS-off generateStaticParams emits `/blog/page/2` (#120).
 
 const BUILD_DIR = resolve(import.meta.dirname, "../../.next/server/app");
 


### PR DESCRIPTION
Follow-up from #119 / #114.

CMS-off CI now prerenders article, author, category, and tag templates. `/blog/page/[page]` was still absent. That template mostly reuses `BlogListPageContent` (already scanned via `/blog.html`); this adds page 2 so the archive route itself is in the SSR-visibility scan.

`generateStaticParams` emits `{ page: \"2\" }` only when `DISABLE_STRAPI_CMS=true`. A Strapi outage with the CMS still enabled returns no pagination paths, so a failed fetch cannot publish a fake `/blog/page/2`. Pagination pages are already `noindex`.

Verified: typecheck, web tests, CMS-off `next build` lists `● /blog/page/2`, post-build scan green.

Closes #120