### PR TITLE
chore(cms): wipe dist when regenerating types

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,10 @@
 
 Run `pnpm typecheck` (Turbo) or `pnpm --filter=<pkg> typecheck`. Never `pnpm --filter=* exec tsc` — in this repo that can re-run install and rewrite `pnpm-lock.yaml`. Do not add `typescript` as a root devDependency; each package that typechecks already has it.
 
+## CMS generated types
+
+Regenerate with `pnpm --filter=cms generate-types`. That script wipes `apps/cms/dist` first. Running `strapi ts:generate-types` against a leftover dist reintroduces the retired page single-types (#121 / #125 / #128).
+
 ## Content ownership
 
 The repo and the CMS each own part of the site, and the split is not obvious

--- a/apps/cms/README.md
+++ b/apps/cms/README.md
@@ -7,6 +7,7 @@ Strapi 5 backend that powers site content and contact submissions.
 - `pnpm --filter=cms dev`
 - `pnpm --filter=cms build`
 - `pnpm --filter=cms start`
+- `pnpm --filter=cms generate-types` (wipes `dist`, then `strapi ts:generate-types`)
 - `task docker:build:cms` (image build from the repo root)
 
 ## Docker / Corepack pnpm pin

--- a/apps/cms/package.json
+++ b/apps/cms/package.json
@@ -12,6 +12,7 @@
     "start": "strapi start",
     "strapi": "strapi",
     "typecheck": "tsc --noEmit",
+    "generate-types": "rm -rf dist && strapi ts:generate-types",
     "seed": "npx tsx scripts/seed.ts",
     "upgrade": "npx @strapi/upgrade latest",
     "upgrade:dry": "npx @strapi/upgrade latest --dry",

--- a/apps/web/tests/cms-generated-schema-lock.test.ts
+++ b/apps/web/tests/cms-generated-schema-lock.test.ts
@@ -1,21 +1,46 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readdirSync, readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { relative, resolve } from "node:path";
 
-// #125. Generated contentTypes.d.ts omitted category/tag schema fields
-// (parent/children/order/headline/intro/seo, and tag description/headline/
-// intro/seo). Lock schema.json attributes onto the generated interface so a
-// later regen cannot silently drop them.
+// #125 / #128 / #130. Generated contentTypes.d.ts omitted category/tag schema
+// fields. Lock every custom API and component schema attribute — name and
+// Schema.Attribute kind — onto the generated interface so a later regen cannot
+// silently drop or retitle them. Glob schema.json under src/api so a second
+// content-type folder cannot go unlocked.
 //
-// `strapi ts:generate-types` must run after wiping apps/cms/dist; a stale
-// dist reintroduces the retired page single-types.
+// Regenerate with `pnpm --filter=cms generate-types`. That script wipes
+// apps/cms/dist first; a leftover dist reintroduces the retired page
+// single-types (#121 / #128).
 
 const cmsRoot = resolve(process.cwd(), "../../apps/cms");
 
 const knownGaps = {
   category: ["parent", "children", "order", "headline", "intro", "seo"],
   tag: ["description", "headline", "intro", "seo"],
+};
+
+const SCHEMA_ATTRIBUTE_KIND: Record<string, string> = {
+  biginteger: "BigInteger",
+  blocks: "Blocks",
+  boolean: "Boolean",
+  component: "Component",
+  date: "Date",
+  datetime: "DateTime",
+  decimal: "Decimal",
+  email: "Email",
+  enumeration: "Enumeration",
+  float: "Float",
+  integer: "Integer",
+  json: "JSON",
+  media: "Media",
+  password: "Password",
+  relation: "Relation",
+  richtext: "RichText",
+  string: "String",
+  text: "Text",
+  time: "Time",
+  uid: "UID",
 };
 
 function pascal(name: string) {
@@ -25,23 +50,49 @@ function pascal(name: string) {
     .join("");
 }
 
-function apiNames() {
-  return readdirSync(resolve(cmsRoot, "src/api"), { withFileTypes: true })
-    .filter((entry) => entry.isDirectory())
-    .map((entry) => entry.name);
+function* filesNamed(dir: string, fileName: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* filesNamed(path, fileName);
+      continue;
+    }
+    if (entry.name === fileName) {
+      yield path;
+    }
+  }
+}
+
+function* jsonFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = resolve(dir, entry.name);
+    if (entry.isDirectory()) {
+      yield* jsonFiles(path);
+      continue;
+    }
+    if (entry.name.endsWith(".json")) {
+      yield path;
+    }
+  }
+}
+
+function schemaAttributes(schemaPath: string) {
+  const schema = JSON.parse(readFileSync(schemaPath, "utf8")) as {
+    attributes?: Record<string, { type?: string }>;
+  };
+  assert.ok(schema.attributes, `${schemaPath} has no attributes`);
+  return schema.attributes;
 }
 
 function schemaAttributeNames(apiName: string) {
-  const schema = JSON.parse(
-    readFileSync(
+  return Object.keys(
+    schemaAttributes(
       resolve(
         cmsRoot,
         `src/api/${apiName}/content-types/${apiName}/schema.json`,
       ),
-      "utf8",
     ),
-  ) as { attributes: Record<string, unknown> };
-  return Object.keys(schema.attributes);
+  );
 }
 
 function interfaceBody(source: string, name: string) {
@@ -59,25 +110,91 @@ function attributesBlock(body: string) {
   return body.slice(idx);
 }
 
-test("every schema.json attribute appears on the generated content type", () => {
+function assertAttributesMatch(
+  attrs: string,
+  attributes: Record<string, { type?: string }>,
+  source: string,
+) {
+  for (const [field, spec] of Object.entries(attributes)) {
+    const type = spec.type ?? "";
+    const kind = SCHEMA_ATTRIBUTE_KIND[type];
+    assert.ok(
+      kind,
+      `${source} field "${field}" has unknown schema type "${type}"`,
+    );
+    assert.ok(
+      attrs.includes(`\n    ${field}: Schema.Attribute.${kind}`),
+      `${source} field "${field}" missing Schema.Attribute.${kind} on the generated interface`,
+    );
+  }
+}
+
+test("cms generate-types wipes dist before strapi ts:generate-types", () => {
+  const pkg = JSON.parse(
+    readFileSync(resolve(cmsRoot, "package.json"), "utf8"),
+  ) as { scripts?: Record<string, string> };
+  assert.equal(
+    pkg.scripts?.["generate-types"],
+    "rm -rf dist && strapi ts:generate-types",
+    "apps/cms generate-types must wipe dist before strapi ts:generate-types (#128)",
+  );
+});
+
+test("every API schema.json attribute appears with the right kind", () => {
   const source = readFileSync(
     resolve(cmsRoot, "types/generated/contentTypes.d.ts"),
     "utf8",
   );
-  const apis = apiNames();
-  assert.ok(apis.includes("category"), "expected category API");
-  assert.ok(apis.includes("tag"), "expected tag API");
+  const apiRoot = resolve(cmsRoot, "src/api");
+  const schemas = [...filesNamed(apiRoot, "schema.json")];
+  assert.ok(schemas.length > 0, "expected at least one API schema.json");
 
-  for (const apiName of apis) {
-    const fields = schemaAttributeNames(apiName);
-    const interfaceName = `Api${pascal(apiName)}${pascal(apiName)}`;
-    const attrs = attributesBlock(interfaceBody(source, interfaceName));
-    for (const field of fields) {
-      assert.ok(
-        attrs.includes(`\n    ${field}: Schema.Attribute.`),
-        `${apiName} schema field "${field}" missing from ${interfaceName}`,
-      );
-    }
+  for (const schemaPath of schemas) {
+    const rel = relative(apiRoot, schemaPath).split("/");
+    assert.equal(
+      rel[1],
+      "content-types",
+      `unexpected schema path ${relative(cmsRoot, schemaPath)}; expected src/api/<api>/content-types/<type>/schema.json`,
+    );
+    assert.equal(rel[3], "schema.json");
+    const apiName = rel[0];
+    const typeName = rel[2];
+    const interfaceName = `Api${pascal(apiName)}${pascal(typeName)}`;
+    const uid = `api::${apiName}.${typeName}`;
+    assert.ok(
+      source.includes(`'${uid}': ${interfaceName}`),
+      `ContentTypeSchemas missing ${uid}`,
+    );
+    assertAttributesMatch(
+      attributesBlock(interfaceBody(source, interfaceName)),
+      schemaAttributes(schemaPath),
+      uid,
+    );
+  }
+});
+
+test("every component schema attribute appears with the right kind", () => {
+  const source = readFileSync(
+    resolve(cmsRoot, "types/generated/components.d.ts"),
+    "utf8",
+  );
+  const componentsRoot = resolve(cmsRoot, "src/components");
+  const schemas = [...jsonFiles(componentsRoot)];
+  assert.ok(schemas.length > 0, "expected at least one component schema");
+
+  for (const schemaPath of schemas) {
+    const rel = relative(componentsRoot, schemaPath).replace(/\.json$/, "");
+    const uid = rel.split("/").join(".");
+    const interfaceName = rel.split("/").map(pascal).join("");
+    assert.ok(
+      source.includes(`'${uid}': ${interfaceName}`),
+      `ComponentSchemas missing ${uid}`,
+    );
+    assertAttributesMatch(
+      attributesBlock(interfaceBody(source, interfaceName)),
+      schemaAttributes(schemaPath),
+      uid,
+    );
   }
 });
 


### PR DESCRIPTION
Follow-up from #127 / #125. Isolated process + lock; no schema drop.

## Why
`strapi ts:generate-types` against a leftover `apps/cms/dist` reintroduces the retired page single-types. #127 documented that in a comment. There was no default path that wipes dist, and the schema lock only checked attribute *names* on custom APIs.

## Change
- `pnpm --filter=cms generate-types` → `rm -rf dist && strapi ts:generate-types`
- Document in `AGENTS.md` and the CMS README
- Lock the script
- Glob every `src/api/**/schema.json` and `src/components/**/*.json`
- Assert each attribute appears as `Schema.Attribute.<Kind>` (Relation vs String vs Component, not just the name)

Closes #128
Closes #130