### PR TITLE
fix(web): drop phone and company from ContactSubmission

### DIFF
--- a/apps/web/src/lib/strapi.ts
+++ b/apps/web/src/lib/strapi.ts
@@ -4,6 +4,7 @@ import type {
   Category,
   Tag,
   ContactSubmission,
+  ContactSubmissionInput,
   StrapiResponse,
   StrapiCollectionResponse,
 } from "@/types/strapi";
@@ -453,10 +454,7 @@ export async function getTagBySlug(
  * Articles, categories, tags and the author record are still CMS-backed.
  */
 export async function submitContactForm(
-  data: Omit<
-    ContactSubmission,
-    "id" | "documentId" | "createdAt" | "updatedAt" | "publishedAt"
-  >
+  data: ContactSubmissionInput,
 ): Promise<StrapiResponse<ContactSubmission>> {
   const path = "/contact-submissions";
   const url = buildApiUrl(path);

--- a/apps/web/src/types/strapi.ts
+++ b/apps/web/src/types/strapi.ts
@@ -238,9 +238,12 @@ export interface ContactSubmission {
   email: string;
   subject?: string;
   message: string;
-  phone?: string;
-  company?: string;
   createdAt?: string;
   updatedAt?: string;
   publishedAt?: string;
 }
+
+export type ContactSubmissionInput = Pick<
+  ContactSubmission,
+  "name" | "email" | "subject" | "message"
+>;

--- a/apps/web/tests/contact-submission-dto.test.ts
+++ b/apps/web/tests/contact-submission-dto.test.ts
@@ -1,0 +1,69 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// #129. Web ContactSubmission carried phone/company that contact-submission
+// schema.json does not have. Lock the DTO and the submit payload to the
+// CMS fields: name, email, subject, message.
+
+const webRoot = process.cwd();
+const cmsRoot = resolve(webRoot, "../../apps/cms");
+
+const METADATA = new Set([
+  "id",
+  "documentId",
+  "createdAt",
+  "updatedAt",
+  "publishedAt",
+]);
+
+function interfaceFields(source: string, name: string) {
+  const marker = `export interface ${name} {`;
+  const start = source.indexOf(marker);
+  assert.ok(start >= 0, `missing ${name}`);
+  const from = source.slice(start + marker.length);
+  const end = from.indexOf("\n}");
+  assert.ok(end >= 0, `${name} has no closing brace`);
+  const fields: string[] = [];
+  for (const line of from.slice(0, end).split("\n")) {
+    const match = line.match(/^\s+([A-Za-z][A-Za-z0-9]*)\??:/);
+    if (match) {
+      fields.push(match[1]);
+    }
+  }
+  return fields;
+}
+
+test("web ContactSubmission fields match the CMS contact-submission schema", () => {
+  const schema = JSON.parse(
+    readFileSync(
+      resolve(
+        cmsRoot,
+        "src/api/contact-submission/content-types/contact-submission/schema.json",
+      ),
+      "utf8",
+    ),
+  ) as { attributes: Record<string, unknown> };
+  const schemaFields = Object.keys(schema.attributes).sort();
+  const dto = interfaceFields(
+    readFileSync(resolve(webRoot, "src/types/strapi.ts"), "utf8"),
+    "ContactSubmission",
+  );
+  const contentFields = dto.filter((field) => !METADATA.has(field)).sort();
+  assert.deepEqual(
+    contentFields,
+    schemaFields,
+    "ContactSubmission must not grow fields the CMS collection does not store (#129)",
+  );
+});
+
+test("submitContactForm accepts ContactSubmissionInput, not the document DTO", () => {
+  const source = readFileSync(resolve(webRoot, "src/lib/strapi.ts"), "utf8");
+  assert.match(
+    source,
+    /export async function submitContactForm\(\n  data: ContactSubmissionInput,/,
+  );
+  assert.doesNotMatch(source, /phone/);
+  assert.doesNotMatch(source, /company/);
+});


### PR DESCRIPTION
Follow-up from #127 / #125. Isolated DTO contract; no schema drop and no generate-types change.

## Why
Web `ContactSubmission` had optional `phone` and `company`. The CMS collection only has `name`, `email`, `subject`, `message`. `submitContactForm` typed its POST body as the document DTO minus timestamps, so those extra fields were legal to send.

Nothing collects them. The contact controller already writes only the four schema fields.

## Change
- Drop `phone` / `company` from the DTO
- `submitContactForm` takes `ContactSubmissionInput` (`Pick` of the schema fields)
- Lock the DTO against `schema.json` so the lie cannot grow back

Closes #129